### PR TITLE
Add LLM response truncation guard

### DIFF
--- a/internal/wiki/analyzer_api.go
+++ b/internal/wiki/analyzer_api.go
@@ -103,7 +103,7 @@ func (a *APIAnalyzer) generateKindDoc(ctx context.Context, grp apiGroupConfig, p
 		return Document{}, fmt.Errorf("rendering api prompt: %w", err)
 	}
 
-	resp, err := a.llm.Complete(ctx, buf.String())
+	resp, err := completeLLMResponse(ctx, buf.String(), a.llm, 1)
 	if err != nil {
 		return Document{}, fmt.Errorf("LLM completion for %s: %w", grp.kind, err)
 	}

--- a/internal/wiki/analyzer_security.go
+++ b/internal/wiki/analyzer_security.go
@@ -116,7 +116,7 @@ func (a *SecurityAnalyzer) runSubPrompt(
 		return nil, nil, fmt.Errorf("rendering prompt: %w", err)
 	}
 
-	resp, err := a.llm.Complete(ctx, buf.String())
+	resp, err := completeLLMResponse(ctx, buf.String(), a.llm, 1)
 	if err != nil {
 		return nil, nil, fmt.Errorf("LLM completion: %w", err)
 	}

--- a/internal/wiki/analyzer_suggestion.go
+++ b/internal/wiki/analyzer_suggestion.go
@@ -41,7 +41,7 @@ func (a *SuggestionAnalyzer) Analyze(ctx context.Context, input AnalyzerInput) (
 		return &AnalyzerOutput{}, nil // non-fatal
 	}
 
-	resp, err := a.llm.Complete(ctx, buf.String())
+	resp, err := completeLLMResponse(ctx, buf.String(), a.llm, 1)
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()

--- a/internal/wiki/diagrams.go
+++ b/internal/wiki/diagrams.go
@@ -32,7 +32,7 @@ func GenerateDiagrams(ctx context.Context, files []ScannedFile, analysis *Analys
 	var diagrams []Diagram
 
 	// 1. Architecture overview (programmatic).
-	diagrams = append(diagrams, generateArchitectureDiagram(analysis.Modules))
+	diagrams = append(diagrams, generateArchitectureDiagram(files, analysis.Modules))
 
 	// 2. Dependency graph (programmatic).
 	diagrams = append(diagrams, generateDependencyDiagram(files, analysis.Modules))
@@ -59,7 +59,12 @@ func GenerateDiagrams(ctx context.Context, files []ScannedFile, analysis *Analys
 }
 
 // generateArchitectureDiagram creates a graph TD showing modules with their summaries.
-func generateArchitectureDiagram(modules []ModuleAnalysis) Diagram {
+func generateArchitectureDiagram(files []ScannedFile, modules []ModuleAnalysis) Diagram {
+	knownModules := make(map[string]bool, len(modules))
+	for _, m := range modules {
+		knownModules[m.Module] = true
+	}
+
 	var b strings.Builder
 	b.WriteString("graph TD\n")
 
@@ -67,6 +72,28 @@ func generateArchitectureDiagram(modules []ModuleAnalysis) Diagram {
 		id := sanitizeID(m.Module)
 		summary := truncateUTF8(m.Summary, 40)
 		fmt.Fprintf(&b, "    %s[\"%s\\n%s\"]\n", id, escapeMermaid(m.Module), escapeMermaid(summary))
+	}
+
+	// Draw edges based on import relationships between known modules.
+	seen := make(map[string]bool)
+	for _, f := range files {
+		if !knownModules[f.Module] {
+			continue
+		}
+		for _, imp := range f.Imports {
+			for mod := range knownModules {
+				if mod == f.Module {
+					continue
+				}
+				if strings.Contains(imp, mod) {
+					edge := f.Module + " -> " + mod
+					if !seen[edge] {
+						seen[edge] = true
+						fmt.Fprintf(&b, "    %s --> %s\n", sanitizeID(f.Module), sanitizeID(mod))
+					}
+				}
+			}
+		}
 	}
 
 	return Diagram{

--- a/internal/wiki/diagrams.go
+++ b/internal/wiki/diagrams.go
@@ -70,8 +70,13 @@ func generateArchitectureDiagram(files []ScannedFile, modules []ModuleAnalysis) 
 
 	for _, m := range modules {
 		id := sanitizeID(m.Module)
-		summary := truncateUTF8(m.Summary, 40)
-		fmt.Fprintf(&b, "    %s[\"%s\\n%s\"]\n", id, escapeMermaid(m.Module), escapeMermaid(summary))
+		summary := firstSentence(m.Summary)
+		summary = truncateUTF8(summary, 60)
+		if summary != "" {
+			fmt.Fprintf(&b, "    %s[\"%s\\n%s\"]\n", id, escapeMermaid(m.Module), escapeMermaid(summary))
+		} else {
+			fmt.Fprintf(&b, "    %s[\"%s\"]\n", id, escapeMermaid(m.Module))
+		}
 	}
 
 	// Draw edges based on import relationships between known modules.
@@ -185,6 +190,18 @@ Respond with ONLY the Mermaid diagram code starting with "sequenceDiagram".`, ar
 		Type:    "sequence",
 		Content: strings.TrimSpace(response),
 	}, nil
+}
+
+// firstSentence returns text up to and including the first sentence
+// terminator (., !, or ?). If no terminator is found, the whole string
+// is returned.
+func firstSentence(s string) string {
+	for i, r := range s {
+		if r == '.' || r == '!' || r == '?' {
+			return s[:i+1]
+		}
+	}
+	return s
 }
 
 // truncateUTF8 truncates s to at most maxRunes Unicode code points,

--- a/internal/wiki/diagrams_test.go
+++ b/internal/wiki/diagrams_test.go
@@ -196,6 +196,41 @@ func TestGenerateDiagramsEmptyLLMResponseForSequence(t *testing.T) {
 	assert.Contains(t, logOutput, "empty response")
 }
 
+func TestGenerateArchitectureDiagram_HasEdges(t *testing.T) {
+	files := []ScannedFile{
+		{Path: "handler.go", Language: "go", Module: "internal/handler", Imports: []string{"github.com/example/internal/store"}},
+		{Path: "store.go", Language: "go", Module: "internal/store", Imports: []string{}},
+	}
+	modules := []ModuleAnalysis{
+		{Module: "internal/handler", Summary: "HTTP handler"},
+		{Module: "internal/store", Summary: "Data store"},
+	}
+
+	diagram := generateArchitectureDiagram(files, modules)
+
+	assert.Equal(t, "Architecture Overview", diagram.Title)
+	assert.Equal(t, "architecture", diagram.Type)
+	assert.Contains(t, diagram.Content, "graph TD")
+	// Should contain nodes.
+	assert.Contains(t, diagram.Content, "internal_handler")
+	assert.Contains(t, diagram.Content, "internal_store")
+	// Should contain edge from handler to store.
+	assert.Contains(t, diagram.Content, "internal_handler --> internal_store")
+}
+
+func TestGenerateArchitectureDiagram_NilFiles(t *testing.T) {
+	modules := []ModuleAnalysis{
+		{Module: "internal/handler", Summary: "HTTP handler"},
+	}
+
+	diagram := generateArchitectureDiagram(nil, modules)
+
+	assert.Equal(t, "Architecture Overview", diagram.Title)
+	assert.Contains(t, diagram.Content, "graph TD")
+	assert.Contains(t, diagram.Content, "internal_handler")
+	assert.NotContains(t, diagram.Content, "-->")
+}
+
 // validatingLLMCompleter is a mock LLM that validates empty responses,
 // matching the behavior of the real LLMCompleter.Complete().
 type validatingLLMCompleter struct {

--- a/internal/wiki/diagrams_test.go
+++ b/internal/wiki/diagrams_test.go
@@ -231,6 +231,58 @@ func TestGenerateArchitectureDiagram_NilFiles(t *testing.T) {
 	assert.NotContains(t, diagram.Content, "-->")
 }
 
+func TestFirstSentence(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "single sentence", in: "Handles HTTP requests.", want: "Handles HTTP requests."},
+		{name: "multiple sentences", in: "Handles HTTP requests. Also does routing.", want: "Handles HTTP requests."},
+		{name: "exclamation", in: "Important module! Do not remove.", want: "Important module!"},
+		{name: "question", in: "Is this needed? Probably.", want: "Is this needed?"},
+		{name: "no terminator", in: "No sentence ending here", want: "No sentence ending here"},
+		{name: "empty", in: "", want: ""},
+		{name: "just period", in: ".", want: "."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, firstSentence(tt.in))
+		})
+	}
+}
+
+func TestArchitectureDiagramShortLabels(t *testing.T) {
+	modules := []ModuleAnalysis{
+		{
+			Module:  "internal/handler",
+			Summary: "The provided text describes a module structure for handling HTTP requests and routing them to appropriate handlers.",
+		},
+		{
+			Module:  "internal/store",
+			Summary: "Persistence layer for data storage.",
+		},
+		{
+			Module:  "internal/empty",
+			Summary: "",
+		},
+	}
+
+	diagram := generateArchitectureDiagram(nil, modules)
+
+	// Long first sentence should be capped at 60 runes.
+	// First sentence: "The provided text describes a module structure for handling HTTP requests and routing them to appropriate handlers."
+	// After truncateUTF8(_, 60): "The provided text describes a module structure for handling "
+	assert.Contains(t, diagram.Content, "The provided text describes a module structure for handling ")
+	assert.NotContains(t, diagram.Content, "appropriate handlers.")
+	// Short summary should use first sentence as-is.
+	assert.Contains(t, diagram.Content, "Persistence layer for data storage.")
+	// Empty summary module should have no \\n separator.
+	assert.Contains(t, diagram.Content, `internal_empty["internal/empty"]`)
+	// Should NOT contain truncated mid-word text.
+	assert.NotContains(t, diagram.Content, "str...")
+}
+
 // validatingLLMCompleter is a mock LLM that validates empty responses,
 // matching the behavior of the real LLMCompleter.Complete().
 type validatingLLMCompleter struct {

--- a/internal/wiki/llm_guard.go
+++ b/internal/wiki/llm_guard.go
@@ -1,0 +1,84 @@
+package wiki
+
+import (
+	"context"
+	"strings"
+	"unicode"
+)
+
+// isResponseTruncated detects if an LLM response appears to have been cut off
+// mid-generation. It checks for unclosed fenced code blocks, continuation
+// punctuation at the end, and lines ending abruptly without terminal punctuation.
+func isResponseTruncated(s string) bool {
+	s = strings.TrimRight(s, " \t")
+	if s == "" {
+		return false
+	}
+
+	// Unclosed fenced code block.
+	if strings.Count(s, "```")%2 != 0 {
+		return true
+	}
+
+	// Get last non-empty line.
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	last := ""
+	for i := len(lines) - 1; i >= 0; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed != "" {
+			last = trimmed
+			break
+		}
+	}
+	if last == "" {
+		return false
+	}
+
+	lastRune := rune(last[len(last)-1])
+
+	// Ends with continuation punctuation.
+	if lastRune == ':' || lastRune == ',' || lastRune == ';' {
+		return true
+	}
+
+	// Terminal punctuation or structural markers mean complete.
+	isTerminal := lastRune == '.' || lastRune == '!' || lastRune == '?' ||
+		lastRune == '|' || lastRune == '*' || lastRune == '`' || lastRune == '-'
+	isStructural := strings.HasPrefix(last, "#") || strings.HasPrefix(last, "-") ||
+		strings.HasPrefix(last, "*") || strings.HasPrefix(last, "|") ||
+		strings.HasPrefix(last, "```")
+
+	if !isTerminal && !isStructural {
+		if unicode.IsLetter(lastRune) || unicode.IsDigit(lastRune) || lastRune == ')' {
+			return true
+		}
+	}
+
+	return false
+}
+
+// completeLLMResponse calls the LLM and, if the response appears truncated,
+// retries up to maxRetries times with a continuation prompt. The continuation
+// text is appended to the original response.
+func completeLLMResponse(ctx context.Context, prompt string, llm LLMCompleter, maxRetries int) (string, error) {
+	resp, err := llm.Complete(ctx, prompt)
+	if err != nil {
+		return "", err
+	}
+
+	for i := 0; i < maxRetries && isResponseTruncated(resp); i++ {
+		tail := resp
+		runes := []rune(tail)
+		if len(runes) > 200 {
+			tail = string(runes[len(runes)-200:])
+		}
+		contPrompt := "Your previous response was cut off. Continue from where you left off. Your previous response ended with:\n\n..." + tail
+		cont, err := llm.Complete(ctx, contPrompt)
+		if err != nil {
+			break // Return what we have.
+		}
+		resp += cont
+	}
+
+	return resp, nil
+}

--- a/internal/wiki/llm_guard_test.go
+++ b/internal/wiki/llm_guard_test.go
@@ -1,0 +1,146 @@
+package wiki
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestIsResponseTruncated(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"complete sentence", "This is complete.\n", false},
+		{"ends with heading", "## Section\nContent here.\n", false},
+		{"mid-sentence", "The Todo", true},
+		{"mid-word", "The applic", true},
+		{"ends with colon", "The following:", true},
+		{"ends with comma", "including foo, bar,", true},
+		{"ends with semicolon", "var x = 1;", true},
+		{"code block open", "```go\nfunc main() {\n", true},
+		{"code block closed", "```go\nfunc main() {}\n```\n", false},
+		{"empty", "", false},
+		{"list item", "- Item one\n- Item two\n", false},
+		{"table row", "| A | B |\n|---|---|\n| 1 | 2 |\n", false},
+		{"ends with exclamation", "Done!\n", false},
+		{"ends with question", "Is this done?\n", false},
+		{"ends with paren", "see section (above)", true},
+		{"whitespace only", "   \t  ", false},
+		{"heading only", "## Overview", false},
+		{"star list", "* Item one\n* Item two\n", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isResponseTruncated(tt.input); got != tt.want {
+				t.Errorf("isResponseTruncated(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// sequenceLLMCompleter returns responses in order, one per call.
+type sequenceLLMCompleter struct {
+	responses []string
+	errors    []error
+	idx       int
+	mu        sync.Mutex
+}
+
+func (s *sequenceLLMCompleter) Complete(_ context.Context, _ string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	i := s.idx
+	s.idx++
+	if i < len(s.errors) && s.errors[i] != nil {
+		return "", s.errors[i]
+	}
+	if i < len(s.responses) {
+		return s.responses[i], nil
+	}
+	return "default", nil
+}
+
+func TestCompleteLLMResponse_NoRetryWhenComplete(t *testing.T) {
+	llm := &sequenceLLMCompleter{
+		responses: []string{"This is a complete response."},
+	}
+	resp, err := completeLLMResponse(context.Background(), "prompt", llm, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != "This is a complete response." {
+		t.Errorf("got %q, want complete response unchanged", resp)
+	}
+	if llm.idx != 1 {
+		t.Errorf("expected 1 LLM call, got %d", llm.idx)
+	}
+}
+
+func TestCompleteLLMResponse_RetryOnTruncation(t *testing.T) {
+	llm := &sequenceLLMCompleter{
+		responses: []string{
+			"The applic",         // truncated
+			"ation is complete.", // continuation
+		},
+	}
+	resp, err := completeLLMResponse(context.Background(), "prompt", llm, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "The applic" + "ation is complete."
+	if resp != want {
+		t.Errorf("got %q, want %q", resp, want)
+	}
+	if llm.idx != 2 {
+		t.Errorf("expected 2 LLM calls, got %d", llm.idx)
+	}
+}
+
+func TestCompleteLLMResponse_RetryErrorReturnsPartial(t *testing.T) {
+	llm := &sequenceLLMCompleter{
+		responses: []string{"The applic", ""},
+		errors:    []error{nil, errors.New("LLM unavailable")},
+	}
+	resp, err := completeLLMResponse(context.Background(), "prompt", llm, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != "The applic" {
+		t.Errorf("got %q, want partial response", resp)
+	}
+}
+
+func TestCompleteLLMResponse_InitialError(t *testing.T) {
+	llm := &sequenceLLMCompleter{
+		errors: []error{errors.New("initial failure")},
+	}
+	_, err := completeLLMResponse(context.Background(), "prompt", llm, 1)
+	if err == nil {
+		t.Fatal("expected error on initial LLM failure")
+	}
+}
+
+func TestCompleteLLMResponse_RespectsMaxRetries(t *testing.T) {
+	llm := &sequenceLLMCompleter{
+		responses: []string{
+			"The applic",   // truncated
+			"ation contin", // still truncated
+			"ues here.",    // complete — but should not be reached with maxRetries=1
+		},
+	}
+	resp, err := completeLLMResponse(context.Background(), "prompt", llm, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// With maxRetries=1, only one retry happens: first call + one continuation.
+	if llm.idx != 2 {
+		t.Errorf("expected 2 LLM calls (maxRetries=1), got %d", llm.idx)
+	}
+	want := "The applic" + "ation contin"
+	if resp != want {
+		t.Errorf("got %q, want %q", resp, want)
+	}
+}

--- a/internal/wiki/scanner_api.go
+++ b/internal/wiki/scanner_api.go
@@ -11,11 +11,11 @@ import (
 
 // apiPatternDef describes a single regex-based API detection rule.
 type apiPatternDef struct {
-	Language    string
-	Kind        string
-	Regex       *regexp.Regexp
-	MethodGroup int // submatch index for HTTP method (0 = none)
-	PathGroup   int // submatch index for path/route (0 = none)
+	Language     string
+	Kind         string
+	Regex        *regexp.Regexp
+	MethodGroup  int // submatch index for HTTP method (0 = none)
+	PathGroup    int // submatch index for path/route (0 = none)
 	HandlerGroup int // submatch index for handler name (0 = none)
 }
 
@@ -24,11 +24,11 @@ var apiPatternDefs []apiPatternDef
 
 func init() {
 	type raw struct {
-		language    string
-		kind        string
-		pattern     string
-		methodGroup int
-		pathGroup   int
+		language     string
+		kind         string
+		pattern      string
+		methodGroup  int
+		pathGroup    int
 		handlerGroup int
 	}
 
@@ -145,6 +145,79 @@ func ScanAPIPatterns(files []ScannedFile, readFile func(string) ([]byte, error))
 	return results
 }
 
+// goGroupRe matches Go route group assignments like: api := router.Group("/prefix")
+var goGroupRe = regexp.MustCompile(`(\w+)\s*:?=\s*\w+\.Group\s*\(\s*"([^"]*)"`)
+
+// resolveRouteGroups rewrites Go source so that routes registered on group
+// variables have their prefix prepended, allowing the existing line-by-line
+// scanner to detect the full path.
+func resolveRouteGroups(src []byte) []byte {
+	// Build varName → prefix map.
+	groups := make(map[string]string)
+	for _, m := range goGroupRe.FindAllSubmatch(src, -1) {
+		varName := string(m[1])
+		prefix := strings.TrimRight(string(m[2]), "/")
+		groups[varName] = prefix
+	}
+	if len(groups) == 0 {
+		return src
+	}
+
+	// For each group variable, rewrite method calls to include the prefix.
+	result := src
+	for varName, prefix := range groups {
+		// Match varName.Method("path" — where path may be empty.
+		re := regexp.MustCompile(regexp.QuoteMeta(varName) + `\.((?i:Get|Post|Put|Delete|Patch|Options|Head))\s*\(\s*"([^"]*)"`)
+		result = re.ReplaceAllFunc(result, func(match []byte) []byte {
+			sub := re.FindSubmatch(match)
+			method := string(sub[1])
+			path := string(sub[2])
+			var fullPath string
+			if path == "" {
+				fullPath = prefix
+			} else {
+				fullPath = prefix + "/" + strings.TrimLeft(path, "/")
+			}
+			// Clean double slashes but preserve leading slash.
+			fullPath = strings.ReplaceAll(fullPath, "//", "/")
+			return []byte(varName + "." + method + `("` + fullPath + `"`)
+		})
+	}
+	return result
+}
+
+// pythonBlueprintRe matches Flask Blueprint with url_prefix.
+var pythonBlueprintRe = regexp.MustCompile(`(\w+)\s*=\s*Blueprint\s*\([^)]*url_prefix\s*=\s*['"]([^'"]+)['"]`)
+
+// resolvePythonBlueprints rewrites Python source so that routes registered on
+// Blueprint variables have the url_prefix prepended.
+func resolvePythonBlueprints(src []byte) []byte {
+	groups := make(map[string]string)
+	for _, m := range pythonBlueprintRe.FindAllSubmatch(src, -1) {
+		varName := string(m[1])
+		prefix := strings.TrimRight(string(m[2]), "/")
+		groups[varName] = prefix
+	}
+	if len(groups) == 0 {
+		return src
+	}
+
+	result := src
+	for varName, prefix := range groups {
+		// Rewrite @varName.method('/path') and @varName.route('/path') patterns.
+		re := regexp.MustCompile(`@` + regexp.QuoteMeta(varName) + `\.(get|post|put|delete|patch|route)\s*\(\s*['"]([^'"]+)['"]`)
+		result = re.ReplaceAllFunc(result, func(match []byte) []byte {
+			sub := re.FindSubmatch(match)
+			method := string(sub[1])
+			path := string(sub[2])
+			fullPath := prefix + "/" + strings.TrimLeft(path, "/")
+			fullPath = strings.ReplaceAll(fullPath, "//", "/")
+			return []byte("@" + varName + "." + method + `('` + fullPath + `'`)
+		})
+	}
+	return result
+}
+
 // scanFile processes a single ScannedFile and returns its API patterns.
 func scanFile(f ScannedFile, readFile func(string) ([]byte, error)) []APIPattern {
 	var results []APIPattern
@@ -184,6 +257,15 @@ func scanFile(f ScannedFile, readFile func(string) ([]byte, error)) []APIPattern
 	content, err := readFile(f.Path)
 	if err != nil {
 		return nil
+	}
+
+	// Resolve route groups / blueprints so prefixed paths are visible to
+	// the line-by-line regex scanner.
+	if f.Language == "go" {
+		content = resolveRouteGroups(content)
+	}
+	if f.Language == "python" {
+		content = resolvePythonBlueprints(content)
 	}
 
 	scanner := bufio.NewScanner(bytes.NewReader(content))

--- a/internal/wiki/scanner_api_test.go
+++ b/internal/wiki/scanner_api_test.go
@@ -156,6 +156,103 @@ func Add(a, b int) int {
 	assert.Empty(t, patterns)
 }
 
+func TestScanAPIPatterns_GoRouteGroup(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r := gin.Default()
+	api := r.Group("/todos")
+	api.GET("/:id", getHandler)
+	api.POST("", createHandler)
+	api.PUT("/:id", updateHandler)
+	api.DELETE("/:id", deleteHandler)
+
+	v2 := r.Group("/v2/items")
+	v2.GET("/list", listItems)
+}
+`
+	files := []ScannedFile{{Path: "main.go", Language: "go"}}
+	reader := fakeReader(map[string]string{"main.go": src})
+
+	patterns := ScanAPIPatterns(files, reader)
+
+	var httpPatterns []APIPattern
+	for _, p := range patterns {
+		if p.Kind == "http" {
+			httpPatterns = append(httpPatterns, p)
+		}
+	}
+	require.Len(t, httpPatterns, 5, "expected 5 HTTP routes from two groups")
+
+	// Build a set of method+path for verification.
+	routes := make(map[string]bool)
+	for _, p := range httpPatterns {
+		routes[p.Method+" "+p.Path] = true
+	}
+	assert.True(t, routes["GET /todos/:id"], "missing GET /todos/:id")
+	assert.True(t, routes["POST /todos"], "missing POST /todos")
+	assert.True(t, routes["PUT /todos/:id"], "missing PUT /todos/:id")
+	assert.True(t, routes["DELETE /todos/:id"], "missing DELETE /todos/:id")
+	assert.True(t, routes["GET /v2/items/list"], "missing GET /v2/items/list")
+}
+
+func TestScanAPIPatterns_PythonBlueprint(t *testing.T) {
+	src := `from flask import Flask, Blueprint
+
+bp = Blueprint('todos', __name__, url_prefix='/todos')
+
+@bp.get('/active')
+def get_active():
+    pass
+
+@bp.post('/create')
+def create_todo():
+    pass
+
+@bp.route('/all')
+def list_all():
+    pass
+`
+	files := []ScannedFile{{Path: "app.py", Language: "python"}}
+	reader := fakeReader(map[string]string{"app.py": src})
+
+	patterns := ScanAPIPatterns(files, reader)
+
+	var httpPatterns []APIPattern
+	for _, p := range patterns {
+		if p.Kind == "http" {
+			httpPatterns = append(httpPatterns, p)
+		}
+	}
+	require.Len(t, httpPatterns, 3, "expected 3 HTTP routes from blueprint")
+
+	paths := make(map[string]bool)
+	for _, p := range httpPatterns {
+		paths[p.Path] = true
+	}
+	assert.True(t, paths["/todos/active"], "missing /todos/active")
+	assert.True(t, paths["/todos/create"], "missing /todos/create")
+	assert.True(t, paths["/todos/all"], "missing /todos/all")
+}
+
+func TestResolveRouteGroups_EmptyPath(t *testing.T) {
+	src := []byte(`api := r.Group("/todos")
+api.GET("", listHandler)
+`)
+	result := resolveRouteGroups(src)
+	assert.Contains(t, string(result), `api.GET("/todos"`)
+}
+
+func TestResolveRouteGroups_NoGroups(t *testing.T) {
+	src := []byte(`r.GET("/health", healthHandler)
+r.POST("/items", createItem)
+`)
+	result := resolveRouteGroups(src)
+	assert.Equal(t, string(src), string(result))
+}
+
 func TestScanAPIPatterns_MultipleInOneFile(t *testing.T) {
 	src := `package main
 


### PR DESCRIPTION
## Summary
- Adds `isResponseTruncated()` to detect when LLM output is cut off mid-generation (unclosed code blocks, continuation punctuation, missing terminal punctuation)
- Adds `completeLLMResponse()` wrapper that retries truncated responses with a continuation prompt
- Wires the guard into security, API, and suggestion analyzers (maxRetries=1)

## Test plan
- [x] `TestIsResponseTruncated` covers complete sentences, mid-word, colon/comma/semicolon endings, open/closed code blocks, empty input, lists, tables
- [x] `TestCompleteLLMResponse_NoRetryWhenComplete` verifies no retry on complete responses
- [x] `TestCompleteLLMResponse_RetryOnTruncation` verifies retry and concatenation
- [x] `TestCompleteLLMResponse_RetryErrorReturnsPartial` verifies graceful degradation on retry error
- [x] `TestCompleteLLMResponse_InitialError` verifies error propagation
- [x] `TestCompleteLLMResponse_RespectsMaxRetries` verifies retry budget
- [x] All existing wiki tests pass (`go test ./internal/wiki/ -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)