### PR TITLE
Support AGENT.md for project-level system prompt injection

### DIFF
--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -374,6 +374,15 @@ func runInteractive() error {
 		opts = append(opts, agent.WithResumeSession(resumeFlag))
 	}
 
+	// Inject project-level AGENT.md into system prompt.
+	agentMD, agentMDErr := config.LoadAgentMD(cwd)
+	if agentMDErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to load AGENT.md: %v\n", agentMDErr)
+	}
+	if agentMD != "" {
+		opts = append(opts, agent.WithAgentMD(agentMD))
+	}
+
 	// Create skill runtime if --skills is provided.
 	rt, storeCloser, err := createSkillRuntime(context.Background(), registry, p, cfg)
 	if err != nil {
@@ -489,6 +498,15 @@ func runHeadless() error {
 	opts = append(opts, agent.WithStore(s))
 	if resumeFlag != "" {
 		opts = append(opts, agent.WithResumeSession(resumeFlag))
+	}
+
+	// Inject project-level AGENT.md into system prompt.
+	agentMD, agentMDErr := config.LoadAgentMD(cwd)
+	if agentMDErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to load AGENT.md: %v\n", agentMDErr)
+	}
+	if agentMD != "" {
+		opts = append(opts, agent.WithAgentMD(agentMD))
 	}
 
 	// Create skill runtime if --skills is provided.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -110,6 +110,30 @@ func TestNewAgentSystemPrompt(t *testing.T) {
 	assert.NotEmpty(t, agent.conversation.SystemPrompt())
 }
 
+func TestWithAgentMD(t *testing.T) {
+	mp := &mockProvider{}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+
+	agentMDContent := "## Project Rules\nAlways use TDD."
+	a := New(mp, reg, autoApprove, cfg, WithAgentMD(agentMDContent))
+
+	prompt := a.conversation.SystemPrompt()
+	assert.Contains(t, prompt, "Project Guidelines")
+	assert.Contains(t, prompt, agentMDContent)
+}
+
+func TestWithAgentMD_Empty(t *testing.T) {
+	mp := &mockProvider{}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+
+	a := New(mp, reg, autoApprove, cfg, WithAgentMD(""))
+
+	prompt := a.conversation.SystemPrompt()
+	assert.NotContains(t, prompt, "Project Guidelines")
+}
+
 func TestTurnTextOnly(t *testing.T) {
 	mp := &mockProvider{
 		events: []provider.StreamEvent{

--- a/internal/config/agentmd.go
+++ b/internal/config/agentmd.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LoadAgentMD reads an AGENT.md file from the given project root directory.
+// Returns the file content, or an empty string if the file does not exist.
+func LoadAgentMD(projectRoot string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(projectRoot, "AGENT.md"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	content := strings.TrimSpace(string(data))
+	if content == "" {
+		return "", nil
+	}
+	return string(data), nil
+}

--- a/internal/config/agentmd_test.go
+++ b/internal/config/agentmd_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadAgentMD_FileExists(t *testing.T) {
+	dir := t.TempDir()
+	content := "## Project Rules\n\nUse TDD always.\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENT.md"), []byte(content), 0o644))
+
+	result, err := LoadAgentMD(dir)
+	require.NoError(t, err)
+	assert.Equal(t, content, result)
+}
+
+func TestLoadAgentMD_FileMissing(t *testing.T) {
+	dir := t.TempDir()
+
+	result, err := LoadAgentMD(dir)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestLoadAgentMD_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENT.md"), []byte(""), 0o644))
+
+	result, err := LoadAgentMD(dir)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}


### PR DESCRIPTION
## Summary
- Add `config.LoadAgentMD(projectRoot)` — reads `AGENT.md`, returns content or empty string if not found
- Add `agent.WithAgentMD(content)` option — injects content under "Project Guidelines" heading in system prompt
- Wire into both `runInteractive()` and `runHeadless()` in `main.go`

## Test plan
- [x] `TestLoadAgentMD_FileExists` — file with content returns content
- [x] `TestLoadAgentMD_FileMissing` — no file returns empty string
- [x] `TestLoadAgentMD_EmptyFile` — empty file returns empty string
- [x] `TestWithAgentMD` — content injected into system prompt
- [x] `TestWithAgentMD_Empty` — empty content doesn't modify prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)