### PR TITLE
Add platform shell sandbox backends

### DIFF
--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -86,6 +86,7 @@ func NewShellTool(workDir string, timeout time.Duration) *ShellTool {
 	return &ShellTool{
 		workDir: workDir,
 		timeout: timeout,
+		sandbox: NewDefaultShellSandbox(workDir),
 	}
 }
 

--- a/internal/tools/shell_sandbox.go
+++ b/internal/tools/shell_sandbox.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"sort"
 	"strings"
 )
 
@@ -48,20 +49,6 @@ func DefaultShellSandboxPolicy(workDir string) ShellSandboxPolicy {
 	writable := []string{workDir, os.TempDir()}
 	if tmpDir := os.Getenv("TMPDIR"); tmpDir != "" {
 		writable = append(writable, tmpDir)
-	}
-	if homeDir, err := os.UserHomeDir(); err == nil {
-		writable = append(writable,
-			filepath.Join(homeDir, ".cache"),
-			filepath.Join(homeDir, ".config"),
-			filepath.Join(homeDir, "Library", "Caches"),
-			filepath.Join(homeDir, "Library", "Application Support"),
-		)
-	}
-	if xdgCache := os.Getenv("XDG_CACHE_HOME"); xdgCache != "" {
-		writable = append(writable, xdgCache)
-	}
-	if xdgConfig := os.Getenv("XDG_CONFIG_HOME"); xdgConfig != "" {
-		writable = append(writable, xdgConfig)
 	}
 
 	return ShellSandboxPolicy{
@@ -111,6 +98,7 @@ func (s *seatbeltSandbox) Wrap(cmd *exec.Cmd) error {
 	}
 
 	profile := buildSeatbeltProfile(s.policy)
+	cmd.Env = sandboxCommandEnv(cmd)
 	cmd.Path = s.binary
 	cmd.Args = append([]string{s.binary, "-p", profile, originalPath}, originalArgs[1:]...)
 	return nil
@@ -129,6 +117,9 @@ func (s *bubblewrapSandbox) Wrap(cmd *exec.Cmd) error {
 	originalPath, originalArgs, err := resolveWrappedCommand(cmd)
 	if err != nil {
 		return err
+	}
+	if !s.policy.AllowSubprocs {
+		return fmt.Errorf("subprocesses disabled by policy: bubblewrap backend does not support this on Linux")
 	}
 
 	args := []string{
@@ -150,12 +141,17 @@ func (s *bubblewrapSandbox) Wrap(cmd *exec.Cmd) error {
 		args = append(args, "--bind", path, path)
 	}
 	for _, path := range existingSandboxPaths(s.policy.DeniedPaths) {
-		args = append(args, "--tmpfs", path)
+		if isDir(path) {
+			args = append(args, "--tmpfs", path)
+			continue
+		}
+		args = append(args, "--ro-bind", "/dev/null", path)
 	}
 	if cmd.Dir != "" {
 		args = append(args, "--chdir", cmd.Dir)
 	}
 
+	cmd.Env = sandboxCommandEnv(cmd)
 	args = append(args, "--", originalPath)
 	args = append(args, originalArgs[1:]...)
 
@@ -186,6 +182,13 @@ func resolveWrappedCommand(cmd *exec.Cmd) (string, []string, error) {
 }
 
 func buildSeatbeltProfile(policy ShellSandboxPolicy) string {
+	allowed := normalizeSandboxPaths(policy.AllowedPaths)
+	writable := normalizeSandboxPaths(policy.WritablePaths)
+	denied := normalizeSandboxPaths(policy.DeniedPaths)
+	sort.SliceStable(denied, func(i, j int) bool {
+		return len(denied[i]) > len(denied[j])
+	})
+
 	lines := []string{
 		"(version 1)",
 		"(deny default)",
@@ -199,17 +202,56 @@ func buildSeatbeltProfile(policy ShellSandboxPolicy) string {
 	if !policy.AllowNetwork {
 		lines = append(lines, "(deny network*)")
 	}
-	for _, path := range normalizeSandboxPaths(policy.AllowedPaths) {
+	for _, path := range allowed {
 		lines = append(lines, fmt.Sprintf("(allow file-read* (subpath %q))", path))
 	}
-	for _, path := range normalizeSandboxPaths(policy.WritablePaths) {
+	for _, path := range writable {
 		lines = append(lines, fmt.Sprintf("(allow file-read* (subpath %q))", path))
 		lines = append(lines, fmt.Sprintf("(allow file-write* (subpath %q))", path))
 	}
-	for _, path := range normalizeSandboxPaths(policy.DeniedPaths) {
+	for _, path := range denied {
 		lines = append(lines, fmt.Sprintf("(deny file-read* file-write* (subpath %q))", path))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func sandboxCommandEnv(cmd *exec.Cmd) []string {
+	env := cmd.Environ()
+	sandboxHome := filepath.Join(cmd.Dir, ".rubichan-sandbox")
+	if cmd.Dir == "" {
+		sandboxHome = filepath.Join(os.TempDir(), "rubichan-sandbox")
+	}
+	return setEnvValues(env, map[string]string{
+		"HOME":            sandboxHome,
+		"XDG_CACHE_HOME":  filepath.Join(sandboxHome, ".cache"),
+		"XDG_CONFIG_HOME": filepath.Join(sandboxHome, ".config"),
+	})
+}
+
+func setEnvValues(env []string, values map[string]string) []string {
+	out := make([]string, 0, len(env)+len(values))
+	remaining := make(map[string]string, len(values))
+	for k, v := range values {
+		remaining[k] = v
+	}
+
+	for _, entry := range env {
+		name, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			out = append(out, entry)
+			continue
+		}
+		if value, exists := remaining[name]; exists {
+			out = append(out, name+"="+value)
+			delete(remaining, name)
+			continue
+		}
+		out = append(out, entry)
+	}
+	for name, value := range remaining {
+		out = append(out, name+"="+value)
+	}
+	return out
 }
 
 func normalizeSandboxPaths(paths []string) []string {
@@ -235,4 +277,12 @@ func existingSandboxPaths(paths []string) []string {
 		}
 	}
 	return out
+}
+
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
 }

--- a/internal/tools/shell_sandbox_test.go
+++ b/internal/tools/shell_sandbox_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,6 +48,9 @@ func TestSelectShellSandboxFallsBackWhenBackendMissing(t *testing.T) {
 }
 
 func TestSeatbeltSandboxWrapsCommand(t *testing.T) {
+	expectedShell, err := exec.LookPath("sh")
+	require.NoError(t, err)
+
 	sb := &seatbeltSandbox{
 		binary: "/usr/bin/sandbox-exec",
 		policy: ShellSandboxPolicy{
@@ -55,28 +61,31 @@ func TestSeatbeltSandboxWrapsCommand(t *testing.T) {
 	}
 	cmd := exec.Command("sh", "-c", "echo hello")
 
-	err := sb.Wrap(cmd)
+	err = sb.Wrap(cmd)
 	require.NoError(t, err)
 	assert.Equal(t, "/usr/bin/sandbox-exec", cmd.Path)
 	assert.Equal(t, "/usr/bin/sandbox-exec", cmd.Args[0])
-	assert.Contains(t, cmd.Args, "/bin/sh")
+	assert.Contains(t, cmd.Args, expectedShell)
 	assert.Contains(t, cmd.Args[2], "(deny default)")
 	assert.Contains(t, cmd.Args[2], `(allow file-write* (subpath "/tmp/work"))`)
 }
 
 func TestBubblewrapSandboxWrapsCommand(t *testing.T) {
 	workDir := t.TempDir()
+	expectedShell, err := exec.LookPath("sh")
+	require.NoError(t, err)
 	sb := &bubblewrapSandbox{
 		binary: "/usr/bin/bwrap",
 		policy: ShellSandboxPolicy{
 			AllowedPaths:  []string{"/bin"},
 			WritablePaths: []string{workDir},
+			AllowSubprocs: true,
 		},
 	}
 	cmd := exec.Command("sh", "-c", "echo hello")
 	cmd.Dir = workDir
 
-	err := sb.Wrap(cmd)
+	err = sb.Wrap(cmd)
 	require.NoError(t, err)
 	assert.Equal(t, "/usr/bin/bwrap", cmd.Path)
 	assert.Equal(t, "/usr/bin/bwrap", cmd.Args[0])
@@ -84,12 +93,14 @@ func TestBubblewrapSandboxWrapsCommand(t *testing.T) {
 	assert.Contains(t, cmd.Args, "--chdir")
 	assert.Contains(t, cmd.Args, workDir)
 	assert.Contains(t, cmd.Args, "--")
-	assert.Equal(t, "/bin/sh", cmd.Args[len(cmd.Args)-3])
+	assert.Equal(t, expectedShell, cmd.Args[len(cmd.Args)-3])
 	assert.Equal(t, "-c", cmd.Args[len(cmd.Args)-2])
 	assert.Equal(t, "echo hello", cmd.Args[len(cmd.Args)-1])
 }
 
 func TestShellToolExecuteInvokesSandbox(t *testing.T) {
+	expectedShell, err := exec.LookPath("sh")
+	require.NoError(t, err)
 	sb := &recordingSandbox{}
 	st := NewShellTool(t.TempDir(), 30*time.Second)
 	st.SetSandbox(sb)
@@ -99,8 +110,36 @@ func TestShellToolExecuteInvokesSandbox(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
 	assert.True(t, sb.called)
-	assert.Equal(t, "/bin/sh", sb.path)
+	assert.Equal(t, expectedShell, sb.path)
 	assert.Equal(t, []string{"sh", "-c", "echo hello"}, sb.args)
+}
+
+func TestBubblewrapSandboxRejectsDisabledSubprocesses(t *testing.T) {
+	sb := &bubblewrapSandbox{
+		binary: "/usr/bin/bwrap",
+		policy: ShellSandboxPolicy{
+			AllowSubprocs: false,
+		},
+	}
+
+	err := sb.Wrap(exec.Command("sh", "-c", "echo hello"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subprocesses disabled by policy")
+}
+
+func TestDefaultShellSandboxPolicyKeepsWritesInsideWorkspaceAndTemp(t *testing.T) {
+	workDir := t.TempDir()
+
+	policy := DefaultShellSandboxPolicy(workDir)
+
+	assert.Contains(t, policy.WritablePaths, workDir)
+	assert.Contains(t, policy.WritablePaths, filepath.Clean(os.TempDir()))
+	for _, path := range policy.WritablePaths {
+		assert.False(t, strings.Contains(path, ".cache"))
+		assert.False(t, strings.Contains(path, ".config"))
+		assert.False(t, strings.Contains(path, "Library/Caches"))
+		assert.False(t, strings.Contains(path, "Library/Application Support"))
+	}
 }
 
 func TestShellToolExecuteReturnsSandboxSetupError(t *testing.T) {
@@ -127,8 +166,12 @@ func (s *recordingSandbox) Name() string {
 }
 
 func (s *recordingSandbox) Wrap(cmd *exec.Cmd) error {
+	resolvedPath, _, resolveErr := resolveWrappedCommand(cmd)
+	if resolveErr != nil {
+		return resolveErr
+	}
 	s.called = true
-	s.path = cmd.Path
+	s.path = resolvedPath
 	s.args = append([]string(nil), cmd.Args...)
 	return s.err
 }

--- a/internal/tools/shell_test.go
+++ b/internal/tools/shell_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newTestShellTool(dir string, timeout time.Duration) *ShellTool {
+	st := NewShellTool(dir, timeout)
+	st.SetSandbox(nil)
+	return st
+}
+
 // initGitRepo initializes a git repo in dir with the given committed files.
 // Each file is created with "initial" as content, staged, and committed.
 func initGitRepo(t *testing.T, dir string, files ...string) {
@@ -30,7 +36,7 @@ func initGitRepo(t *testing.T, dir string, files ...string) {
 
 	for _, cmd := range cmds {
 		input, _ := json.Marshal(map[string]string{"command": cmd})
-		st := NewShellTool(dir, 30*time.Second)
+		st := newTestShellTool(dir, 30*time.Second)
 		r, err := st.Execute(context.Background(), input)
 		require.NoError(t, err, "setup cmd %q", cmd)
 		require.False(t, r.IsError, "setup cmd %q: %s", cmd, r.Content)
@@ -39,7 +45,7 @@ func initGitRepo(t *testing.T, dir string, files ...string) {
 
 func TestShellToolExecute(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	assert.Equal(t, "shell", st.Name())
 	assert.NotEmpty(t, st.Description())
@@ -56,7 +62,7 @@ func TestShellToolExecute(t *testing.T) {
 
 func TestShellToolTimeout(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 100*time.Millisecond)
+	st := newTestShellTool(dir, 100*time.Millisecond)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "sleep 10",
@@ -69,7 +75,7 @@ func TestShellToolTimeout(t *testing.T) {
 
 func TestShellToolExitCode(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "echo error output >&2; exit 1",
@@ -82,7 +88,7 @@ func TestShellToolExitCode(t *testing.T) {
 
 func TestShellToolExecuteStreamEmitsEvents(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "echo hello stream",
@@ -101,7 +107,7 @@ func TestShellToolExecuteStreamEmitsEvents(t *testing.T) {
 
 func TestShellToolOutputTruncation(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	// Generate output larger than 30KB (30 * 1024 = 30720 bytes)
 	// Use printf to generate a known large output
@@ -118,7 +124,7 @@ func TestShellToolOutputTruncation(t *testing.T) {
 
 func TestShellToolLargeOutputSetsDisplayContent(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	// Generate output larger than 30KB but smaller than 100KB.
 	// 50KB = 50 * 1024 = 51200 bytes.
@@ -138,7 +144,7 @@ func TestShellToolLargeOutputSetsDisplayContent(t *testing.T) {
 
 func TestShellToolHugeOutputCapsDisplayContent(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	// Generate output larger than 100KB (maxDisplayBytes).
 	// 120KB = 120 * 1024 = 122880 bytes.
@@ -159,7 +165,7 @@ func TestShellToolHugeOutputCapsDisplayContent(t *testing.T) {
 
 func TestShellToolSmallOutputNoDisplayContent(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "echo hello",
@@ -173,7 +179,7 @@ func TestShellToolSmallOutputNoDisplayContent(t *testing.T) {
 
 func TestShellToolInvalidJSON(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	result, err := st.Execute(context.Background(), json.RawMessage(`{invalid`))
 	require.NoError(t, err)
@@ -184,7 +190,7 @@ func TestShellToolInvalidJSON(t *testing.T) {
 func TestShellToolSetDiffTracker(t *testing.T) {
 	dir := t.TempDir()
 	dt := NewDiffTracker()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 	st.SetDiffTracker(dt)
 
 	// Run a command that doesn't change files — git diff should not record anything
@@ -200,7 +206,7 @@ func TestShellToolSetDiffTracker(t *testing.T) {
 
 func TestShellToolNoDiffTrackerDoesNotPanic(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second) // No DiffTracker
+	st := newTestShellTool(dir, 30*time.Second) // No DiffTracker
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "echo safe",
@@ -215,7 +221,7 @@ func TestShellToolDetectChangesInGitRepo(t *testing.T) {
 	initGitRepo(t, dir, "tracked.txt")
 
 	dt := NewDiffTracker()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 	st.SetDiffTracker(dt)
 
 	// Modify a tracked file and create an untracked file in one command.
@@ -243,7 +249,7 @@ func TestShellToolDetectChangesRespectsOwnTimeout(t *testing.T) {
 	initGitRepo(t, dir, "file.txt")
 
 	dt := NewDiffTracker()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 	st.SetDiffTracker(dt)
 
 	// Modify a file so git status has something to report.
@@ -268,7 +274,7 @@ func TestShellToolDetectChangesDeduplicates(t *testing.T) {
 	initGitRepo(t, dir, "file.txt")
 
 	dt := NewDiffTracker()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 	st.SetDiffTracker(dt)
 
 	// First command: modify file.txt
@@ -305,12 +311,12 @@ func TestShellToolDetectChangesIgnoresPreExistingDirtyFiles(t *testing.T) {
 	preInput, _ := json.Marshal(map[string]string{
 		"command": "echo dirty > preexisting.txt",
 	})
-	preShell := NewShellTool(dir, 30*time.Second)
+	preShell := newTestShellTool(dir, 30*time.Second)
 	_, err := preShell.Execute(context.Background(), preInput)
 	require.NoError(t, err)
 
 	dt := NewDiffTracker()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 	st.SetDiffTracker(dt)
 
 	// Now modify tracked.txt — only this should be recorded.
@@ -336,7 +342,7 @@ func TestShellToolDetectChangesRunsOnTimeout(t *testing.T) {
 
 	dt := NewDiffTracker()
 	// Very short timeout to trigger the timeout path.
-	st := NewShellTool(dir, 100*time.Millisecond)
+	st := newTestShellTool(dir, 100*time.Millisecond)
 	st.SetDiffTracker(dt)
 
 	// Command that writes a file then sleeps past the timeout.
@@ -360,7 +366,7 @@ func TestShellToolDetectChangesRunsOnTimeout(t *testing.T) {
 
 func TestShellToolInterceptorAllowsRecursiveRMInsideWorkdir(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	victim := dir + "/victim"
 	require.NoError(t, os.Mkdir(victim, 0755))
@@ -382,7 +388,7 @@ func TestShellToolInterceptorBlocksRecursiveRMOutsideWorkdir(t *testing.T) {
 	require.NoError(t, os.Mkdir(parentVictim, 0755))
 	t.Cleanup(func() { _ = os.RemoveAll(parentVictim) })
 
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 	input, _ := json.Marshal(map[string]string{
 		"command": "rm -rf ../outside-victim",
 	})
@@ -397,7 +403,7 @@ func TestShellToolInterceptorBlocksRecursiveRMOutsideWorkdir(t *testing.T) {
 
 func TestShellToolInterceptorWarnsOnRedirect(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "echo hi > redirected.txt",
@@ -415,7 +421,7 @@ func TestShellToolInterceptorWarnsOnRedirect(t *testing.T) {
 
 func TestShellToolInterceptorWarnsOnSedInPlace(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "sed -i",
@@ -429,7 +435,7 @@ func TestShellToolInterceptorWarnsOnSedInPlace(t *testing.T) {
 
 func TestShellToolInterceptorRoutesApplyPatchToFileTool(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "apply_patch foo",
@@ -443,7 +449,7 @@ func TestShellToolInterceptorRoutesApplyPatchToFileTool(t *testing.T) {
 
 func TestShellToolInterceptorRoutesApplyPatchAfterCommandSeparator(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "echo ok; apply_patch foo",
@@ -456,7 +462,7 @@ func TestShellToolInterceptorRoutesApplyPatchAfterCommandSeparator(t *testing.T)
 
 func TestShellToolInterceptorRoutesApplyPatchWithEnvPrefix(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "FOO=1 apply_patch foo",
@@ -469,7 +475,7 @@ func TestShellToolInterceptorRoutesApplyPatchWithEnvPrefix(t *testing.T) {
 
 func TestShellToolInterceptorRoutesApplyPatchViaShC(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": `sh -c 'apply_patch foo'`,
@@ -482,7 +488,7 @@ func TestShellToolInterceptorRoutesApplyPatchViaShC(t *testing.T) {
 
 func TestShellToolInterceptorRoutesApplyPatchInsideQuotedSeparator(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": `sh -c "echo \"a|b\"; apply_patch foo"`,
@@ -495,7 +501,7 @@ func TestShellToolInterceptorRoutesApplyPatchInsideQuotedSeparator(t *testing.T)
 
 func TestShellToolInterceptorRoutesApplyPatchViaEnv(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "env FOO=1 apply_patch foo",
@@ -508,7 +514,7 @@ func TestShellToolInterceptorRoutesApplyPatchViaEnv(t *testing.T) {
 
 func TestShellToolExecuteStreamTimeout(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 200*time.Millisecond)
+	st := newTestShellTool(dir, 200*time.Millisecond)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "echo before && sleep 10",
@@ -527,7 +533,7 @@ func TestShellToolExecuteStreamTimeout(t *testing.T) {
 
 func TestShellToolExecuteStreamExitCode(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "echo error >&2; exit 1",
@@ -549,7 +555,7 @@ func TestShellToolExecuteStreamExitCode(t *testing.T) {
 
 func TestShellToolExecuteStreamInvalidJSON(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	result, err := st.ExecuteStream(context.Background(), json.RawMessage(`{invalid`), func(ev ToolEvent) {})
 	require.NoError(t, err)
@@ -559,7 +565,7 @@ func TestShellToolExecuteStreamInvalidJSON(t *testing.T) {
 
 func TestShellToolExecuteStreamBlockedCommand(t *testing.T) {
 	dir := t.TempDir()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 
 	input, _ := json.Marshal(map[string]string{
 		"command": "apply_patch foo",
@@ -583,7 +589,7 @@ func TestShellToolExecuteStreamDetectsChanges(t *testing.T) {
 	initGitRepo(t, dir, "tracked.txt")
 
 	dt := NewDiffTracker()
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 	st.SetDiffTracker(dt)
 
 	input, _ := json.Marshal(map[string]string{
@@ -609,7 +615,7 @@ func TestShellToolInterceptorBlocksRecursiveRMViaShC(t *testing.T) {
 	require.NoError(t, os.Mkdir(parentVictim, 0755))
 	t.Cleanup(func() { _ = os.RemoveAll(parentVictim) })
 
-	st := NewShellTool(dir, 30*time.Second)
+	st := newTestShellTool(dir, 30*time.Second)
 	input, _ := json.Marshal(map[string]string{
 		"command": "sh -c 'rm -rf ../outside-victim-shc'",
 	})


### PR DESCRIPTION
## Summary
- add OS-level shell sandbox backends with automatic Seatbelt/Bubblewrap selection
- wrap shell tool execution through the selected sandbox backend
- cover backend selection and wrapping behavior with focused tests

Closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OS-level sandboxing for shell command execution with configurable filesystem and network access restrictions.
  * Implemented automatic sandbox backend selection for enhanced cross-platform compatibility.

* **Tests**
  * Comprehensive tests validate sandbox initialization, command wrapping, and error handling across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->