### PR TITLE
Handle approval checker auto-approvals before approval function

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -779,6 +779,22 @@ type toolExecResult struct {
 	isError   bool
 }
 
+func (a *Agent) approvalResultForTool(tc provider.ToolUseBlock) ApprovalResult {
+	if a.approvalChecker == nil {
+		return ApprovalRequired
+	}
+	return a.approvalChecker.CheckApproval(tc.Name, tc.Input)
+}
+
+func toolErrorResult(tc provider.ToolUseBlock, msg string) toolExecResult {
+	return toolExecResult{
+		toolUseID: tc.ID,
+		content:   msg,
+		isError:   true,
+		event:     makeToolResultEvent(tc.ID, tc.Name, msg, "", true),
+	}
+}
+
 // executeTools runs the pending tool calls, parallelizing auto-approved ones.
 // Returns true if the context was cancelled during execution.
 func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTools []provider.ToolUseBlock) bool {
@@ -789,16 +805,17 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 
 	// Partition into auto-approved and needs-approval using input-sensitive check.
 	type indexedTool struct {
-		index int
-		tc    provider.ToolUseBlock
+		index          int
+		tc             provider.ToolUseBlock
+		approvalResult ApprovalResult
 	}
 	var autoApproved, needsApproval []indexedTool
 	for i, tc := range pendingTools {
-		result := a.approvalChecker.CheckApproval(tc.Name, tc.Input)
+		result := a.approvalResultForTool(tc)
 		if result == AutoApproved || result == TrustRuleApproved {
-			autoApproved = append(autoApproved, indexedTool{index: i, tc: tc})
+			autoApproved = append(autoApproved, indexedTool{index: i, tc: tc, approvalResult: result})
 		} else {
-			needsApproval = append(needsApproval, indexedTool{index: i, tc: tc})
+			needsApproval = append(needsApproval, indexedTool{index: i, tc: tc, approvalResult: result})
 		}
 	}
 
@@ -861,7 +878,7 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 			},
 		}
 
-		results[it.index] = a.executeSingleToolWithApproval(ctx, ch, it.tc)
+		results[it.index] = a.executeSingleToolWithApproval(ctx, ch, it.tc, it.approvalResult)
 	}
 
 	// Emit all results and update conversation in original tool call order.
@@ -891,7 +908,7 @@ func (a *Agent) executeToolsSequential(ctx context.Context, ch chan<- TurnEvent,
 			},
 		}
 
-		r := a.executeSingleToolWithApproval(ctx, ch, tc)
+		r := a.executeSingleToolWithApproval(ctx, ch, tc, a.approvalResultForTool(tc))
 		a.conversation.AddToolResult(r.toolUseID, r.content, r.isError)
 		a.persistToolResult(r.toolUseID, r.content, r.isError)
 		ch <- r.event
@@ -900,43 +917,22 @@ func (a *Agent) executeToolsSequential(ctx context.Context, ch chan<- TurnEvent,
 }
 
 // executeSingleToolWithApproval runs approval check then delegates to executeSingleTool.
-func (a *Agent) executeSingleToolWithApproval(ctx context.Context, ch chan<- TurnEvent, tc provider.ToolUseBlock) toolExecResult {
-	if a.approvalChecker != nil {
-		result := a.approvalChecker.CheckApproval(tc.Name, tc.Input)
-		if result == AutoApproved || result == TrustRuleApproved {
-			return a.executeSingleTool(ctx, ch, tc)
-		}
+func (a *Agent) executeSingleToolWithApproval(ctx context.Context, ch chan<- TurnEvent, tc provider.ToolUseBlock, approvalResult ApprovalResult) toolExecResult {
+	if approvalResult == AutoApproved || approvalResult == TrustRuleApproved {
+		return a.executeSingleTool(ctx, ch, tc)
 	}
 
 	if a.approve == nil {
-		result := "approval function not configured"
-		return toolExecResult{
-			toolUseID: tc.ID,
-			content:   result,
-			isError:   true,
-			event:     makeToolResultEvent(tc.ID, tc.Name, result, "", true),
-		}
+		return toolErrorResult(tc, "approval function not configured")
 	}
 
 	// Check approval.
 	approved, approvalErr := a.approve(ctx, tc.Name, tc.Input)
 	if approvalErr != nil {
-		result := fmt.Sprintf("approval error: %s", approvalErr)
-		return toolExecResult{
-			toolUseID: tc.ID,
-			content:   result,
-			isError:   true,
-			event:     makeToolResultEvent(tc.ID, tc.Name, result, "", true),
-		}
+		return toolErrorResult(tc, fmt.Sprintf("approval error: %s", approvalErr))
 	}
 	if !approved {
-		result := "tool call denied by user"
-		return toolExecResult{
-			toolUseID: tc.ID,
-			content:   result,
-			isError:   true,
-			event:     makeToolResultEvent(tc.ID, tc.Name, result, "", true),
-		}
+		return toolErrorResult(tc, "tool call denied by user")
 	}
 
 	return a.executeSingleTool(ctx, ch, tc)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1451,6 +1451,52 @@ func TestMissingApprovalFuncReturnsToolError(t *testing.T) {
 	assert.Equal(t, "approval function not configured", results[0].Content)
 }
 
+func TestMissingApprovalFuncWithApprovalCheckerReturnsToolError(t *testing.T) {
+	toolA := &mockTool{
+		name:        "tool_a",
+		description: "tool A",
+		inputSchema: json.RawMessage(`{"type":"object"}`),
+		executeFn: func(_ context.Context, _ json.RawMessage) (tools.ToolResult, error) {
+			t.Fatal("tool should not execute when approval is required without an approval function")
+			return tools.ToolResult{}, nil
+		},
+	}
+
+	dmp := &dynamicMockProvider{
+		responses: [][]provider.StreamEvent{
+			{
+				{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "t1", Name: "tool_a"}},
+				{Type: "text_delta", Text: `{}`},
+				{Type: "stop"},
+			},
+			{
+				{Type: "text_delta", Text: "Done."},
+				{Type: "stop"},
+			},
+		},
+	}
+
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(toolA))
+
+	cfg := config.DefaultConfig()
+	a := New(dmp, reg, nil, cfg, WithAutoApproveChecker(&selectiveChecker{approved: map[string]bool{}}))
+
+	ch, err := a.Turn(context.Background(), "run tool")
+	require.NoError(t, err)
+
+	var results []ToolResultEvent
+	for ev := range ch {
+		if ev.Type == "tool_result" {
+			results = append(results, *ev.ToolResult)
+		}
+	}
+
+	require.Len(t, results, 1)
+	assert.True(t, results[0].IsError)
+	assert.Equal(t, "approval function not configured", results[0].Content)
+}
+
 func TestMixedParallelAndSequential(t *testing.T) {
 	// tool_a is auto-approved, tool_b is not. They should be partitioned:
 	// tool_a runs in the parallel batch, tool_b runs sequentially after.


### PR DESCRIPTION
Summary
- check the approval checker first and allow auto/TrustRule-approved tools to bypass the approval function
- return a clear tool error when approval is required but no approval function is configured
- add regression tests covering auto-approved tools without approval functions and missing approval functions

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-approved tools are emitted and executed immediately (including parallel execution) while preserving original result ordering.

* **Bug Fixes**
  * Consistent error reporting for missing approval configuration and denial paths; clearer tool-result error messages.
  * Sequential execution now respects per-tool approval outcomes.

* **Tests**
  * Expanded tests covering auto-approved execution, missing approval function scenarios, and approval-checker interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->