### PR TITLE
Support .security.yaml for project-specific security rules

### DIFF
--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -567,6 +567,15 @@ func runHeadless() error {
 		}
 		engine := newDefaultSecurityEngine(engineCfg)
 
+		// Load .security.yaml for custom rules.
+		projectCfg, projectCfgErr := security.LoadProjectConfig(cwd)
+		if projectCfgErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: loading .security.yaml: %v\n", projectCfgErr)
+		}
+		if projectCfg != nil && len(projectCfg.Rules) > 0 {
+			engine.AddScanner(scanner.NewCustomRuleScanner(projectCfg.Rules))
+		}
+
 		var wg conc.WaitGroup
 		wg.Go(func() {
 			var runErr error
@@ -584,6 +593,11 @@ func runHeadless() error {
 			secReport = report
 		})
 		wg.Wait()
+
+		// Apply severity overrides from .security.yaml after scan completes.
+		if secReport != nil && projectCfg != nil && len(projectCfg.Overrides) > 0 {
+			security.ApplyOverrides(secReport.Findings, projectCfg.Overrides)
+		}
 	} else {
 		var runErr error
 		result, runErr = hr.Run(ctx, promptText, mode)

--- a/internal/security/projectconfig.go
+++ b/internal/security/projectconfig.go
@@ -1,0 +1,97 @@
+package security
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ProjectSecurityConfig represents a project-level .security.yaml file.
+type ProjectSecurityConfig struct {
+	Rules     []CustomRule `yaml:"rules"`
+	Overrides []Override   `yaml:"overrides"`
+	CI        CIConfig     `yaml:"ci"`
+}
+
+// CustomRule defines a project-specific regex-based security rule.
+type CustomRule struct {
+	ID       string `yaml:"id"`
+	Pattern  string `yaml:"pattern"`
+	Severity string `yaml:"severity"`
+	Title    string `yaml:"title"`
+	Category string `yaml:"category"`
+}
+
+// Override changes the severity of a specific finding by ID.
+type Override struct {
+	FindingID string `yaml:"finding_id"`
+	Severity  string `yaml:"severity"`
+	Reason    string `yaml:"reason"`
+}
+
+// CIConfig holds CI/CD-specific settings from .security.yaml.
+type CIConfig struct {
+	FailOn string `yaml:"fail_on"`
+}
+
+// LoadProjectConfig reads and parses .security.yaml from the given directory.
+// Returns nil if the file does not exist.
+func LoadProjectConfig(dir string) (*ProjectSecurityConfig, error) {
+	data, err := os.ReadFile(filepath.Join(dir, ".security.yaml"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading .security.yaml: %w", err)
+	}
+
+	if strings.TrimSpace(string(data)) == "" {
+		return nil, nil
+	}
+
+	var cfg ProjectSecurityConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing .security.yaml: %w", err)
+	}
+
+	// Validate severity strings against known values.
+	for i, r := range cfg.Rules {
+		if r.Severity != "" && SeverityRank(Severity(r.Severity)) == 0 {
+			return nil, fmt.Errorf(".security.yaml: rule %q has invalid severity %q (must be critical, high, medium, low, or info)", r.ID, r.Severity)
+		}
+		if r.ID == "" {
+			return nil, fmt.Errorf(".security.yaml: rule at index %d is missing required id field", i)
+		}
+	}
+	for _, o := range cfg.Overrides {
+		if o.Severity != "" && SeverityRank(Severity(o.Severity)) == 0 {
+			return nil, fmt.Errorf(".security.yaml: override for %q has invalid severity %q (must be critical, high, medium, low, or info)", o.FindingID, o.Severity)
+		}
+	}
+
+	return &cfg, nil
+}
+
+// ApplyOverrides mutates the severity of findings that match override rules.
+// Returns the number of findings modified.
+func ApplyOverrides(findings []Finding, overrides []Override) int {
+	if len(findings) == 0 || len(overrides) == 0 {
+		return 0
+	}
+	overrideMap := make(map[string]Override, len(overrides))
+	for _, o := range overrides {
+		overrideMap[o.FindingID] = o
+	}
+
+	count := 0
+	for i := range findings {
+		if o, ok := overrideMap[findings[i].ID]; ok {
+			findings[i].Severity = Severity(o.Severity)
+			count++
+		}
+	}
+	return count
+}

--- a/internal/security/projectconfig_test.go
+++ b/internal/security/projectconfig_test.go
@@ -1,0 +1,157 @@
+package security
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadProjectConfig_ValidYAML(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+rules:
+  - id: custom-001
+    pattern: "TODO.*HACK"
+    severity: medium
+    title: "TODO HACK marker found"
+    category: misconfiguration
+  - id: custom-002
+    pattern: "password\\s*=\\s*\"[^\"]+\""
+    severity: high
+    title: "Hardcoded password"
+    category: secrets-exposure
+
+overrides:
+  - finding_id: SEC-001
+    severity: info
+    reason: "Known false positive"
+
+ci:
+  fail_on: critical
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".security.yaml"), []byte(yaml), 0o644))
+
+	cfg, err := LoadProjectConfig(dir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Len(t, cfg.Rules, 2)
+	assert.Equal(t, "custom-001", cfg.Rules[0].ID)
+	assert.Equal(t, "TODO.*HACK", cfg.Rules[0].Pattern)
+	assert.Equal(t, "medium", cfg.Rules[0].Severity)
+
+	assert.Len(t, cfg.Overrides, 1)
+	assert.Equal(t, "SEC-001", cfg.Overrides[0].FindingID)
+	assert.Equal(t, "info", cfg.Overrides[0].Severity)
+
+	assert.Equal(t, "critical", cfg.CI.FailOn)
+}
+
+func TestLoadProjectConfig_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg, err := LoadProjectConfig(dir)
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestLoadProjectConfig_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".security.yaml"), []byte(""), 0o644))
+
+	cfg, err := LoadProjectConfig(dir)
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestLoadProjectConfig_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".security.yaml"), []byte("{{invalid"), 0o644))
+
+	_, err := LoadProjectConfig(dir)
+	assert.Error(t, err)
+}
+
+func TestApplyOverrides_ChangesSeverity(t *testing.T) {
+	findings := []Finding{
+		{ID: "SEC-001", Severity: SeverityHigh, Title: "High finding"},
+		{ID: "SEC-002", Severity: SeverityMedium, Title: "Medium finding"},
+	}
+	overrides := []Override{
+		{FindingID: "SEC-001", Severity: "info", Reason: "known false positive"},
+	}
+
+	count := ApplyOverrides(findings, overrides)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, SeverityInfo, findings[0].Severity)
+	assert.Equal(t, SeverityMedium, findings[1].Severity, "unmatched finding unchanged")
+}
+
+func TestApplyOverrides_NoMatches(t *testing.T) {
+	findings := []Finding{
+		{ID: "SEC-001", Severity: SeverityHigh, Title: "High finding"},
+	}
+	overrides := []Override{
+		{FindingID: "SEC-999", Severity: "low"},
+	}
+
+	count := ApplyOverrides(findings, overrides)
+	assert.Equal(t, 0, count)
+	assert.Equal(t, SeverityHigh, findings[0].Severity)
+}
+
+func TestApplyOverrides_EmptyInputs(t *testing.T) {
+	assert.Equal(t, 0, ApplyOverrides(nil, nil))
+	assert.Equal(t, 0, ApplyOverrides([]Finding{}, nil))
+	assert.Equal(t, 0, ApplyOverrides(nil, []Override{{FindingID: "x"}}))
+}
+
+func TestLoadProjectConfig_InvalidRuleSeverity(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+rules:
+  - id: custom-001
+    pattern: "test"
+    severity: banana
+    title: "Bad severity"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".security.yaml"), []byte(yaml), 0o644))
+
+	_, err := LoadProjectConfig(dir)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid severity")
+	assert.Contains(t, err.Error(), "banana")
+}
+
+func TestLoadProjectConfig_InvalidOverrideSeverity(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+overrides:
+  - finding_id: SEC-001
+    severity: typo
+    reason: "test"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".security.yaml"), []byte(yaml), 0o644))
+
+	_, err := LoadProjectConfig(dir)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid severity")
+}
+
+func TestLoadProjectConfig_MissingRuleID(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+rules:
+  - pattern: "test"
+    severity: high
+    title: "No ID"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".security.yaml"), []byte(yaml), 0o644))
+
+	_, err := LoadProjectConfig(dir)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required id")
+}

--- a/internal/security/scanner/custom.go
+++ b/internal/security/scanner/custom.go
@@ -1,0 +1,103 @@
+package scanner
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/julianshen/rubichan/internal/security"
+)
+
+// compiledCustomRule holds a pre-compiled regex alongside its metadata.
+type compiledCustomRule struct {
+	rule security.CustomRule
+	re   *regexp.Regexp
+}
+
+// CustomRuleScanner applies project-specific regex patterns defined in
+// .security.yaml to detect custom security issues.
+type CustomRuleScanner struct {
+	rules []compiledCustomRule
+}
+
+// NewCustomRuleScanner creates a scanner from project-specific custom rules.
+// Invalid regex patterns are silently skipped.
+func NewCustomRuleScanner(rules []security.CustomRule) *CustomRuleScanner {
+	var compiled []compiledCustomRule
+	for _, r := range rules {
+		re, err := regexp.Compile(r.Pattern)
+		if err != nil {
+			continue
+		}
+		compiled = append(compiled, compiledCustomRule{rule: r, re: re})
+	}
+	return &CustomRuleScanner{rules: compiled}
+}
+
+func (s *CustomRuleScanner) Name() string {
+	return "custom-rules"
+}
+
+func (s *CustomRuleScanner) Scan(ctx context.Context, target security.ScanTarget) ([]security.Finding, error) {
+	if len(s.rules) == 0 {
+		return nil, nil
+	}
+
+	files, err := security.CollectFiles(target, nil)
+	if err != nil {
+		return nil, fmt.Errorf("collecting files: %w", err)
+	}
+
+	var findings []security.Finding
+	for _, relPath := range files {
+		if ctx.Err() != nil {
+			return findings, ctx.Err()
+		}
+
+		absPath := filepath.Join(target.RootDir, relPath)
+		fileFindings, scanErr := s.scanFile(absPath, relPath)
+		if scanErr != nil {
+			continue
+		}
+		findings = append(findings, fileFindings...)
+	}
+	return findings, nil
+}
+
+func (s *CustomRuleScanner) scanFile(absPath, relPath string) ([]security.Finding, error) {
+	f, err := os.Open(absPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var findings []security.Finding
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		for _, cr := range s.rules {
+			if cr.re.MatchString(line) {
+				findings = append(findings, security.Finding{
+					ID:       cr.rule.ID,
+					Scanner:  "custom-rules",
+					Severity: security.Severity(cr.rule.Severity),
+					Category: security.Category(cr.rule.Category),
+					Title:    cr.rule.Title,
+					Location: security.Location{
+						File:      relPath,
+						StartLine: lineNum,
+						EndLine:   lineNum,
+					},
+					Evidence:   line,
+					Confidence: security.ConfidenceHigh,
+				})
+			}
+		}
+	}
+	return findings, scanner.Err()
+}

--- a/internal/security/scanner/custom_test.go
+++ b/internal/security/scanner/custom_test.go
@@ -1,0 +1,73 @@
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/security"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomRuleScanner_MatchesPattern(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("// TODO: HACK fix this later\n"), 0o644))
+
+	rules := []security.CustomRule{
+		{
+			ID:       "custom-001",
+			Pattern:  "TODO.*HACK",
+			Severity: "medium",
+			Title:    "TODO HACK marker",
+			Category: "misconfiguration",
+		},
+	}
+
+	s := NewCustomRuleScanner(rules)
+	findings, err := s.Scan(context.Background(), security.ScanTarget{RootDir: dir})
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	assert.Equal(t, "custom-001", findings[0].ID)
+	assert.Equal(t, security.SeverityMedium, findings[0].Severity)
+	assert.Equal(t, "TODO HACK marker", findings[0].Title)
+	assert.Contains(t, findings[0].Location.File, "main.go")
+}
+
+func TestCustomRuleScanner_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "clean.go"), []byte("package clean\n"), 0o644))
+
+	rules := []security.CustomRule{
+		{ID: "custom-001", Pattern: "VULNERABLE", Severity: "high", Title: "Vulnerable code"},
+	}
+
+	s := NewCustomRuleScanner(rules)
+	findings, err := s.Scan(context.Background(), security.ScanTarget{RootDir: dir})
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+func TestCustomRuleScanner_InvalidRegex(t *testing.T) {
+	rules := []security.CustomRule{
+		{ID: "custom-bad", Pattern: "[invalid", Severity: "high", Title: "Bad pattern"},
+	}
+
+	s := NewCustomRuleScanner(rules)
+	findings, err := s.Scan(context.Background(), security.ScanTarget{RootDir: t.TempDir()})
+	require.NoError(t, err)
+	assert.Empty(t, findings, "invalid regex should be skipped, not error")
+}
+
+func TestCustomRuleScanner_EmptyRules(t *testing.T) {
+	s := NewCustomRuleScanner(nil)
+	findings, err := s.Scan(context.Background(), security.ScanTarget{RootDir: t.TempDir()})
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+func TestCustomRuleScanner_Name(t *testing.T) {
+	s := NewCustomRuleScanner(nil)
+	assert.Equal(t, "custom-rules", s.Name())
+}


### PR DESCRIPTION
## Summary
- Add `LoadProjectConfig()` to parse `.security.yaml` with custom regex rules, severity overrides, and CI settings (FR-4.9)
- Add `CustomRuleScanner` implementing `StaticScanner` — applies project-specific regex patterns during security scans
- Add `ApplyOverrides()` to mutate finding severities for known false positives
- Validate severity strings and require rule IDs on load
- Wire into headless code-review: load `.security.yaml`, register custom scanner, apply overrides

## Test plan
- [x] Parse valid YAML with rules, overrides, CI config
- [x] Missing file returns nil, no error
- [x] Empty file returns nil
- [x] Invalid YAML returns parse error
- [x] Invalid rule severity rejected
- [x] Invalid override severity rejected
- [x] Missing rule ID rejected
- [x] Override changes matching finding severity
- [x] No matches leaves findings unchanged
- [x] Empty inputs handled gracefully
- [x] Custom scanner matches pattern in file
- [x] No match returns empty results
- [x] Invalid regex skipped gracefully
- [x] Empty rules returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)