### PR TITLE
Fix wiki setContentAndAutoScroll compilation errors

### DIFF
--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -124,7 +124,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				detail = fmt.Sprintf("  Wiki: %s (%d items)", stage, msg.progress.Total)
 			}
 			m.content.WriteString(detail + "\n")
-			m.setContentAndAutoScroll(m.content.String())
+			m.setContentAndAutoScroll()
 		}
 		return m, m.waitForWikiEvent(msg.progressCh, msg.doneCh)
 
@@ -137,7 +137,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.content.WriteString("Wiki generation complete!\n")
 		}
-		m.setContentAndAutoScroll(m.content.String())
+		m.setContentAndAutoScroll()
 		return m, nil
 
 	case spinner.TickMsg:

--- a/internal/tui/wiki_command.go
+++ b/internal/tui/wiki_command.go
@@ -124,7 +124,7 @@ func (wf *WikiForm) Concurrency() int {
 func (m *Model) startWikiGeneration(wf *WikiForm) tea.Cmd {
 	m.wikiRunning = true
 	m.content.WriteString(fmt.Sprintf("Wiki generation started (%s -> %s)\n", wf.Format, wf.OutDir))
-	m.setContentAndAutoScroll(m.content.String())
+	m.setContentAndAutoScroll()
 	m.statusBar.SetWikiProgress("starting")
 
 	dir := filepath.Clean(filepath.Join(m.wikiCfg.WorkDir, wf.Path))
@@ -133,13 +133,13 @@ func (m *Model) startWikiGeneration(wf *WikiForm) tea.Cmd {
 	if rel, err := filepath.Rel(base, dir); err != nil || strings.HasPrefix(rel, "..") {
 		m.wikiRunning = false
 		m.content.WriteString(persona.ErrorMessage("project path escapes working directory"))
-		m.setContentAndAutoScroll(m.content.String())
+		m.setContentAndAutoScroll()
 		return nil
 	}
 	if rel, err := filepath.Rel(base, outDir); err != nil || strings.HasPrefix(rel, "..") {
 		m.wikiRunning = false
 		m.content.WriteString(persona.ErrorMessage("output directory escapes working directory"))
-		m.setContentAndAutoScroll(m.content.String())
+		m.setContentAndAutoScroll()
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- Remove erroneous string argument from 5 `setContentAndAutoScroll()` call sites in wiki TUI code
- The method takes no parameters (reads `m.content` internally), but the wiki PR was rebased against a version with the old signature

## Test plan
- [x] `go build ./internal/tui/` compiles cleanly
- [x] `go build ./cmd/rubichan/` compiles cleanly  
- [x] `go test ./internal/tui/...` all passing
- [x] `go install github.com/julianshen/rubichan/cmd/rubichan@latest` should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal code structure for content display and auto-scroll operations to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->