### PR TITLE
Add shell safety interceptor warnings and blocks

### DIFF
--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -31,12 +32,13 @@ type commandInterceptorRule struct {
 
 type commandInterception struct {
 	blockReason string
+	routeReason string
 	warnings    []string
 }
 
 var defaultShellInterceptionRules = []commandInterceptorRule{
 	{
-		pattern: regexp.MustCompile(`(?m)^\s*apply_patch\b`),
+		pattern: regexp.MustCompile(`^$`), // handled via token-aware parser in inspectShellCommand
 		action:  interceptRouteToFileTool,
 		message: "apply_patch shell commands must be routed through the file tool",
 	},
@@ -51,7 +53,7 @@ var defaultShellInterceptionRules = []commandInterceptorRule{
 		message: "command uses sed -i for in-place file edits",
 	},
 	{
-		pattern: regexp.MustCompile(`(?i)\brm\b[^;\n]*\s-[^\n;]*r[^\n;]*(?:\s|$)`),
+		pattern: regexp.MustCompile(`^$`), // handled via path-aware parser in inspectShellCommand
 		action:  interceptBlock,
 		message: "recursive rm is blocked by shell safety interceptor",
 	},
@@ -115,7 +117,13 @@ func (s *ShellTool) Execute(ctx context.Context, input json.RawMessage) (ToolRes
 	if err := json.Unmarshal(input, &in); err != nil {
 		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
 	}
-	interception := inspectShellCommand(in.Command)
+	interception := inspectShellCommand(in.Command, s.workDir)
+	if interception.routeReason != "" {
+		return ToolResult{
+			Content: fmt.Sprintf("command requires routing: %s. Use the file tool for this operation.", interception.routeReason),
+			IsError: true,
+		}, nil
+	}
 	if interception.blockReason != "" {
 		return ToolResult{
 			Content: fmt.Sprintf("command blocked: %s. Use the file tool for file edits.", interception.blockReason),
@@ -173,8 +181,16 @@ func (s *ShellTool) Execute(ctx context.Context, input json.RawMessage) (ToolRes
 	return withInterceptionWarnings(ToolResult{Content: content, DisplayContent: displayContent}, interception.warnings), nil
 }
 
-func inspectShellCommand(command string) commandInterception {
+func inspectShellCommand(command, workDir string) commandInterception {
 	out := commandInterception{}
+
+	if containsCommandToken(command, "apply_patch") {
+		out.routeReason = "apply_patch shell commands must be routed through the file tool"
+	}
+	if outsideTargets := findRecursiveRMOutsideWorkdir(command, workDir); len(outsideTargets) > 0 {
+		out.blockReason = fmt.Sprintf("recursive rm target(s) escape working directory: %s", strings.Join(outsideTargets, ", "))
+	}
+
 	for _, rule := range defaultShellInterceptionRules {
 		if !rule.pattern.MatchString(command) {
 			continue
@@ -183,12 +199,278 @@ func inspectShellCommand(command string) commandInterception {
 		case interceptWarn:
 			out.warnings = append(out.warnings, rule.message)
 		case interceptBlock, interceptRouteToFileTool:
-			if out.blockReason == "" {
+			if out.blockReason == "" && out.routeReason == "" {
 				out.blockReason = rule.message
 			}
 		}
 	}
 	return out
+}
+
+func containsCommandToken(command, want string) bool {
+	segments := splitShellSegments(command)
+	for _, segment := range segments {
+		exe, args := parseCommandExecutable(segment)
+		if exe == "" {
+			continue
+		}
+		if exe == want {
+			return true
+		}
+		if isShellWrapper(exe) && len(args) >= 2 {
+			// Handle nested shell executions like: sh -c "..."
+			for i := 0; i < len(args)-1; i++ {
+				if strings.HasPrefix(args[i], "-") && strings.Contains(args[i], "c") {
+					if containsCommandToken(args[i+1], want) {
+						return true
+					}
+					break
+				}
+			}
+		}
+		if isCommandPrefixWrapper(exe) {
+			for i := 0; i < len(args); i++ {
+				n := args[i]
+				if strings.Contains(n, "=") && !strings.HasPrefix(n, "=") {
+					continue
+				}
+				joined := strings.Join(args[i:], " ")
+				if containsCommandToken(joined, want) {
+					return true
+				}
+				break
+			}
+		}
+	}
+	return false
+}
+
+func findRecursiveRMOutsideWorkdir(command, workDir string) []string {
+	var outside []string
+	segments := splitShellSegments(command)
+
+	for _, segment := range segments {
+		exe, fields := parseCommandExecutable(segment)
+		if exe == "" {
+			continue
+		}
+		if isShellWrapper(exe) && len(fields) >= 2 {
+			for i := 0; i < len(fields)-1; i++ {
+				if strings.HasPrefix(fields[i], "-") && strings.Contains(fields[i], "c") {
+					outside = append(outside, findRecursiveRMOutsideWorkdir(fields[i+1], workDir)...)
+					break
+				}
+			}
+			continue
+		}
+		if isCommandPrefixWrapper(exe) {
+			start := 0
+			for start < len(fields) {
+				n := fields[start]
+				if strings.Contains(n, "=") && !strings.HasPrefix(n, "=") {
+					start++
+					continue
+				}
+				break
+			}
+			if start < len(fields) {
+				outside = append(outside, findRecursiveRMOutsideWorkdir(strings.Join(fields[start:], " "), workDir)...)
+			}
+			continue
+		}
+		if exe != "rm" {
+			continue
+		}
+
+		recursive := false
+		targets := make([]string, 0, len(fields))
+		parseTargets := false
+		for _, token := range fields {
+			if token == "" {
+				continue
+			}
+			if parseTargets {
+				targets = append(targets, token)
+				continue
+			}
+			if token == "--" {
+				parseTargets = true
+				continue
+			}
+			if strings.HasPrefix(token, "--") {
+				if token == "--recursive" {
+					recursive = true
+				}
+				continue
+			}
+			if strings.HasPrefix(token, "-") {
+				if strings.Contains(token, "r") {
+					recursive = true
+				}
+				continue
+			}
+			targets = append(targets, token)
+		}
+
+		if !recursive {
+			continue
+		}
+		for _, target := range targets {
+			if isOutsideWorkdir(target, workDir) {
+				outside = append(outside, target)
+			}
+		}
+	}
+
+	return outside
+}
+
+func splitShellSegments(command string) []string {
+	var segments []string
+	var current strings.Builder
+	inSingle := false
+	inDouble := false
+	escaped := false
+
+	flush := func() {
+		part := strings.TrimSpace(current.String())
+		if part != "" {
+			segments = append(segments, part)
+		}
+		current.Reset()
+	}
+
+	for _, r := range command {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			current.WriteRune(r)
+			escaped = true
+			continue
+		}
+		if r == '\'' && !inDouble {
+			inSingle = !inSingle
+			current.WriteRune(r)
+			continue
+		}
+		if r == '"' && !inSingle {
+			inDouble = !inDouble
+			current.WriteRune(r)
+			continue
+		}
+		if !inSingle && !inDouble && (r == ';' || r == '\n' || r == '\r') {
+			flush()
+			continue
+		}
+		current.WriteRune(r)
+	}
+	flush()
+	return segments
+}
+
+func parseCommandExecutable(segment string) (string, []string) {
+	fields := parseShellWords(segment)
+	if len(fields) == 0 {
+		return "", nil
+	}
+	idx := 0
+	for idx < len(fields) {
+		n := fields[idx]
+		if strings.Contains(n, "=") && !strings.HasPrefix(n, "=") {
+			idx++
+			continue
+		}
+		exe := n
+		args := make([]string, 0, len(fields)-(idx+1))
+		for _, field := range fields[idx+1:] {
+			args = append(args, field)
+		}
+		return exe, args
+	}
+	return "", nil
+}
+
+func parseShellWords(s string) []string {
+	var out []string
+	var current strings.Builder
+	inSingle := false
+	inDouble := false
+	escaped := false
+
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		out = append(out, current.String())
+		current.Reset()
+	}
+
+	for _, r := range s {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' && !inSingle {
+			escaped = true
+			continue
+		}
+		if r == '\'' && !inDouble {
+			inSingle = !inSingle
+			continue
+		}
+		if r == '"' && !inSingle {
+			inDouble = !inDouble
+			continue
+		}
+		if !inSingle && !inDouble && (r == ' ' || r == '\t') {
+			flush()
+			continue
+		}
+		current.WriteRune(r)
+	}
+	flush()
+	return out
+}
+
+func isShellWrapper(exe string) bool {
+	switch exe {
+	case "sh", "bash", "zsh", "/bin/sh", "/bin/bash", "/bin/zsh":
+		return true
+	default:
+		return false
+	}
+}
+
+func isCommandPrefixWrapper(exe string) bool {
+	switch exe {
+	case "env", "command", "sudo":
+		return true
+	default:
+		return false
+	}
+}
+
+func isOutsideWorkdir(target, workDir string) bool {
+	if target == "" || target == "-" {
+		return false
+	}
+	if strings.HasPrefix(target, "~") {
+		return true
+	}
+
+	var absTarget string
+	if filepath.IsAbs(target) {
+		absTarget = filepath.Clean(target)
+	} else {
+		absTarget = filepath.Clean(filepath.Join(workDir, target))
+	}
+	absWorkDir := filepath.Clean(workDir)
+
+	return !strings.HasPrefix(absTarget, absWorkDir+string(filepath.Separator)) && absTarget != absWorkDir
 }
 
 func withInterceptionWarnings(result ToolResult, warnings []string) ToolResult {

--- a/internal/tools/shell_test.go
+++ b/internal/tools/shell_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -338,7 +339,7 @@ func TestShellToolDetectChangesRunsOnTimeout(t *testing.T) {
 	assert.True(t, pathSet["file.txt"], "file.txt should be detected despite command timeout")
 }
 
-func TestShellToolInterceptorBlocksRecursiveRM(t *testing.T) {
+func TestShellToolInterceptorAllowsRecursiveRMInsideWorkdir(t *testing.T) {
 	dir := t.TempDir()
 	st := NewShellTool(dir, 30*time.Second)
 
@@ -350,11 +351,29 @@ func TestShellToolInterceptorBlocksRecursiveRM(t *testing.T) {
 	})
 	result, err := st.Execute(context.Background(), input)
 	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	_, statErr := os.Stat(victim)
+	assert.Error(t, statErr, "in-workdir recursive rm should execute")
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestShellToolInterceptorBlocksRecursiveRMOutsideWorkdir(t *testing.T) {
+	dir := t.TempDir()
+	parentVictim := filepath.Join(filepath.Dir(dir), "outside-victim")
+	require.NoError(t, os.Mkdir(parentVictim, 0755))
+	t.Cleanup(func() { _ = os.RemoveAll(parentVictim) })
+
+	st := NewShellTool(dir, 30*time.Second)
+	input, _ := json.Marshal(map[string]string{
+		"command": "rm -rf ../outside-victim",
+	})
+	result, err := st.Execute(context.Background(), input)
+	require.NoError(t, err)
 	assert.True(t, result.IsError)
 	assert.Contains(t, result.Content, "command blocked")
-	assert.Contains(t, result.Content, "recursive rm")
-	_, statErr := os.Stat(victim)
-	assert.NoError(t, statErr, "blocked command should not execute")
+	assert.Contains(t, result.Content, "escape working directory")
+	_, statErr := os.Stat(parentVictim)
+	assert.NoError(t, statErr, "outside target should remain because command is blocked")
 }
 
 func TestShellToolInterceptorWarnsOnRedirect(t *testing.T) {
@@ -399,6 +418,89 @@ func TestShellToolInterceptorRoutesApplyPatchToFileTool(t *testing.T) {
 	result, err := st.Execute(context.Background(), input)
 	require.NoError(t, err)
 	assert.True(t, result.IsError)
-	assert.Contains(t, result.Content, "command blocked")
+	assert.Contains(t, result.Content, "command requires routing")
 	assert.Contains(t, result.Content, "routed through the file tool")
+}
+
+func TestShellToolInterceptorRoutesApplyPatchAfterCommandSeparator(t *testing.T) {
+	dir := t.TempDir()
+	st := NewShellTool(dir, 30*time.Second)
+
+	input, _ := json.Marshal(map[string]string{
+		"command": "echo ok; apply_patch foo",
+	})
+	result, err := st.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "command requires routing")
+}
+
+func TestShellToolInterceptorRoutesApplyPatchWithEnvPrefix(t *testing.T) {
+	dir := t.TempDir()
+	st := NewShellTool(dir, 30*time.Second)
+
+	input, _ := json.Marshal(map[string]string{
+		"command": "FOO=1 apply_patch foo",
+	})
+	result, err := st.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "command requires routing")
+}
+
+func TestShellToolInterceptorRoutesApplyPatchViaShC(t *testing.T) {
+	dir := t.TempDir()
+	st := NewShellTool(dir, 30*time.Second)
+
+	input, _ := json.Marshal(map[string]string{
+		"command": `sh -c 'apply_patch foo'`,
+	})
+	result, err := st.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "command requires routing")
+}
+
+func TestShellToolInterceptorRoutesApplyPatchInsideQuotedSeparator(t *testing.T) {
+	dir := t.TempDir()
+	st := NewShellTool(dir, 30*time.Second)
+
+	input, _ := json.Marshal(map[string]string{
+		"command": `sh -c "echo \"a|b\"; apply_patch foo"`,
+	})
+	result, err := st.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "command requires routing")
+}
+
+func TestShellToolInterceptorRoutesApplyPatchViaEnv(t *testing.T) {
+	dir := t.TempDir()
+	st := NewShellTool(dir, 30*time.Second)
+
+	input, _ := json.Marshal(map[string]string{
+		"command": "env FOO=1 apply_patch foo",
+	})
+	result, err := st.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "command requires routing")
+}
+
+func TestShellToolInterceptorBlocksRecursiveRMViaShC(t *testing.T) {
+	dir := t.TempDir()
+	parentVictim := filepath.Join(filepath.Dir(dir), "outside-victim-shc")
+	require.NoError(t, os.Mkdir(parentVictim, 0755))
+	t.Cleanup(func() { _ = os.RemoveAll(parentVictim) })
+
+	st := NewShellTool(dir, 30*time.Second)
+	input, _ := json.Marshal(map[string]string{
+		"command": "sh -c 'rm -rf ../outside-victim-shc'",
+	})
+	result, err := st.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "command blocked")
+	_, statErr := os.Stat(parentVictim)
+	assert.NoError(t, statErr, "outside target should remain because command is blocked")
 }


### PR DESCRIPTION
Summary
- add regex-based interception rules that warn on risky file ops and block destructive commands like recursive rm
- include interception messaging in shell tool output so users see why a command was flagged
- cover the new behavior with unit tests to ensure blocking and warning paths work correctly

Testing
- Not run (not requested)