### PR TITLE
Fix E2E evaluation findings: --no-color, KG validation, query perf, session ID

### DIFF
--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -19,7 +19,9 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/google/uuid"
+	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 
 	"github.com/sourcegraph/conc"
@@ -87,6 +89,7 @@ var (
 	apiBaseFlag      string
 	apiKeyFlag       string
 	autoApprove      bool
+	noColor          bool
 	noAltScreen      bool
 	noMouse          bool
 	plainTUI         bool
@@ -517,6 +520,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&apiBaseFlag, "api-base", "", "base URL for OpenAI-compatible API (e.g. http://localhost:1234/v1)")
 	rootCmd.PersistentFlags().StringVar(&apiKeyFlag, "api-key", "", "API key for the provider (use 'none' for local servers)")
 	rootCmd.PersistentFlags().BoolVar(&autoApprove, "auto-approve", false, "auto-approve all tool calls (dangerous: enables RCE)")
+	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "suppress all ANSI color output (also respects NO_COLOR env var)")
 	rootCmd.PersistentFlags().BoolVar(&noAltScreen, "no-alt-screen", false, "run interactive TUI in the normal terminal buffer")
 	rootCmd.PersistentFlags().BoolVar(&noMouse, "no-mouse", false, "disable mouse tracking in the interactive TUI")
 	rootCmd.PersistentFlags().BoolVar(&plainTUI, "plain-tui", false, "run a reduced interactive TUI optimized for PTY capture and automation")
@@ -1357,6 +1361,12 @@ func applyAPIKeyFlag(cfg *config.Config) {
 }
 
 func runInteractive() error {
+	// Suppress ANSI color output when --no-color flag is set or the NO_COLOR
+	// environment variable is present (https://no-color.org/).
+	if noColor || os.Getenv("NO_COLOR") != "" {
+		lipgloss.SetColorProfile(termenv.Ascii)
+	}
+
 	// Resolve config path early for bootstrap check.
 	cfgDir, err := configDir()
 	if err != nil {

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -512,6 +512,13 @@ func main() {
 		},
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		PersistentPreRun: func(_ *cobra.Command, _ []string) {
+			// Suppress ANSI color globally when --no-color is set or the
+			// NO_COLOR environment variable is present (https://no-color.org/).
+			if noColor || os.Getenv("NO_COLOR") != "" {
+				lipgloss.SetColorProfile(termenv.Ascii)
+			}
+		},
 	}
 
 	rootCmd.PersistentFlags().StringVar(&configPath, "config", "", "path to config file")
@@ -1361,12 +1368,6 @@ func applyAPIKeyFlag(cfg *config.Config) {
 }
 
 func runInteractive() error {
-	// Suppress ANSI color output when --no-color flag is set or the NO_COLOR
-	// environment variable is present (https://no-color.org/).
-	if noColor || os.Getenv("NO_COLOR") != "" {
-		lipgloss.SetColorProfile(termenv.Ascii)
-	}
-
 	// Resolve config path early for bootstrap check.
 	cfgDir, err := configDir()
 	if err != nil {

--- a/cmd/rubichan/main_test.go
+++ b/cmd/rubichan/main_test.go
@@ -311,6 +311,20 @@ func TestResumeFlagDefinedOnRootCmd(t *testing.T) {
 	}
 }
 
+func TestNoColorFlagDefined(t *testing.T) {
+	var localNoColor bool
+	cmd := &cobra.Command{
+		Use:  "rubichan",
+		RunE: func(_ *cobra.Command, _ []string) error { return nil },
+	}
+	cmd.PersistentFlags().BoolVar(&localNoColor, "no-color", false, "suppress all ANSI color output (also respects NO_COLOR env var)")
+
+	flag := cmd.PersistentFlags().Lookup("no-color")
+	require.NotNil(t, flag, "--no-color flag must exist")
+	assert.Equal(t, "bool", flag.Value.Type())
+	assert.Contains(t, flag.Usage, "NO_COLOR")
+}
+
 func TestNewDefaultSecurityEngine(t *testing.T) {
 	engine := newDefaultSecurityEngine(security.EngineConfig{Concurrency: 4})
 	require.NotNil(t, engine)

--- a/cmd/rubichan/session.go
+++ b/cmd/rubichan/session.go
@@ -59,7 +59,7 @@ func sessionListCmd() *cobra.Command {
 					title += fmt.Sprintf(" (forked from %s)", truncateID(sess.ForkedFrom))
 				}
 				ago := time.Since(sess.UpdatedAt).Truncate(time.Minute)
-				fmt.Printf("%-10s  %-35s  %-15s  %s ago\n", truncateID(sess.ID), title, sess.Model, ago)
+				fmt.Printf("%-36s  %-35s  %-15s  %s ago\n", sess.ID, title, sess.Model, ago)
 			}
 			return nil
 		},

--- a/internal/commands/session.go
+++ b/internal/commands/session.go
@@ -51,12 +51,9 @@ func (c *sessionsCommand) Execute(_ context.Context, _ []string) (Result, error)
 			}
 			title += fmt.Sprintf(" (forked from %s)", fid)
 		}
-		sid := s.ID
-		if len(sid) > 8 {
-			sid = sid[:8]
-		}
+		// Show full session ID so output is usable with --resume.
 		fmt.Fprintf(&sb, "  %s  %-30s  %s  %s\n",
-			sid, title, s.Model, s.UpdatedAt.Format("2006-01-02 15:04"))
+			s.ID, title, s.Model, s.UpdatedAt.Format("2006-01-02 15:04"))
 	}
 	return Result{Output: sb.String()}, nil
 }

--- a/internal/commands/session_test.go
+++ b/internal/commands/session_test.go
@@ -25,9 +25,9 @@ func TestSessionsCommand(t *testing.T) {
 
 	result, err := cmd.Execute(context.Background(), nil)
 	require.NoError(t, err)
-	assert.Contains(t, result.Output, "abc-1234")
+	assert.Contains(t, result.Output, "abc-12345")
 	assert.Contains(t, result.Output, "Fix auth")
-	assert.Contains(t, result.Output, "forked from abc-1234")
+	assert.Contains(t, result.Output, "forked from abc-1234") // forked-from stays truncated
 }
 
 func TestSessionsCommandEmpty(t *testing.T) {
@@ -44,6 +44,19 @@ func TestSessionsCommandNilCallback(t *testing.T) {
 	result, err := cmd.Execute(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Contains(t, result.Output, "not available")
+}
+
+func TestSessionsCommandShowsFullID(t *testing.T) {
+	fullUUID := "8a5b6c0f-1234-5678-abcd-ef0123456789"
+	sessions := []store.Session{
+		{ID: fullUUID, Title: "Test", Model: "opus", UpdatedAt: time.Now()},
+	}
+	cmd := commands.NewSessionsCommand(func() ([]store.Session, error) {
+		return sessions, nil
+	})
+	result, err := cmd.Execute(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, fullUUID, "full session UUID must appear in output for --resume")
 }
 
 func TestForkCommand(t *testing.T) {

--- a/internal/knowledgegraph/graph.go
+++ b/internal/knowledgegraph/graph.go
@@ -973,7 +973,7 @@ func appendKindLayerClauses(query string, args []any, kinds []kg.EntityKind, lay
 	if len(layers) > 0 {
 		query += ` AND e.layer IN (` + repeatedPlaceholder(len(layers)) + `)`
 		for _, l := range layers {
-			args = append(args, string(l))
+			args = append(args, normalizedLayer(l))
 		}
 	}
 	return query, args

--- a/internal/knowledgegraph/graph.go
+++ b/internal/knowledgegraph/graph.go
@@ -833,22 +833,7 @@ func (g *KnowledgeGraph) vectorSearch(ctx context.Context, queryVec []float32, r
 	var args []any
 	if len(req.KindFilter) > 0 || len(req.LayerFilter) > 0 {
 		query += ` JOIN entities e ON e.id = em.entity_id WHERE 1=1`
-		if len(req.KindFilter) > 0 {
-			placeholders := make([]string, len(req.KindFilter))
-			for i, k := range req.KindFilter {
-				placeholders[i] = "?"
-				args = append(args, string(k))
-			}
-			query += ` AND e.kind IN (` + strings.Join(placeholders, ",") + `)`
-		}
-		if len(req.LayerFilter) > 0 {
-			placeholders := make([]string, len(req.LayerFilter))
-			for i, l := range req.LayerFilter {
-				placeholders[i] = "?"
-				args = append(args, string(l))
-			}
-			query += ` AND e.layer IN (` + strings.Join(placeholders, ",") + `)`
-		}
+		query, args = appendKindLayerClauses(query, args, req.KindFilter, req.LayerFilter)
 	}
 
 	rows, err := g.db.QueryContext(ctx, query, args...)
@@ -922,22 +907,7 @@ func (g *KnowledgeGraph) ftsSearch(ctx context.Context, query string, req kg.Que
 		sql += ` JOIN entities e ON e.id = entities_fts.id`
 	}
 	sql += ` WHERE entities_fts MATCH ?`
-	if len(req.KindFilter) > 0 {
-		placeholders := make([]string, len(req.KindFilter))
-		for i, k := range req.KindFilter {
-			placeholders[i] = "?"
-			args = append(args, string(k))
-		}
-		sql += ` AND e.kind IN (` + strings.Join(placeholders, ",") + `)`
-	}
-	if len(req.LayerFilter) > 0 {
-		placeholders := make([]string, len(req.LayerFilter))
-		for i, l := range req.LayerFilter {
-			placeholders[i] = "?"
-			args = append(args, string(l))
-		}
-		sql += ` AND e.layer IN (` + strings.Join(placeholders, ",") + `)`
-	}
+	sql, args = appendKindLayerClauses(sql, args, req.KindFilter, req.LayerFilter)
 	sql += ` ORDER BY rank LIMIT 100`
 
 	rows, err := g.db.QueryContext(ctx, sql, args...)
@@ -991,27 +961,22 @@ func normalizedLayer(l kg.EntityLayer) string {
 	return string(l)
 }
 
-// containsKind checks if a kind is in the filter list.
-func containsKind(kinds []kg.EntityKind, k kg.EntityKind) bool {
-	for _, kind := range kinds {
-		if kind == k {
-			return true
+// appendKindLayerClauses appends AND e.kind IN (...) and/or AND e.layer IN (...)
+// clauses to the query, returning the updated query and args.
+func appendKindLayerClauses(query string, args []any, kinds []kg.EntityKind, layers []kg.EntityLayer) (string, []any) {
+	if len(kinds) > 0 {
+		query += ` AND e.kind IN (` + repeatedPlaceholder(len(kinds)) + `)`
+		for _, k := range kinds {
+			args = append(args, string(k))
 		}
 	}
-	return false
-}
-
-// containsLayer checks if a layer is in the filter list.
-// Treats empty layer as base for matching purposes.
-func containsLayer(layers []kg.EntityLayer, l kg.EntityLayer) bool {
-	normalizedL := normalizedLayer(l)
-	for _, layer := range layers {
-		normalizedFilter := normalizedLayer(layer)
-		if normalizedFilter == normalizedL {
-			return true
+	if len(layers) > 0 {
+		query += ` AND e.layer IN (` + repeatedPlaceholder(len(layers)) + `)`
+		for _, l := range layers {
+			args = append(args, string(l))
 		}
 	}
-	return false
+	return query, args
 }
 
 func repeatedPlaceholder(count int) string {

--- a/internal/knowledgegraph/graph.go
+++ b/internal/knowledgegraph/graph.go
@@ -827,9 +827,31 @@ func (g *KnowledgeGraph) Close() error {
 // Helper functions
 
 func (g *KnowledgeGraph) vectorSearch(ctx context.Context, queryVec []float32, req kg.QueryRequest) ([]kg.ScoredEntity, error) {
-	rows, err := g.db.QueryContext(ctx, `
-		SELECT entity_id, vector, dims FROM embeddings
-	`)
+	// Pre-filter embeddings via JOIN when Kind/Layer filters are set,
+	// reducing the number of vectors to score.
+	query := `SELECT em.entity_id, em.vector, em.dims FROM embeddings em`
+	var args []any
+	if len(req.KindFilter) > 0 || len(req.LayerFilter) > 0 {
+		query += ` JOIN entities e ON e.id = em.entity_id WHERE 1=1`
+		if len(req.KindFilter) > 0 {
+			placeholders := make([]string, len(req.KindFilter))
+			for i, k := range req.KindFilter {
+				placeholders[i] = "?"
+				args = append(args, string(k))
+			}
+			query += ` AND e.kind IN (` + strings.Join(placeholders, ",") + `)`
+		}
+		if len(req.LayerFilter) > 0 {
+			placeholders := make([]string, len(req.LayerFilter))
+			for i, l := range req.LayerFilter {
+				placeholders[i] = "?"
+				args = append(args, string(l))
+			}
+			query += ` AND e.layer IN (` + strings.Join(placeholders, ",") + `)`
+		}
+	}
+
+	rows, err := g.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("vectorSearch: %w", err)
 	}
@@ -863,37 +885,62 @@ func (g *KnowledgeGraph) vectorSearch(ctx context.Context, queryVec []float32, r
 		return scoredResults[i].score > scoredResults[j].score
 	})
 
-	// Convert to ScoredEntity with post-fetch filtering
+	// Cap candidates before entity fetches to avoid N+1 on entire table.
+	candidateLimit := req.Limit
+	if candidateLimit <= 0 {
+		candidateLimit = 20
+	}
+	// Fetch extra candidates to account for possible cache misses.
+	candidateLimit *= 2
+	if candidateLimit > len(scoredResults) {
+		candidateLimit = len(scoredResults)
+	}
+	scoredResults = scoredResults[:candidateLimit]
+
+	// Fetch full entities (filters already applied in SQL when set).
 	var results []kg.ScoredEntity
 	for _, s := range scoredResults {
 		e, err := g.Get(ctx, s.id)
-		if err != nil {
+		if err != nil || e == nil {
 			continue
 		}
-		if e != nil {
-			// Apply KindFilter
-			if len(req.KindFilter) > 0 && !containsKind(req.KindFilter, e.Kind) {
-				continue
-			}
-			// Apply LayerFilter
-			if len(req.LayerFilter) > 0 && !containsLayer(req.LayerFilter, e.Layer) {
-				continue
-			}
-			results = append(results, kg.ScoredEntity{
-				Entity:          e,
-				Score:           s.score,
-				EstimatedTokens: estimateTokens(e),
-			})
-		}
+		results = append(results, kg.ScoredEntity{
+			Entity:          e,
+			Score:           s.score,
+			EstimatedTokens: estimateTokens(e),
+		})
 	}
 
 	return results, nil
 }
 
 func (g *KnowledgeGraph) ftsSearch(ctx context.Context, query string, req kg.QueryRequest) ([]kg.ScoredEntity, error) {
-	rows, err := g.db.QueryContext(ctx, `
-		SELECT id FROM entities_fts WHERE entities_fts MATCH ? ORDER BY rank LIMIT 100
-	`, query)
+	// Push Kind/Layer filtering into SQL via JOIN to reduce entity fetches.
+	sql := `SELECT entities_fts.id FROM entities_fts`
+	args := []any{query}
+	if len(req.KindFilter) > 0 || len(req.LayerFilter) > 0 {
+		sql += ` JOIN entities e ON e.id = entities_fts.id`
+	}
+	sql += ` WHERE entities_fts MATCH ?`
+	if len(req.KindFilter) > 0 {
+		placeholders := make([]string, len(req.KindFilter))
+		for i, k := range req.KindFilter {
+			placeholders[i] = "?"
+			args = append(args, string(k))
+		}
+		sql += ` AND e.kind IN (` + strings.Join(placeholders, ",") + `)`
+	}
+	if len(req.LayerFilter) > 0 {
+		placeholders := make([]string, len(req.LayerFilter))
+		for i, l := range req.LayerFilter {
+			placeholders[i] = "?"
+			args = append(args, string(l))
+		}
+		sql += ` AND e.layer IN (` + strings.Join(placeholders, ",") + `)`
+	}
+	sql += ` ORDER BY rank LIMIT 100`
+
+	rows, err := g.db.QueryContext(ctx, sql, args...)
 	if err != nil {
 		return nil, fmt.Errorf("ftsSearch: %w", err)
 	}
@@ -907,24 +954,14 @@ func (g *KnowledgeGraph) ftsSearch(ctx context.Context, query string, req kg.Que
 		}
 
 		e, err := g.Get(ctx, id)
-		if err != nil {
+		if err != nil || e == nil {
 			continue
 		}
-		if e != nil {
-			// Apply KindFilter
-			if len(req.KindFilter) > 0 && !containsKind(req.KindFilter, e.Kind) {
-				continue
-			}
-			// Apply LayerFilter
-			if len(req.LayerFilter) > 0 && !containsLayer(req.LayerFilter, e.Layer) {
-				continue
-			}
-			results = append(results, kg.ScoredEntity{
-				Entity:          e,
-				Score:           0.5, // FTS doesn't provide scores; use neutral value
-				EstimatedTokens: estimateTokens(e),
-			})
-		}
+		results = append(results, kg.ScoredEntity{
+			Entity:          e,
+			Score:           0.5, // FTS doesn't provide scores; use neutral value
+			EstimatedTokens: estimateTokens(e),
+		})
 	}
 
 	return results, nil

--- a/internal/knowledgegraph/markdown.go
+++ b/internal/knowledgegraph/markdown.go
@@ -3,6 +3,7 @@ package knowledgegraph
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -103,6 +104,33 @@ func writeEntityFile(knowledgeDir string, e *kg.Entity) error {
 	return nil
 }
 
+// validKinds enumerates accepted EntityKind values for frontmatter validation.
+var validKinds = map[string]bool{
+	string(kg.KindArchitecture): true,
+	string(kg.KindDecision):     true,
+	string(kg.KindGotcha):       true,
+	string(kg.KindPattern):      true,
+	string(kg.KindModule):       true,
+	string(kg.KindIntegration):  true,
+}
+
+// validateFrontmatter checks required fields and value constraints.
+func validateFrontmatter(fm *frontmatter, path string) error {
+	if strings.TrimSpace(fm.ID) == "" {
+		return fmt.Errorf("readEntityFile: %s: missing required field 'id'", path)
+	}
+	if strings.TrimSpace(fm.Kind) == "" {
+		return fmt.Errorf("readEntityFile: %s: missing required field 'kind'", path)
+	}
+	if !validKinds[fm.Kind] {
+		return fmt.Errorf("readEntityFile: %s: invalid kind %q (valid: architecture, decision, gotcha, pattern, module, integration)", path, fm.Kind)
+	}
+	if fm.Confidence < 0 || fm.Confidence > 1 {
+		return fmt.Errorf("readEntityFile: %s: confidence must be between 0.0 and 1.0, got %g", path, fm.Confidence)
+	}
+	return nil
+}
+
 // readEntityFile parses a markdown file into an Entity.
 // Expects YAML frontmatter between --- markers, followed by markdown body.
 func readEntityFile(path string) (*kg.Entity, error) {
@@ -121,6 +149,11 @@ func readEntityFile(path string) (*kg.Entity, error) {
 	fm := &frontmatter{}
 	if err := yaml.Unmarshal(parts[1], fm); err != nil {
 		return nil, fmt.Errorf("readEntityFile: parsing YAML from %s: %w", path, err)
+	}
+
+	// Validate required fields
+	if err := validateFrontmatter(fm, path); err != nil {
+		return nil, err
 	}
 
 	// Body is parts[2], trimming leading newline
@@ -159,8 +192,8 @@ func readEntityFile(path string) (*kg.Entity, error) {
 }
 
 // walkKnowledgeDir walks all .md files in knowledgeDir and returns parsed entities.
-// Uses filepath.WalkDir for efficiency. Returns an error if any file fails to parse,
-// but accumulated entities up to that point are lost (transaction-like semantics).
+// Files with validation errors (missing ID, invalid kind, etc.) are skipped with a
+// log warning rather than aborting the entire walk.
 func walkKnowledgeDir(knowledgeDir string) ([]*kg.Entity, error) {
 	var entities []*kg.Entity
 
@@ -187,10 +220,11 @@ func walkKnowledgeDir(knowledgeDir string) ([]*kg.Entity, error) {
 			return nil
 		}
 
-		// Parse the markdown file
+		// Parse the markdown file; skip files with validation errors.
 		e, err := readEntityFile(path)
 		if err != nil {
-			return err
+			log.Printf("walkKnowledgeDir: skipping %s: %v", path, err)
+			return nil
 		}
 
 		entities = append(entities, e)

--- a/internal/knowledgegraph/markdown.go
+++ b/internal/knowledgegraph/markdown.go
@@ -2,6 +2,7 @@ package knowledgegraph
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -12,6 +13,16 @@ import (
 	kg "github.com/julianshen/rubichan/pkg/knowledgegraph"
 	"gopkg.in/yaml.v3"
 )
+
+// ValidationError indicates a frontmatter field failed validation.
+// Distinct from I/O or parse errors so callers can skip bad files
+// without swallowing infrastructure failures.
+type ValidationError struct {
+	Path string
+	Msg  string
+}
+
+func (e *ValidationError) Error() string { return e.Msg }
 
 // frontmatter is the YAML structure parsed from each .md file's --- block.
 type frontmatter struct {
@@ -115,18 +126,20 @@ var validKinds = map[string]bool{
 }
 
 // validateFrontmatter checks required fields and value constraints.
+// Returns *ValidationError for field-level issues so callers can
+// distinguish validation failures from I/O or parse errors.
 func validateFrontmatter(fm *frontmatter, path string) error {
 	if strings.TrimSpace(fm.ID) == "" {
-		return fmt.Errorf("readEntityFile: %s: missing required field 'id'", path)
+		return &ValidationError{Path: path, Msg: fmt.Sprintf("readEntityFile: %s: missing required field 'id'", path)}
 	}
 	if strings.TrimSpace(fm.Kind) == "" {
-		return fmt.Errorf("readEntityFile: %s: missing required field 'kind'", path)
+		return &ValidationError{Path: path, Msg: fmt.Sprintf("readEntityFile: %s: missing required field 'kind'", path)}
 	}
 	if !validKinds[fm.Kind] {
-		return fmt.Errorf("readEntityFile: %s: invalid kind %q (valid: architecture, decision, gotcha, pattern, module, integration)", path, fm.Kind)
+		return &ValidationError{Path: path, Msg: fmt.Sprintf("readEntityFile: %s: invalid kind %q (valid: architecture, decision, gotcha, pattern, module, integration)", path, fm.Kind)}
 	}
 	if fm.Confidence < 0 || fm.Confidence > 1 {
-		return fmt.Errorf("readEntityFile: %s: confidence must be between 0.0 and 1.0, got %g", path, fm.Confidence)
+		return &ValidationError{Path: path, Msg: fmt.Sprintf("readEntityFile: %s: confidence must be between 0.0 and 1.0, got %g", path, fm.Confidence)}
 	}
 	return nil
 }
@@ -220,11 +233,16 @@ func walkKnowledgeDir(knowledgeDir string) ([]*kg.Entity, error) {
 			return nil
 		}
 
-		// Parse the markdown file; skip files with validation errors.
+		// Parse the markdown file; skip validation errors but propagate
+		// I/O and parse errors which indicate infrastructure problems.
 		e, err := readEntityFile(path)
 		if err != nil {
-			log.Printf("walkKnowledgeDir: skipping %s: %v", path, err)
-			return nil
+			var valErr *ValidationError
+			if errors.As(err, &valErr) {
+				log.Printf("walkKnowledgeDir: skipping %s: %v", path, err)
+				return nil
+			}
+			return err
 		}
 
 		entities = append(entities, e)

--- a/internal/knowledgegraph/markdown_test.go
+++ b/internal/knowledgegraph/markdown_test.go
@@ -185,6 +185,23 @@ func TestWalkKnowledgeDirEmpty(t *testing.T) {
 	require.Empty(t, read)
 }
 
+func TestValidKindsCoversAllEntityKinds(t *testing.T) {
+	// Catch drift: if a new EntityKind constant is added to pkg/knowledgegraph
+	// but not to validKinds, this test fails.
+	allKinds := []kg.EntityKind{
+		kg.KindArchitecture,
+		kg.KindDecision,
+		kg.KindGotcha,
+		kg.KindPattern,
+		kg.KindModule,
+		kg.KindIntegration,
+	}
+	for _, k := range allKinds {
+		require.True(t, validKinds[string(k)], "validKinds missing %q", k)
+	}
+	require.Len(t, validKinds, len(allKinds), "validKinds has entries not in EntityKind constants")
+}
+
 func TestValidateFrontmatterMissingID(t *testing.T) {
 	dir := tempDir(t)
 	path := filepath.Join(dir, "no-id.md")

--- a/internal/knowledgegraph/markdown_test.go
+++ b/internal/knowledgegraph/markdown_test.go
@@ -185,6 +185,73 @@ func TestWalkKnowledgeDirEmpty(t *testing.T) {
 	require.Empty(t, read)
 }
 
+func TestValidateFrontmatterMissingID(t *testing.T) {
+	dir := tempDir(t)
+	path := filepath.Join(dir, "no-id.md")
+	content := "---\nkind: gotcha\ntitle: No ID\n---\nBody text."
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	_, err := readEntityFile(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing required field 'id'")
+}
+
+func TestValidateFrontmatterMissingKind(t *testing.T) {
+	dir := tempDir(t)
+	path := filepath.Join(dir, "no-kind.md")
+	content := "---\nid: test-001\ntitle: No Kind\n---\nBody text."
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	_, err := readEntityFile(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing required field 'kind'")
+}
+
+func TestValidateFrontmatterInvalidKind(t *testing.T) {
+	dir := tempDir(t)
+	path := filepath.Join(dir, "bad-kind.md")
+	content := "---\nid: test-001\nkind: foobar\ntitle: Bad Kind\n---\nBody."
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	_, err := readEntityFile(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid kind")
+}
+
+func TestValidateFrontmatterBadConfidence(t *testing.T) {
+	dir := tempDir(t)
+	path := filepath.Join(dir, "bad-conf.md")
+	content := "---\nid: test-001\nkind: gotcha\nconfidence: 1.5\n---\nBody."
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	_, err := readEntityFile(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "confidence must be between")
+}
+
+func TestWalkKnowledgeDirSkipsInvalidFiles(t *testing.T) {
+	dir := tempDir(t)
+
+	// Write a valid entity
+	valid := &kg.Entity{
+		ID: "valid-001", Kind: kg.KindArchitecture, Title: "Valid",
+		Source: kg.SourceManual, Created: time.Now(), Updated: time.Now(),
+	}
+	require.NoError(t, writeEntityFile(dir, valid))
+
+	// Write an invalid file (missing ID) directly
+	badDir := filepath.Join(dir, "gotcha")
+	require.NoError(t, os.MkdirAll(badDir, 0o755))
+	badPath := filepath.Join(badDir, "invalid.md")
+	require.NoError(t, os.WriteFile(badPath, []byte("---\nkind: gotcha\n---\nNo ID here."), 0o644))
+
+	// Walk should skip the invalid file and return the valid one
+	entities, err := walkKnowledgeDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entities, 1)
+	require.Equal(t, "valid-001", entities[0].ID)
+}
+
 func TestReadEntityMissingFrontmatter(t *testing.T) {
 	dir := tempDir(t)
 	path := filepath.Join(dir, "bad.md")


### PR DESCRIPTION
## Summary
- **--no-color flag + NO_COLOR env var** (#5): Suppress ANSI output for CI/expect automation via `lipgloss.SetColorProfile(termenv.Ascii)`
- **KG frontmatter validation** (#10): Reject entities with missing ID/Kind, invalid Kind enum, bad confidence range. Walk skips invalid files instead of aborting
- **KG query performance** (#6): Push Kind/Layer filters into SQL JOINs, cap vector candidates at 2x limit before entity fetches
- **Full session UUID** (#7): `/sessions` and `session list` show full UUID instead of truncated 8-char ID for `--resume` compatibility

## Test plan
- [ ] `go test ./...` — all pass
- [ ] `rubichan --no-color` — no ANSI escape codes in output
- [ ] `NO_COLOR=1 rubichan` — same behavior as --no-color
- [ ] Create .knowledge entity with missing ID — skipped with log warning
- [ ] Create .knowledge entity with `kind: invalid` — rejected with error
- [ ] `/sessions` output shows full UUID, copy-pasteable to `--resume`
- [ ] KG query with KindFilter returns only matching kinds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-color` CLI flag and `NO_COLOR` environment variable support to disable colored output globally.
  * Implemented frontmatter validation for knowledge graph markdown files with required field and value constraint enforcement.

* **Improvements**
  * Session IDs now display in full format.
  * Enhanced knowledge graph search filtering and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->