### PR TITLE
Wire conversation persistence into interactive and headless modes

### DIFF
--- a/cmd/rubichan/main_test.go
+++ b/cmd/rubichan/main_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVersionString(t *testing.T) {
@@ -24,4 +27,30 @@ func TestVersionStringDefaults(t *testing.T) {
 func TestAutoApproveDefaultsFalse(t *testing.T) {
 	// autoApprove is a package-level var; verify it defaults to false
 	assert.False(t, autoApprove, "auto-approve must default to false to prevent RCE")
+}
+
+func TestOpenStore_CreatesDB(t *testing.T) {
+	dir := t.TempDir()
+	s, err := openStore(dir)
+	require.NoError(t, err)
+	defer s.Close()
+
+	dbPath := filepath.Join(dir, "rubichan.db")
+	_, err = os.Stat(dbPath)
+	assert.NoError(t, err, "database file should exist")
+}
+
+func TestOpenStore_CreatesMissingDirs(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "config")
+	s, err := openStore(dir)
+	require.NoError(t, err)
+	defer s.Close()
+
+	dbPath := filepath.Join(dir, "rubichan.db")
+	_, err = os.Stat(dbPath)
+	assert.NoError(t, err, "database file should exist in nested directory")
+}
+
+func TestResumeFlagDefaults(t *testing.T) {
+	assert.Empty(t, resumeFlag, "resume flag must default to empty")
 }


### PR DESCRIPTION
## Summary
- Extract `openStore()` and `configDir()` helpers to create the SQLite conversation store
- Both `runInteractive()` and `runHeadless()` now pass `agent.WithStore()` so sessions and messages are persisted to `~/.config/rubichan/rubichan.db`
- Add `--resume <session-id>` flag to resume a prior conversation session

## Test plan
- [x] `TestOpenStore_CreatesDB` — verifies DB file is created
- [x] `TestOpenStore_CreatesMissingDirs` — verifies nested directory creation
- [x] `TestResumeFlagDefaults` — verifies flag defaults to empty
- [ ] Manual: `rubichan --headless --prompt "hello"` persists session
- [ ] Manual: `rubichan --resume <id>` resumes a previous session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to resume previous conversations
  * Implemented conversation persistence to maintain chat history across sessions

* **Tests**
  * Added tests validating store creation and resume functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->