### PR TITLE
Detect route group registrations in API scanner

### DIFF
--- a/internal/wiki/scanner_api.go
+++ b/internal/wiki/scanner_api.go
@@ -11,11 +11,11 @@ import (
 
 // apiPatternDef describes a single regex-based API detection rule.
 type apiPatternDef struct {
-	Language    string
-	Kind        string
-	Regex       *regexp.Regexp
-	MethodGroup int // submatch index for HTTP method (0 = none)
-	PathGroup   int // submatch index for path/route (0 = none)
+	Language     string
+	Kind         string
+	Regex        *regexp.Regexp
+	MethodGroup  int // submatch index for HTTP method (0 = none)
+	PathGroup    int // submatch index for path/route (0 = none)
 	HandlerGroup int // submatch index for handler name (0 = none)
 }
 
@@ -24,11 +24,11 @@ var apiPatternDefs []apiPatternDef
 
 func init() {
 	type raw struct {
-		language    string
-		kind        string
-		pattern     string
-		methodGroup int
-		pathGroup   int
+		language     string
+		kind         string
+		pattern      string
+		methodGroup  int
+		pathGroup    int
 		handlerGroup int
 	}
 
@@ -145,6 +145,79 @@ func ScanAPIPatterns(files []ScannedFile, readFile func(string) ([]byte, error))
 	return results
 }
 
+// goGroupRe matches Go route group assignments like: api := router.Group("/prefix")
+var goGroupRe = regexp.MustCompile(`(\w+)\s*:?=\s*\w+\.Group\s*\(\s*"([^"]*)"`)
+
+// resolveRouteGroups rewrites Go source so that routes registered on group
+// variables have their prefix prepended, allowing the existing line-by-line
+// scanner to detect the full path.
+func resolveRouteGroups(src []byte) []byte {
+	// Build varName → prefix map.
+	groups := make(map[string]string)
+	for _, m := range goGroupRe.FindAllSubmatch(src, -1) {
+		varName := string(m[1])
+		prefix := strings.TrimRight(string(m[2]), "/")
+		groups[varName] = prefix
+	}
+	if len(groups) == 0 {
+		return src
+	}
+
+	// For each group variable, rewrite method calls to include the prefix.
+	result := src
+	for varName, prefix := range groups {
+		// Match varName.Method("path" — where path may be empty.
+		re := regexp.MustCompile(regexp.QuoteMeta(varName) + `\.((?i:Get|Post|Put|Delete|Patch|Options|Head))\s*\(\s*"([^"]*)"`)
+		result = re.ReplaceAllFunc(result, func(match []byte) []byte {
+			sub := re.FindSubmatch(match)
+			method := string(sub[1])
+			path := string(sub[2])
+			var fullPath string
+			if path == "" {
+				fullPath = prefix
+			} else {
+				fullPath = prefix + "/" + strings.TrimLeft(path, "/")
+			}
+			// Clean double slashes but preserve leading slash.
+			fullPath = strings.ReplaceAll(fullPath, "//", "/")
+			return []byte(varName + "." + method + `("` + fullPath + `"`)
+		})
+	}
+	return result
+}
+
+// pythonBlueprintRe matches Flask Blueprint with url_prefix.
+var pythonBlueprintRe = regexp.MustCompile(`(\w+)\s*=\s*Blueprint\s*\([^)]*url_prefix\s*=\s*['"]([^'"]+)['"]`)
+
+// resolvePythonBlueprints rewrites Python source so that routes registered on
+// Blueprint variables have the url_prefix prepended.
+func resolvePythonBlueprints(src []byte) []byte {
+	groups := make(map[string]string)
+	for _, m := range pythonBlueprintRe.FindAllSubmatch(src, -1) {
+		varName := string(m[1])
+		prefix := strings.TrimRight(string(m[2]), "/")
+		groups[varName] = prefix
+	}
+	if len(groups) == 0 {
+		return src
+	}
+
+	result := src
+	for varName, prefix := range groups {
+		// Rewrite @varName.method('/path') and @varName.route('/path') patterns.
+		re := regexp.MustCompile(`@` + regexp.QuoteMeta(varName) + `\.(get|post|put|delete|patch|route)\s*\(\s*['"]([^'"]+)['"]`)
+		result = re.ReplaceAllFunc(result, func(match []byte) []byte {
+			sub := re.FindSubmatch(match)
+			method := string(sub[1])
+			path := string(sub[2])
+			fullPath := prefix + "/" + strings.TrimLeft(path, "/")
+			fullPath = strings.ReplaceAll(fullPath, "//", "/")
+			return []byte("@" + varName + "." + method + `('` + fullPath + `'`)
+		})
+	}
+	return result
+}
+
 // scanFile processes a single ScannedFile and returns its API patterns.
 func scanFile(f ScannedFile, readFile func(string) ([]byte, error)) []APIPattern {
 	var results []APIPattern
@@ -184,6 +257,15 @@ func scanFile(f ScannedFile, readFile func(string) ([]byte, error)) []APIPattern
 	content, err := readFile(f.Path)
 	if err != nil {
 		return nil
+	}
+
+	// Resolve route groups / blueprints so prefixed paths are visible to
+	// the line-by-line regex scanner.
+	if f.Language == "go" {
+		content = resolveRouteGroups(content)
+	}
+	if f.Language == "python" {
+		content = resolvePythonBlueprints(content)
 	}
 
 	scanner := bufio.NewScanner(bytes.NewReader(content))

--- a/internal/wiki/scanner_api_test.go
+++ b/internal/wiki/scanner_api_test.go
@@ -156,6 +156,103 @@ func Add(a, b int) int {
 	assert.Empty(t, patterns)
 }
 
+func TestScanAPIPatterns_GoRouteGroup(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r := gin.Default()
+	api := r.Group("/todos")
+	api.GET("/:id", getHandler)
+	api.POST("", createHandler)
+	api.PUT("/:id", updateHandler)
+	api.DELETE("/:id", deleteHandler)
+
+	v2 := r.Group("/v2/items")
+	v2.GET("/list", listItems)
+}
+`
+	files := []ScannedFile{{Path: "main.go", Language: "go"}}
+	reader := fakeReader(map[string]string{"main.go": src})
+
+	patterns := ScanAPIPatterns(files, reader)
+
+	var httpPatterns []APIPattern
+	for _, p := range patterns {
+		if p.Kind == "http" {
+			httpPatterns = append(httpPatterns, p)
+		}
+	}
+	require.Len(t, httpPatterns, 5, "expected 5 HTTP routes from two groups")
+
+	// Build a set of method+path for verification.
+	routes := make(map[string]bool)
+	for _, p := range httpPatterns {
+		routes[p.Method+" "+p.Path] = true
+	}
+	assert.True(t, routes["GET /todos/:id"], "missing GET /todos/:id")
+	assert.True(t, routes["POST /todos"], "missing POST /todos")
+	assert.True(t, routes["PUT /todos/:id"], "missing PUT /todos/:id")
+	assert.True(t, routes["DELETE /todos/:id"], "missing DELETE /todos/:id")
+	assert.True(t, routes["GET /v2/items/list"], "missing GET /v2/items/list")
+}
+
+func TestScanAPIPatterns_PythonBlueprint(t *testing.T) {
+	src := `from flask import Flask, Blueprint
+
+bp = Blueprint('todos', __name__, url_prefix='/todos')
+
+@bp.get('/active')
+def get_active():
+    pass
+
+@bp.post('/create')
+def create_todo():
+    pass
+
+@bp.route('/all')
+def list_all():
+    pass
+`
+	files := []ScannedFile{{Path: "app.py", Language: "python"}}
+	reader := fakeReader(map[string]string{"app.py": src})
+
+	patterns := ScanAPIPatterns(files, reader)
+
+	var httpPatterns []APIPattern
+	for _, p := range patterns {
+		if p.Kind == "http" {
+			httpPatterns = append(httpPatterns, p)
+		}
+	}
+	require.Len(t, httpPatterns, 3, "expected 3 HTTP routes from blueprint")
+
+	paths := make(map[string]bool)
+	for _, p := range httpPatterns {
+		paths[p.Path] = true
+	}
+	assert.True(t, paths["/todos/active"], "missing /todos/active")
+	assert.True(t, paths["/todos/create"], "missing /todos/create")
+	assert.True(t, paths["/todos/all"], "missing /todos/all")
+}
+
+func TestResolveRouteGroups_EmptyPath(t *testing.T) {
+	src := []byte(`api := r.Group("/todos")
+api.GET("", listHandler)
+`)
+	result := resolveRouteGroups(src)
+	assert.Contains(t, string(result), `api.GET("/todos"`)
+}
+
+func TestResolveRouteGroups_NoGroups(t *testing.T) {
+	src := []byte(`r.GET("/health", healthHandler)
+r.POST("/items", createItem)
+`)
+	result := resolveRouteGroups(src)
+	assert.Equal(t, string(src), string(result))
+}
+
 func TestScanAPIPatterns_MultipleInOneFile(t *testing.T) {
 	src := `package main
 


### PR DESCRIPTION
## Summary
- Add `resolveRouteGroups()` to detect Go Gin-style `.Group("/prefix")` assignments and prepend the prefix to routes registered on group variables
- Add `resolvePythonBlueprints()` to detect Flask `Blueprint(..., url_prefix='/prefix')` and prepend the prefix to blueprint routes
- Both resolvers rewrite source content before the existing line-by-line regex scan, so no existing patterns need modification
- Handles empty sub-paths correctly (e.g., `api.POST("", handler)` resolves to just the group prefix)

## Test plan
- [x] `TestScanAPIPatterns_GoRouteGroup`: Gin-style group with 5 routes across 2 groups, verifies all detected with correct prefixed paths
- [x] `TestScanAPIPatterns_PythonBlueprint`: Flask blueprint with url_prefix, verifies 3 routes have prefixed paths
- [x] `TestResolveRouteGroups_EmptyPath`: Verifies `api.GET("", handler)` resolves to just the prefix `/todos`
- [x] `TestResolveRouteGroups_NoGroups`: Verifies passthrough when no groups present
- [x] Full `go test ./internal/wiki/` passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved API route detection for Go route groups and Python Flask blueprints to properly resolve route prefixes and paths.

* **Tests**
  * Added comprehensive test coverage for route group composition in Go and Flask blueprint URL-prefix routing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->