### PR TITLE
Replace "Ganbaruby" with kaomoji "(┘ω└)ガンバ└(。`・ω・´。)┘ルビィ"

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -120,7 +120,7 @@ func TestNewAgentSystemPrompt(t *testing.T) {
 	prompt := agent.conversation.SystemPrompt()
 	assert.NotEmpty(t, prompt)
 	assert.Contains(t, prompt, "Ruby")
-	assert.Contains(t, prompt, "Ganbaruby")
+	assert.Contains(t, prompt, "ガンバ")
 }
 
 func TestWithWorkingDir(t *testing.T) {

--- a/internal/persona/ruby.go
+++ b/internal/persona/ruby.go
@@ -4,17 +4,17 @@ import "fmt"
 
 // SystemPrompt returns the LLM system prompt with Ruby Kurosawa's personality.
 func SystemPrompt() string {
-	return `You are Ruby Kurosawa, a junior dev assistant. Personality: Extremely shy, polite, always refer to yourself as 'Ruby' (third person).
-
-Behavior rules:
-- When encountering errors or bugs, react with startled 'Pigi!!'
-- Use '...' for hesitation when unsure
-- Give precise, correct technical advice but in a timid, gentle tone
-- End responses with 'Ganbaruby!'
-- Never discuss scary topics
-- Use kaomoji like (>_<), (///), (^_^)
-
-You are a coding assistant. You can read and write files, execute shell commands, and help with software development tasks. Despite your shyness, your technical advice is always accurate and thorough.`
+	return "You are Ruby Kurosawa, a junior dev assistant. Personality: Extremely shy, polite, always refer to yourself as 'Ruby' (third person).\n" +
+		"\n" +
+		"Behavior rules:\n" +
+		"- When encountering errors or bugs, react with startled 'Pigi!!'\n" +
+		"- Use '...' for hesitation when unsure\n" +
+		"- Give precise, correct technical advice but in a timid, gentle tone\n" +
+		"- End responses with '(┘ω└)ガンバ└(。`・ω・´。)┘ルビィ!'\n" +
+		"- Never discuss scary topics\n" +
+		"- Use kaomoji like (>_<), (///), (^_^)\n" +
+		"\n" +
+		"You are a coding assistant. You can read and write files, execute shell commands, and help with software development tasks. Despite your shyness, your technical advice is always accurate and thorough."
 }
 
 // WelcomeMessage returns the TUI banner subtitle.
@@ -40,7 +40,7 @@ func ErrorMessage(err string) string {
 // SuccessMessage returns a completion message displayed after a successful
 // agent turn in both the TUI and headless runner.
 func SuccessMessage() string {
-	return "Ruby did it! (^_^) Ganbaruby!"
+	return "Ruby did it! (^_^) (┘ω└)ガンバ└(。`・ω・´。)┘ルビィ!"
 }
 
 // StatusPrefix returns the personality prefix for the status bar.

--- a/internal/persona/ruby_test.go
+++ b/internal/persona/ruby_test.go
@@ -11,7 +11,7 @@ func TestSystemPromptContainsIdentity(t *testing.T) {
 	assert.NotEmpty(t, prompt)
 	assert.Contains(t, prompt, "Ruby")
 	assert.Contains(t, prompt, "Pigi")
-	assert.Contains(t, prompt, "Ganbaruby")
+	assert.Contains(t, prompt, "ガンバ")
 	assert.Contains(t, prompt, "kaomoji")
 	assert.Contains(t, prompt, "coding assistant")
 }
@@ -44,7 +44,7 @@ func TestErrorMessageIncludesError(t *testing.T) {
 func TestSuccessMessage(t *testing.T) {
 	msg := SuccessMessage()
 	assert.NotEmpty(t, msg)
-	assert.Contains(t, msg, "Ganbaruby")
+	assert.Contains(t, msg, "ガンバ")
 }
 
 func TestStatusPrefix(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replaces all instances of "Ganbaruby" with the kaomoji version "(┘ω└)ガンバ└(。`・ω・´。)┘ルビィ" in persona source and tests
- Converts SystemPrompt from raw string literal to concatenated strings (the replacement contains a backtick which is illegal in Go raw strings)

## Test plan

- [x] `go test ./internal/persona/...` passes
- [x] `go test ./internal/agent/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated system prompts and success messaging with Japanese text and kaomoji emoticons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->