### PR TITLE
fix(tui): handle bare slash command input

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -253,27 +253,18 @@ func (m *Model) handleCommand(cmd string) tea.Cmd {
 	}
 
 	name := strings.ToLower(strings.TrimPrefix(parts[0], "/"))
-	if name == "" {
-		if helpCmd, ok := m.cmdRegistry.Get("help"); ok {
-			result, err := helpCmd.Execute(context.Background(), nil)
-			if err != nil {
-				m.content.WriteString(fmt.Sprintf("Error: %s\n", err.Error()))
-				m.viewport.SetContent(m.content.String())
-				return nil
-			}
-			if result.Output != "" {
-				m.content.WriteString(result.Output + "\n")
-				m.viewport.SetContent(m.content.String())
-			}
-			return nil
-		}
-		m.content.WriteString("Type /help to show available commands.\n")
-		m.viewport.SetContent(m.content.String())
-		return nil
+	slashOnly := name == ""
+	if slashOnly {
+		name = "help"
 	}
 
 	slashCmd, ok := m.cmdRegistry.Get(name)
 	if !ok {
+		if slashOnly {
+			m.content.WriteString("Type /help to show available commands.\n")
+			m.viewport.SetContent(m.content.String())
+			return nil
+		}
 		m.content.WriteString(fmt.Sprintf("Unknown command: %s\n", parts[0]))
 		m.viewport.SetContent(m.content.String())
 		return nil

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -125,6 +125,16 @@ func TestModelHandleSlashOnlyShowsHelp(t *testing.T) {
 	assert.Contains(t, m.content.String(), "Available commands:")
 }
 
+func TestModelHandleSlashOnlyWithoutHelpCommand(t *testing.T) {
+	reg := commands.NewRegistry()
+	m := NewModel(nil, "rubichan", "claude-3", 50, "", nil, reg)
+	cmd := m.handleCommand("/")
+
+	assert.Nil(t, cmd)
+	assert.NotContains(t, m.content.String(), "Unknown command")
+	assert.Contains(t, m.content.String(), "Type /help to show available commands.")
+}
+
 // --- Task 24 Tests ---
 
 func TestModelInit(t *testing.T) {


### PR DESCRIPTION
## Summary
- treat a bare slash input as a help trigger instead of an unknown command
- keep fallback guidance when help command is unavailable
- add a regression test for slash-only command input

## Testing
- go test ./internal/tui/...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Typing "/" alone now triggers the help flow: it either shows available commands or displays "Type /help to show available commands." instead of reporting an unknown command.

* **Tests**
  * Added tests covering "/" handling for both default help content and registry-backed help, ensuring no unknown-command error is shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->