### PR TITLE
Fix duplicate tool registration in subagents

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -398,15 +398,21 @@ func New(p provider.LLMProvider, t *tools.Registry, approve ApprovalFunc, cfg *c
 	a.deferral = tools.NewDeferralManager(deferralThreshold)
 
 	// Register tool_search tool so the LLM can discover deferred tools.
+	// Skip if already present (e.g. subagent inheriting parent's filtered registry).
 	toolSearchTool := tools.NewToolSearchTool(a.deferral)
-	if err := a.tools.Register(toolSearchTool); err != nil {
-		log.Printf("warning: failed to register tool_search tool: %v", err)
+	if _, exists := a.tools.Get(toolSearchTool.Name()); !exists {
+		if err := a.tools.Register(toolSearchTool); err != nil {
+			log.Printf("warning: failed to register tool_search tool: %v", err)
+		}
 	}
 
 	// Register compact_context tool for agent-initiated compaction.
+	// Skip if already present (e.g. subagent inheriting parent's filtered registry).
 	compactTool := tools.NewCompactContextTool(&agentCompactor{agent: a})
-	if err := a.tools.Register(compactTool); err != nil {
-		log.Printf("warning: failed to register compact_context tool: %v", err)
+	if _, exists := a.tools.Get(compactTool.Name()); !exists {
+		if err := a.tools.Register(compactTool); err != nil {
+			log.Printf("warning: failed to register compact_context tool: %v", err)
+		}
 	}
 
 	return a

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -123,6 +123,29 @@ func TestNewAgentSystemPrompt(t *testing.T) {
 	assert.Contains(t, prompt, "ガンバ")
 }
 
+func TestNewAgentSkipsPreRegisteredTools(t *testing.T) {
+	mp := &mockProvider{}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+
+	// Pre-register compact_context and tool_search (simulates subagent
+	// inheriting parent's filtered registry).
+	preCompact := tools.NewCompactContextTool(&agentCompactor{agent: &Agent{}})
+	require.NoError(t, reg.Register(preCompact))
+	preSearch := tools.NewToolSearchTool(tools.NewDeferralManager(0.10))
+	require.NoError(t, reg.Register(preSearch))
+
+	// New should not panic or log warnings about duplicate registration.
+	a := New(mp, reg, autoApprove, cfg)
+	require.NotNil(t, a)
+
+	// Tools should still be present (not removed or double-registered).
+	_, ok := reg.Get("compact_context")
+	assert.True(t, ok)
+	_, ok = reg.Get("tool_search")
+	assert.True(t, ok)
+}
+
 func TestWithWorkingDir(t *testing.T) {
 	mp := &mockProvider{}
 	reg := tools.NewRegistry()


### PR DESCRIPTION
## Summary
- Fix "tool already registered: compact_context" warning when spawning subagents
- `Registry.Filter` copies parent tools into child registry, then `agent.New` tried to register `compact_context` and `tool_search` again
- Now checks existence before registering, skipping if already present

## Root Cause
`DefaultSubagentSpawner.Spawn` calls `ParentTools.Filter(cfg.Tools)` which copies all tools (including `compact_context` and `tool_search`) into a new registry. It then passes this registry to `agent.New`, which unconditionally registers these tools again → duplicate registration error.

## Test plan
- [x] New test `TestNewAgentSkipsPreRegisteredTools` verifies no error when tools are pre-registered
- [x] All existing tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)