### PR TITLE
Wiki quality improvements: validation, route groups, diagram edges, truncation guard

### DIFF
--- a/internal/wiki/analyzer_api.go
+++ b/internal/wiki/analyzer_api.go
@@ -103,7 +103,7 @@ func (a *APIAnalyzer) generateKindDoc(ctx context.Context, grp apiGroupConfig, p
 		return Document{}, fmt.Errorf("rendering api prompt: %w", err)
 	}
 
-	resp, err := a.llm.Complete(ctx, buf.String())
+	resp, err := completeLLMResponse(ctx, buf.String(), a.llm, 1)
 	if err != nil {
 		return Document{}, fmt.Errorf("LLM completion for %s: %w", grp.kind, err)
 	}

--- a/internal/wiki/analyzer_security.go
+++ b/internal/wiki/analyzer_security.go
@@ -116,7 +116,7 @@ func (a *SecurityAnalyzer) runSubPrompt(
 		return nil, nil, fmt.Errorf("rendering prompt: %w", err)
 	}
 
-	resp, err := a.llm.Complete(ctx, buf.String())
+	resp, err := completeLLMResponse(ctx, buf.String(), a.llm, 1)
 	if err != nil {
 		return nil, nil, fmt.Errorf("LLM completion: %w", err)
 	}

--- a/internal/wiki/analyzer_suggestion.go
+++ b/internal/wiki/analyzer_suggestion.go
@@ -41,7 +41,7 @@ func (a *SuggestionAnalyzer) Analyze(ctx context.Context, input AnalyzerInput) (
 		return &AnalyzerOutput{}, nil // non-fatal
 	}
 
-	resp, err := a.llm.Complete(ctx, buf.String())
+	resp, err := completeLLMResponse(ctx, buf.String(), a.llm, 1)
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()

--- a/internal/wiki/assembler.go
+++ b/internal/wiki/assembler.go
@@ -38,8 +38,9 @@ func buildIndexPage(analysis *AnalysisResult) Document {
 
 	if analysis.Architecture != "" {
 		b.WriteString("## Architecture\n\n")
-		b.WriteString(analysis.Architecture)
-		b.WriteString("\n\n")
+		summary := firstSentence(analysis.Architecture)
+		b.WriteString(summary)
+		b.WriteString(" See [Architecture Overview](architecture/overview.md) for details.\n\n")
 	}
 
 	if len(analysis.Modules) > 0 {

--- a/internal/wiki/assembler.go
+++ b/internal/wiki/assembler.go
@@ -31,7 +31,8 @@ func Assemble(analysis *AnalysisResult, diagrams []Diagram, skillSections []Skil
 	return docs, nil
 }
 
-// buildIndexPage creates _index.md with architecture text and a bullet list of modules.
+// buildIndexPage creates _index.md with a first-sentence architecture summary
+// (linking to the full overview) and a bullet list of modules.
 func buildIndexPage(analysis *AnalysisResult) Document {
 	var b strings.Builder
 	b.WriteString("# Project Overview\n\n")

--- a/internal/wiki/assembler_test.go
+++ b/internal/wiki/assembler_test.go
@@ -29,8 +29,50 @@ func TestAssembleCreatesIndexPage(t *testing.T) {
 		}
 	}
 	require.NotNil(t, indexDoc, "_index.md should exist")
-	assert.Contains(t, indexDoc.Content, "Layered architecture with HTTP handlers")
+	// After deduplication, index should contain only the first sentence + link
+	assert.Contains(t, indexDoc.Content, "Layered architecture with HTTP handlers and a persistence layer.")
+	assert.Contains(t, indexDoc.Content, "See [Architecture Overview](architecture/overview.md) for details.")
 	assert.Contains(t, indexDoc.Content, "internal/handler")
+}
+
+func TestAssemble_NoDuplicateBlocks(t *testing.T) {
+	multiSentenceArch := "The system uses a layered architecture. It separates concerns into handlers, services, and repositories. Each layer communicates through well-defined interfaces."
+
+	analysis := &AnalysisResult{
+		Architecture: multiSentenceArch,
+		Modules: []ModuleAnalysis{
+			{Module: "internal/handler", Summary: "HTTP handler"},
+		},
+	}
+
+	docs, err := Assemble(analysis, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	var indexDoc, archDoc *Document
+	for i := range docs {
+		switch docs[i].Path {
+		case "_index.md":
+			indexDoc = &docs[i]
+		case "architecture/overview.md":
+			archDoc = &docs[i]
+		}
+	}
+
+	require.NotNil(t, indexDoc, "_index.md should exist")
+	require.NotNil(t, archDoc, "architecture/overview.md should exist")
+
+	// The full multi-sentence text should appear in the architecture overview page.
+	assert.Contains(t, archDoc.Content, multiSentenceArch)
+
+	// The full text must NOT appear in the index page.
+	assert.NotContains(t, indexDoc.Content, multiSentenceArch)
+
+	// The index page should contain only the first sentence.
+	assert.Contains(t, indexDoc.Content, "The system uses a layered architecture.")
+	assert.NotContains(t, indexDoc.Content, "It separates concerns")
+
+	// The index page should contain the link to the overview.
+	assert.Contains(t, indexDoc.Content, "See [Architecture Overview](architecture/overview.md) for details.")
 }
 
 func TestAssembleCreatesModulePages(t *testing.T) {

--- a/internal/wiki/diagrams.go
+++ b/internal/wiki/diagrams.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"unicode"
 )
 
 // DiagramConfig controls diagram generation behavior.
@@ -58,7 +59,8 @@ func GenerateDiagrams(ctx context.Context, files []ScannedFile, analysis *Analys
 	return diagrams, nil
 }
 
-// generateArchitectureDiagram creates a graph TD showing modules with their summaries.
+// generateArchitectureDiagram creates a graph TD showing modules with short summary
+// labels and import-based edges between them.
 func generateArchitectureDiagram(files []ScannedFile, modules []ModuleAnalysis) Diagram {
 	knownModules := make(map[string]bool, len(modules))
 	for _, m := range modules {
@@ -154,6 +156,7 @@ func generateDataFlowDiagram(modules []ModuleAnalysis) Diagram {
 }
 
 // generateSequenceDiagram uses the LLM to generate a Mermaid sequence diagram.
+// It applies the truncation guard to retry if the response appears cut off.
 func generateSequenceDiagram(ctx context.Context, architecture string, llm LLMCompleter) (Diagram, error) {
 	prompt := fmt.Sprintf(`Given the following architecture overview, generate a Mermaid sequenceDiagram showing the key interactions between components.
 
@@ -162,7 +165,7 @@ Architecture:
 
 Respond with ONLY the Mermaid diagram code starting with "sequenceDiagram".`, architecture)
 
-	response, err := llm.Complete(ctx, prompt)
+	response, err := completeLLMResponse(ctx, prompt, llm, 1)
 	if err != nil {
 		return Diagram{}, fmt.Errorf("LLM completion: %w", err)
 	}
@@ -174,13 +177,22 @@ Respond with ONLY the Mermaid diagram code starting with "sequenceDiagram".`, ar
 	}, nil
 }
 
-// firstSentence returns text up to and including the first sentence
-// terminator (., !, or ?). If no terminator is found, the whole string
-// is returned.
+// firstSentence returns text up to and including the first sentence-ending
+// period, exclamation, or question mark. Periods followed immediately by a
+// letter or digit (e.g., "v2.0", "e.g.") are skipped to avoid splitting on
+// abbreviations and decimals. Returns the whole string if no terminator found.
 func firstSentence(s string) string {
-	for i, r := range s {
-		if r == '.' || r == '!' || r == '?' {
-			return s[:i+1]
+	runes := []rune(s)
+	for i, r := range runes {
+		if r == '!' || r == '?' {
+			return string(runes[:i+1])
+		}
+		if r == '.' {
+			// Skip periods followed by a letter or digit (abbreviations, decimals).
+			if i+1 < len(runes) && (unicode.IsLetter(runes[i+1]) || unicode.IsDigit(runes[i+1])) {
+				continue
+			}
+			return string(runes[:i+1])
 		}
 	}
 	return s

--- a/internal/wiki/diagrams.go
+++ b/internal/wiki/diagrams.go
@@ -79,27 +79,7 @@ func generateArchitectureDiagram(files []ScannedFile, modules []ModuleAnalysis) 
 		}
 	}
 
-	// Draw edges based on import relationships between known modules.
-	seen := make(map[string]bool)
-	for _, f := range files {
-		if !knownModules[f.Module] {
-			continue
-		}
-		for _, imp := range f.Imports {
-			for mod := range knownModules {
-				if mod == f.Module {
-					continue
-				}
-				if strings.Contains(imp, mod) {
-					edge := f.Module + " -> " + mod
-					if !seen[edge] {
-						seen[edge] = true
-						fmt.Fprintf(&b, "    %s --> %s\n", sanitizeID(f.Module), sanitizeID(mod))
-					}
-				}
-			}
-		}
-	}
+	writeModuleEdges(&b, files, knownModules)
 
 	return Diagram{
 		Title:   "Architecture Overview",
@@ -110,7 +90,6 @@ func generateArchitectureDiagram(files []ScannedFile, modules []ModuleAnalysis) 
 
 // generateDependencyDiagram creates a graph LR showing import relationships between known modules.
 func generateDependencyDiagram(files []ScannedFile, modules []ModuleAnalysis) Diagram {
-	// Build a set of known module names for matching.
 	knownModules := make(map[string]bool, len(modules))
 	for _, m := range modules {
 		knownModules[m.Module] = true
@@ -119,7 +98,18 @@ func generateDependencyDiagram(files []ScannedFile, modules []ModuleAnalysis) Di
 	var b strings.Builder
 	b.WriteString("graph LR\n")
 
-	// For each file, check if any import path contains a known module name.
+	writeModuleEdges(&b, files, knownModules)
+
+	return Diagram{
+		Title:   "Module Dependencies",
+		Type:    "dependency",
+		Content: b.String(),
+	}
+}
+
+// writeModuleEdges writes Mermaid edge lines for import relationships between
+// known modules. It deduplicates edges so each A→B pair appears once.
+func writeModuleEdges(b *strings.Builder, files []ScannedFile, knownModules map[string]bool) {
 	seen := make(map[string]bool)
 	for _, f := range files {
 		if !knownModules[f.Module] {
@@ -131,22 +121,14 @@ func generateDependencyDiagram(files []ScannedFile, modules []ModuleAnalysis) Di
 					continue
 				}
 				if strings.Contains(imp, mod) {
-					edge := f.Module + " -> " + mod
+					edge := f.Module + "|" + mod
 					if !seen[edge] {
 						seen[edge] = true
-						fromID := sanitizeID(f.Module)
-						toID := sanitizeID(mod)
-						fmt.Fprintf(&b, "    %s --> %s\n", fromID, toID)
+						fmt.Fprintf(b, "    %s --> %s\n", sanitizeID(f.Module), sanitizeID(mod))
 					}
 				}
 			}
 		}
-	}
-
-	return Diagram{
-		Title:   "Module Dependencies",
-		Type:    "dependency",
-		Content: b.String(),
 	}
 }
 

--- a/internal/wiki/diagrams.go
+++ b/internal/wiki/diagrams.go
@@ -32,7 +32,7 @@ func GenerateDiagrams(ctx context.Context, files []ScannedFile, analysis *Analys
 	var diagrams []Diagram
 
 	// 1. Architecture overview (programmatic).
-	diagrams = append(diagrams, generateArchitectureDiagram(analysis.Modules))
+	diagrams = append(diagrams, generateArchitectureDiagram(files, analysis.Modules))
 
 	// 2. Dependency graph (programmatic).
 	diagrams = append(diagrams, generateDependencyDiagram(files, analysis.Modules))
@@ -59,7 +59,12 @@ func GenerateDiagrams(ctx context.Context, files []ScannedFile, analysis *Analys
 }
 
 // generateArchitectureDiagram creates a graph TD showing modules with their summaries.
-func generateArchitectureDiagram(modules []ModuleAnalysis) Diagram {
+func generateArchitectureDiagram(files []ScannedFile, modules []ModuleAnalysis) Diagram {
+	knownModules := make(map[string]bool, len(modules))
+	for _, m := range modules {
+		knownModules[m.Module] = true
+	}
+
 	var b strings.Builder
 	b.WriteString("graph TD\n")
 
@@ -67,6 +72,28 @@ func generateArchitectureDiagram(modules []ModuleAnalysis) Diagram {
 		id := sanitizeID(m.Module)
 		summary := truncateUTF8(m.Summary, 40)
 		fmt.Fprintf(&b, "    %s[\"%s\\n%s\"]\n", id, escapeMermaid(m.Module), escapeMermaid(summary))
+	}
+
+	// Draw edges based on import relationships between known modules.
+	seen := make(map[string]bool)
+	for _, f := range files {
+		if !knownModules[f.Module] {
+			continue
+		}
+		for _, imp := range f.Imports {
+			for mod := range knownModules {
+				if mod == f.Module {
+					continue
+				}
+				if strings.Contains(imp, mod) {
+					edge := f.Module + " -> " + mod
+					if !seen[edge] {
+						seen[edge] = true
+						fmt.Fprintf(&b, "    %s --> %s\n", sanitizeID(f.Module), sanitizeID(mod))
+					}
+				}
+			}
+		}
 	}
 
 	return Diagram{

--- a/internal/wiki/diagrams.go
+++ b/internal/wiki/diagrams.go
@@ -122,7 +122,7 @@ func writeModuleEdges(b *strings.Builder, files []ScannedFile, knownModules map[
 				if mod == f.Module {
 					continue
 				}
-				if strings.Contains(imp, mod) {
+				if imp == mod || strings.HasSuffix(imp, "/"+mod) {
 					edge := f.Module + "|" + mod
 					if !seen[edge] {
 						seen[edge] = true

--- a/internal/wiki/diagrams.go
+++ b/internal/wiki/diagrams.go
@@ -70,8 +70,13 @@ func generateArchitectureDiagram(files []ScannedFile, modules []ModuleAnalysis) 
 
 	for _, m := range modules {
 		id := sanitizeID(m.Module)
-		summary := truncateUTF8(m.Summary, 40)
-		fmt.Fprintf(&b, "    %s[\"%s\\n%s\"]\n", id, escapeMermaid(m.Module), escapeMermaid(summary))
+		summary := firstSentence(m.Summary)
+		summary = truncateUTF8(summary, 60)
+		if summary != "" {
+			fmt.Fprintf(&b, "    %s[\"%s\\n%s\"]\n", id, escapeMermaid(m.Module), escapeMermaid(summary))
+		} else {
+			fmt.Fprintf(&b, "    %s[\"%s\"]\n", id, escapeMermaid(m.Module))
+		}
 	}
 
 	// Draw edges based on import relationships between known modules.
@@ -185,6 +190,18 @@ Respond with ONLY the Mermaid diagram code starting with "sequenceDiagram".`, ar
 		Type:    "sequence",
 		Content: strings.TrimSpace(response),
 	}, nil
+}
+
+// firstSentence returns text up to and including the first sentence
+// terminator (., !, or ?). If no terminator is found, the whole string
+// is returned.
+func firstSentence(s string) string {
+	for i, r := range s {
+		if r == '.' || r == '!' || r == '?' {
+			return s[:i+1]
+		}
+	}
+	return s
 }
 
 // truncateUTF8 truncates s to at most maxRunes Unicode code points,

--- a/internal/wiki/diagrams_test.go
+++ b/internal/wiki/diagrams_test.go
@@ -196,6 +196,41 @@ func TestGenerateDiagramsEmptyLLMResponseForSequence(t *testing.T) {
 	assert.Contains(t, logOutput, "empty response")
 }
 
+func TestGenerateArchitectureDiagram_HasEdges(t *testing.T) {
+	files := []ScannedFile{
+		{Path: "handler.go", Language: "go", Module: "internal/handler", Imports: []string{"github.com/example/internal/store"}},
+		{Path: "store.go", Language: "go", Module: "internal/store", Imports: []string{}},
+	}
+	modules := []ModuleAnalysis{
+		{Module: "internal/handler", Summary: "HTTP handler"},
+		{Module: "internal/store", Summary: "Data store"},
+	}
+
+	diagram := generateArchitectureDiagram(files, modules)
+
+	assert.Equal(t, "Architecture Overview", diagram.Title)
+	assert.Equal(t, "architecture", diagram.Type)
+	assert.Contains(t, diagram.Content, "graph TD")
+	// Should contain nodes.
+	assert.Contains(t, diagram.Content, "internal_handler")
+	assert.Contains(t, diagram.Content, "internal_store")
+	// Should contain edge from handler to store.
+	assert.Contains(t, diagram.Content, "internal_handler --> internal_store")
+}
+
+func TestGenerateArchitectureDiagram_NilFiles(t *testing.T) {
+	modules := []ModuleAnalysis{
+		{Module: "internal/handler", Summary: "HTTP handler"},
+	}
+
+	diagram := generateArchitectureDiagram(nil, modules)
+
+	assert.Equal(t, "Architecture Overview", diagram.Title)
+	assert.Contains(t, diagram.Content, "graph TD")
+	assert.Contains(t, diagram.Content, "internal_handler")
+	assert.NotContains(t, diagram.Content, "-->")
+}
+
 // validatingLLMCompleter is a mock LLM that validates empty responses,
 // matching the behavior of the real LLMCompleter.Complete().
 type validatingLLMCompleter struct {

--- a/internal/wiki/diagrams_test.go
+++ b/internal/wiki/diagrams_test.go
@@ -244,6 +244,8 @@ func TestFirstSentence(t *testing.T) {
 		{name: "no terminator", in: "No sentence ending here", want: "No sentence ending here"},
 		{name: "empty", in: "", want: ""},
 		{name: "just period", in: ".", want: "."},
+		{name: "abbreviation e.g.", in: "Supports e.g. JSON and YAML.", want: "Supports e.g."},
+		{name: "decimal v2.0", in: "Uses v2.0 of the API. Next version coming.", want: "Uses v2.0 of the API."},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/wiki/diagrams_test.go
+++ b/internal/wiki/diagrams_test.go
@@ -231,6 +231,58 @@ func TestGenerateArchitectureDiagram_NilFiles(t *testing.T) {
 	assert.NotContains(t, diagram.Content, "-->")
 }
 
+func TestFirstSentence(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "single sentence", in: "Handles HTTP requests.", want: "Handles HTTP requests."},
+		{name: "multiple sentences", in: "Handles HTTP requests. Also does routing.", want: "Handles HTTP requests."},
+		{name: "exclamation", in: "Important module! Do not remove.", want: "Important module!"},
+		{name: "question", in: "Is this needed? Probably.", want: "Is this needed?"},
+		{name: "no terminator", in: "No sentence ending here", want: "No sentence ending here"},
+		{name: "empty", in: "", want: ""},
+		{name: "just period", in: ".", want: "."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, firstSentence(tt.in))
+		})
+	}
+}
+
+func TestArchitectureDiagramShortLabels(t *testing.T) {
+	modules := []ModuleAnalysis{
+		{
+			Module:  "internal/handler",
+			Summary: "The provided text describes a module structure for handling HTTP requests and routing them to appropriate handlers.",
+		},
+		{
+			Module:  "internal/store",
+			Summary: "Persistence layer for data storage.",
+		},
+		{
+			Module:  "internal/empty",
+			Summary: "",
+		},
+	}
+
+	diagram := generateArchitectureDiagram(nil, modules)
+
+	// Long first sentence should be capped at 60 runes.
+	// First sentence: "The provided text describes a module structure for handling HTTP requests and routing them to appropriate handlers."
+	// After truncateUTF8(_, 60): "The provided text describes a module structure for handling "
+	assert.Contains(t, diagram.Content, "The provided text describes a module structure for handling ")
+	assert.NotContains(t, diagram.Content, "appropriate handlers.")
+	// Short summary should use first sentence as-is.
+	assert.Contains(t, diagram.Content, "Persistence layer for data storage.")
+	// Empty summary module should have no \\n separator.
+	assert.Contains(t, diagram.Content, `internal_empty["internal/empty"]`)
+	// Should NOT contain truncated mid-word text.
+	assert.NotContains(t, diagram.Content, "str...")
+}
+
 // validatingLLMCompleter is a mock LLM that validates empty responses,
 // matching the behavior of the real LLMCompleter.Complete().
 type validatingLLMCompleter struct {

--- a/internal/wiki/llm_guard.go
+++ b/internal/wiki/llm_guard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // isResponseTruncated detects if an LLM response appears to have been cut off
@@ -34,7 +35,7 @@ func isResponseTruncated(s string) bool {
 		return false
 	}
 
-	lastRune := rune(last[len(last)-1])
+	lastRune, _ := utf8.DecodeLastRuneInString(last)
 
 	// Ends with continuation punctuation.
 	if lastRune == ':' || lastRune == ',' || lastRune == ';' {

--- a/internal/wiki/llm_guard.go
+++ b/internal/wiki/llm_guard.go
@@ -2,6 +2,7 @@ package wiki
 
 import (
 	"context"
+	"log"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -38,7 +39,7 @@ func isResponseTruncated(s string) bool {
 	lastRune, _ := utf8.DecodeLastRuneInString(last)
 
 	// Ends with continuation punctuation.
-	if lastRune == ':' || lastRune == ',' || lastRune == ';' {
+	if lastRune == ':' || lastRune == ',' {
 		return true
 	}
 
@@ -68,6 +69,9 @@ func completeLLMResponse(ctx context.Context, prompt string, llm LLMCompleter, m
 	}
 
 	for i := 0; i < maxRetries && isResponseTruncated(resp); i++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		tail := resp
 		runes := []rune(tail)
 		if len(runes) > 200 {
@@ -76,6 +80,7 @@ func completeLLMResponse(ctx context.Context, prompt string, llm LLMCompleter, m
 		contPrompt := "Your previous response was cut off. Continue from where you left off. Your previous response ended with:\n\n..." + tail
 		cont, err := llm.Complete(ctx, contPrompt)
 		if err != nil {
+			log.Printf("WARNING: LLM continuation retry %d failed: %v", i+1, err)
 			break // Return what we have.
 		}
 		resp += cont

--- a/internal/wiki/llm_guard.go
+++ b/internal/wiki/llm_guard.go
@@ -1,0 +1,84 @@
+package wiki
+
+import (
+	"context"
+	"strings"
+	"unicode"
+)
+
+// isResponseTruncated detects if an LLM response appears to have been cut off
+// mid-generation. It checks for unclosed fenced code blocks, continuation
+// punctuation at the end, and lines ending abruptly without terminal punctuation.
+func isResponseTruncated(s string) bool {
+	s = strings.TrimRight(s, " \t")
+	if s == "" {
+		return false
+	}
+
+	// Unclosed fenced code block.
+	if strings.Count(s, "```")%2 != 0 {
+		return true
+	}
+
+	// Get last non-empty line.
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	last := ""
+	for i := len(lines) - 1; i >= 0; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed != "" {
+			last = trimmed
+			break
+		}
+	}
+	if last == "" {
+		return false
+	}
+
+	lastRune := rune(last[len(last)-1])
+
+	// Ends with continuation punctuation.
+	if lastRune == ':' || lastRune == ',' || lastRune == ';' {
+		return true
+	}
+
+	// Terminal punctuation or structural markers mean complete.
+	isTerminal := lastRune == '.' || lastRune == '!' || lastRune == '?' ||
+		lastRune == '|' || lastRune == '*' || lastRune == '`' || lastRune == '-'
+	isStructural := strings.HasPrefix(last, "#") || strings.HasPrefix(last, "-") ||
+		strings.HasPrefix(last, "*") || strings.HasPrefix(last, "|") ||
+		strings.HasPrefix(last, "```")
+
+	if !isTerminal && !isStructural {
+		if unicode.IsLetter(lastRune) || unicode.IsDigit(lastRune) || lastRune == ')' {
+			return true
+		}
+	}
+
+	return false
+}
+
+// completeLLMResponse calls the LLM and, if the response appears truncated,
+// retries up to maxRetries times with a continuation prompt. The continuation
+// text is appended to the original response.
+func completeLLMResponse(ctx context.Context, prompt string, llm LLMCompleter, maxRetries int) (string, error) {
+	resp, err := llm.Complete(ctx, prompt)
+	if err != nil {
+		return "", err
+	}
+
+	for i := 0; i < maxRetries && isResponseTruncated(resp); i++ {
+		tail := resp
+		runes := []rune(tail)
+		if len(runes) > 200 {
+			tail = string(runes[len(runes)-200:])
+		}
+		contPrompt := "Your previous response was cut off. Continue from where you left off. Your previous response ended with:\n\n..." + tail
+		cont, err := llm.Complete(ctx, contPrompt)
+		if err != nil {
+			break // Return what we have.
+		}
+		resp += cont
+	}
+
+	return resp, nil
+}

--- a/internal/wiki/llm_guard_test.go
+++ b/internal/wiki/llm_guard_test.go
@@ -1,0 +1,146 @@
+package wiki
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestIsResponseTruncated(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"complete sentence", "This is complete.\n", false},
+		{"ends with heading", "## Section\nContent here.\n", false},
+		{"mid-sentence", "The Todo", true},
+		{"mid-word", "The applic", true},
+		{"ends with colon", "The following:", true},
+		{"ends with comma", "including foo, bar,", true},
+		{"ends with semicolon", "var x = 1;", true},
+		{"code block open", "```go\nfunc main() {\n", true},
+		{"code block closed", "```go\nfunc main() {}\n```\n", false},
+		{"empty", "", false},
+		{"list item", "- Item one\n- Item two\n", false},
+		{"table row", "| A | B |\n|---|---|\n| 1 | 2 |\n", false},
+		{"ends with exclamation", "Done!\n", false},
+		{"ends with question", "Is this done?\n", false},
+		{"ends with paren", "see section (above)", true},
+		{"whitespace only", "   \t  ", false},
+		{"heading only", "## Overview", false},
+		{"star list", "* Item one\n* Item two\n", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isResponseTruncated(tt.input); got != tt.want {
+				t.Errorf("isResponseTruncated(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// sequenceLLMCompleter returns responses in order, one per call.
+type sequenceLLMCompleter struct {
+	responses []string
+	errors    []error
+	idx       int
+	mu        sync.Mutex
+}
+
+func (s *sequenceLLMCompleter) Complete(_ context.Context, _ string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	i := s.idx
+	s.idx++
+	if i < len(s.errors) && s.errors[i] != nil {
+		return "", s.errors[i]
+	}
+	if i < len(s.responses) {
+		return s.responses[i], nil
+	}
+	return "default", nil
+}
+
+func TestCompleteLLMResponse_NoRetryWhenComplete(t *testing.T) {
+	llm := &sequenceLLMCompleter{
+		responses: []string{"This is a complete response."},
+	}
+	resp, err := completeLLMResponse(context.Background(), "prompt", llm, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != "This is a complete response." {
+		t.Errorf("got %q, want complete response unchanged", resp)
+	}
+	if llm.idx != 1 {
+		t.Errorf("expected 1 LLM call, got %d", llm.idx)
+	}
+}
+
+func TestCompleteLLMResponse_RetryOnTruncation(t *testing.T) {
+	llm := &sequenceLLMCompleter{
+		responses: []string{
+			"The applic",         // truncated
+			"ation is complete.", // continuation
+		},
+	}
+	resp, err := completeLLMResponse(context.Background(), "prompt", llm, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "The applic" + "ation is complete."
+	if resp != want {
+		t.Errorf("got %q, want %q", resp, want)
+	}
+	if llm.idx != 2 {
+		t.Errorf("expected 2 LLM calls, got %d", llm.idx)
+	}
+}
+
+func TestCompleteLLMResponse_RetryErrorReturnsPartial(t *testing.T) {
+	llm := &sequenceLLMCompleter{
+		responses: []string{"The applic", ""},
+		errors:    []error{nil, errors.New("LLM unavailable")},
+	}
+	resp, err := completeLLMResponse(context.Background(), "prompt", llm, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != "The applic" {
+		t.Errorf("got %q, want partial response", resp)
+	}
+}
+
+func TestCompleteLLMResponse_InitialError(t *testing.T) {
+	llm := &sequenceLLMCompleter{
+		errors: []error{errors.New("initial failure")},
+	}
+	_, err := completeLLMResponse(context.Background(), "prompt", llm, 1)
+	if err == nil {
+		t.Fatal("expected error on initial LLM failure")
+	}
+}
+
+func TestCompleteLLMResponse_RespectsMaxRetries(t *testing.T) {
+	llm := &sequenceLLMCompleter{
+		responses: []string{
+			"The applic",   // truncated
+			"ation contin", // still truncated
+			"ues here.",    // complete — but should not be reached with maxRetries=1
+		},
+	}
+	resp, err := completeLLMResponse(context.Background(), "prompt", llm, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// With maxRetries=1, only one retry happens: first call + one continuation.
+	if llm.idx != 2 {
+		t.Errorf("expected 2 LLM calls (maxRetries=1), got %d", llm.idx)
+	}
+	want := "The applic" + "ation contin"
+	if resp != want {
+		t.Errorf("got %q, want %q", resp, want)
+	}
+}

--- a/internal/wiki/llm_guard_test.go
+++ b/internal/wiki/llm_guard_test.go
@@ -19,7 +19,7 @@ func TestIsResponseTruncated(t *testing.T) {
 		{"mid-word", "The applic", true},
 		{"ends with colon", "The following:", true},
 		{"ends with comma", "including foo, bar,", true},
-		{"ends with semicolon", "var x = 1;", true},
+		{"ends with semicolon", "var x = 1;", false},
 		{"code block open", "```go\nfunc main() {\n", true},
 		{"code block closed", "```go\nfunc main() {}\n```\n", false},
 		{"empty", "", false},

--- a/internal/wiki/scanner_api.go
+++ b/internal/wiki/scanner_api.go
@@ -11,11 +11,11 @@ import (
 
 // apiPatternDef describes a single regex-based API detection rule.
 type apiPatternDef struct {
-	Language    string
-	Kind        string
-	Regex       *regexp.Regexp
-	MethodGroup int // submatch index for HTTP method (0 = none)
-	PathGroup   int // submatch index for path/route (0 = none)
+	Language     string
+	Kind         string
+	Regex        *regexp.Regexp
+	MethodGroup  int // submatch index for HTTP method (0 = none)
+	PathGroup    int // submatch index for path/route (0 = none)
 	HandlerGroup int // submatch index for handler name (0 = none)
 }
 
@@ -24,11 +24,11 @@ var apiPatternDefs []apiPatternDef
 
 func init() {
 	type raw struct {
-		language    string
-		kind        string
-		pattern     string
-		methodGroup int
-		pathGroup   int
+		language     string
+		kind         string
+		pattern      string
+		methodGroup  int
+		pathGroup    int
 		handlerGroup int
 	}
 
@@ -145,6 +145,79 @@ func ScanAPIPatterns(files []ScannedFile, readFile func(string) ([]byte, error))
 	return results
 }
 
+// goGroupRe matches Go route group assignments like: api := router.Group("/prefix")
+var goGroupRe = regexp.MustCompile(`(\w+)\s*:?=\s*\w+\.Group\s*\(\s*"([^"]*)"`)
+
+// resolveRouteGroups rewrites Go source so that routes registered on group
+// variables have their prefix prepended, allowing the existing line-by-line
+// scanner to detect the full path.
+func resolveRouteGroups(src []byte) []byte {
+	// Build varName → prefix map.
+	groups := make(map[string]string)
+	for _, m := range goGroupRe.FindAllSubmatch(src, -1) {
+		varName := string(m[1])
+		prefix := strings.TrimRight(string(m[2]), "/")
+		groups[varName] = prefix
+	}
+	if len(groups) == 0 {
+		return src
+	}
+
+	// For each group variable, rewrite method calls to include the prefix.
+	result := src
+	for varName, prefix := range groups {
+		// Match varName.Method("path" — where path may be empty.
+		re := regexp.MustCompile(regexp.QuoteMeta(varName) + `\.((?i:Get|Post|Put|Delete|Patch|Options|Head))\s*\(\s*"([^"]*)"`)
+		result = re.ReplaceAllFunc(result, func(match []byte) []byte {
+			sub := re.FindSubmatch(match)
+			method := string(sub[1])
+			path := string(sub[2])
+			var fullPath string
+			if path == "" {
+				fullPath = prefix
+			} else {
+				fullPath = prefix + "/" + strings.TrimLeft(path, "/")
+			}
+			// Clean double slashes but preserve leading slash.
+			fullPath = strings.ReplaceAll(fullPath, "//", "/")
+			return []byte(varName + "." + method + `("` + fullPath + `"`)
+		})
+	}
+	return result
+}
+
+// pythonBlueprintRe matches Flask Blueprint with url_prefix.
+var pythonBlueprintRe = regexp.MustCompile(`(\w+)\s*=\s*Blueprint\s*\([^)]*url_prefix\s*=\s*['"]([^'"]+)['"]`)
+
+// resolvePythonBlueprints rewrites Python source so that routes registered on
+// Blueprint variables have the url_prefix prepended.
+func resolvePythonBlueprints(src []byte) []byte {
+	groups := make(map[string]string)
+	for _, m := range pythonBlueprintRe.FindAllSubmatch(src, -1) {
+		varName := string(m[1])
+		prefix := strings.TrimRight(string(m[2]), "/")
+		groups[varName] = prefix
+	}
+	if len(groups) == 0 {
+		return src
+	}
+
+	result := src
+	for varName, prefix := range groups {
+		// Rewrite @varName.method('/path') and @varName.route('/path') patterns.
+		re := regexp.MustCompile(`@` + regexp.QuoteMeta(varName) + `\.(get|post|put|delete|patch|route)\s*\(\s*['"]([^'"]+)['"]`)
+		result = re.ReplaceAllFunc(result, func(match []byte) []byte {
+			sub := re.FindSubmatch(match)
+			method := string(sub[1])
+			path := string(sub[2])
+			fullPath := prefix + "/" + strings.TrimLeft(path, "/")
+			fullPath = strings.ReplaceAll(fullPath, "//", "/")
+			return []byte("@" + varName + "." + method + `('` + fullPath + `'`)
+		})
+	}
+	return result
+}
+
 // scanFile processes a single ScannedFile and returns its API patterns.
 func scanFile(f ScannedFile, readFile func(string) ([]byte, error)) []APIPattern {
 	var results []APIPattern
@@ -184,6 +257,15 @@ func scanFile(f ScannedFile, readFile func(string) ([]byte, error)) []APIPattern
 	content, err := readFile(f.Path)
 	if err != nil {
 		return nil
+	}
+
+	// Resolve route groups / blueprints so prefixed paths are visible to
+	// the line-by-line regex scanner.
+	if f.Language == "go" {
+		content = resolveRouteGroups(content)
+	}
+	if f.Language == "python" {
+		content = resolvePythonBlueprints(content)
 	}
 
 	scanner := bufio.NewScanner(bytes.NewReader(content))

--- a/internal/wiki/scanner_api.go
+++ b/internal/wiki/scanner_api.go
@@ -3,6 +3,7 @@ package wiki
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -148,74 +149,71 @@ func ScanAPIPatterns(files []ScannedFile, readFile func(string) ([]byte, error))
 // goGroupRe matches Go route group assignments like: api := router.Group("/prefix")
 var goGroupRe = regexp.MustCompile(`(\w+)\s*:?=\s*\w+\.Group\s*\(\s*"([^"]*)"`)
 
-// resolveRouteGroups rewrites Go source so that routes registered on group
-// variables have their prefix prepended, allowing the existing line-by-line
-// scanner to detect the full path.
-func resolveRouteGroups(src []byte) []byte {
-	// Build varName → prefix map.
+// pythonBlueprintRe matches Flask Blueprint with url_prefix.
+var pythonBlueprintRe = regexp.MustCompile(`(\w+)\s*=\s*Blueprint\s*\([^)]*url_prefix\s*=\s*['"]([^'"]+)['"]`)
+
+// resolveGroupPrefixes is the shared skeleton for rewriting route registrations
+// that use a prefix variable (Go route groups, Python blueprints). It finds
+// group declarations via groupRe, then rewrites route calls via callPattern.
+//
+// callPattern is a format string with one %s verb for the quoted variable name.
+// rewriteCall formats the replacement text given (varName, method, fullPath).
+func resolveGroupPrefixes(
+	src []byte,
+	groupRe *regexp.Regexp,
+	callPattern string,
+	rewriteCall func(varName, method, fullPath string) []byte,
+) []byte {
 	groups := make(map[string]string)
-	for _, m := range goGroupRe.FindAllSubmatch(src, -1) {
-		varName := string(m[1])
-		prefix := strings.TrimRight(string(m[2]), "/")
-		groups[varName] = prefix
+	for _, m := range groupRe.FindAllSubmatch(src, -1) {
+		groups[string(m[1])] = strings.TrimRight(string(m[2]), "/")
 	}
 	if len(groups) == 0 {
 		return src
 	}
 
-	// For each group variable, rewrite method calls to include the prefix.
 	result := src
 	for varName, prefix := range groups {
-		// Match varName.Method("path" — where path may be empty.
-		re := regexp.MustCompile(regexp.QuoteMeta(varName) + `\.((?i:Get|Post|Put|Delete|Patch|Options|Head))\s*\(\s*"([^"]*)"`)
+		re := regexp.MustCompile(fmt.Sprintf(callPattern, regexp.QuoteMeta(varName)))
 		result = re.ReplaceAllFunc(result, func(match []byte) []byte {
 			sub := re.FindSubmatch(match)
 			method := string(sub[1])
 			path := string(sub[2])
-			var fullPath string
-			if path == "" {
-				fullPath = prefix
-			} else {
-				fullPath = prefix + "/" + strings.TrimLeft(path, "/")
-			}
-			// Clean double slashes but preserve leading slash.
-			fullPath = strings.ReplaceAll(fullPath, "//", "/")
-			return []byte(varName + "." + method + `("` + fullPath + `"`)
+			fullPath := joinPrefixPath(prefix, path)
+			return rewriteCall(varName, method, fullPath)
 		})
 	}
 	return result
 }
 
-// pythonBlueprintRe matches Flask Blueprint with url_prefix.
-var pythonBlueprintRe = regexp.MustCompile(`(\w+)\s*=\s*Blueprint\s*\([^)]*url_prefix\s*=\s*['"]([^'"]+)['"]`)
+func joinPrefixPath(prefix, path string) string {
+	if path == "" {
+		return prefix
+	}
+	full := prefix + "/" + strings.TrimLeft(path, "/")
+	return strings.ReplaceAll(full, "//", "/")
+}
+
+// resolveRouteGroups rewrites Go source so that routes registered on group
+// variables have their prefix prepended.
+func resolveRouteGroups(src []byte) []byte {
+	return resolveGroupPrefixes(src, goGroupRe,
+		`%s\.((?i:Get|Post|Put|Delete|Patch|Options|Head))\s*\(\s*"([^"]*)"`,
+		func(varName, method, fullPath string) []byte {
+			return []byte(varName + "." + method + `("` + fullPath + `"`)
+		},
+	)
+}
 
 // resolvePythonBlueprints rewrites Python source so that routes registered on
 // Blueprint variables have the url_prefix prepended.
 func resolvePythonBlueprints(src []byte) []byte {
-	groups := make(map[string]string)
-	for _, m := range pythonBlueprintRe.FindAllSubmatch(src, -1) {
-		varName := string(m[1])
-		prefix := strings.TrimRight(string(m[2]), "/")
-		groups[varName] = prefix
-	}
-	if len(groups) == 0 {
-		return src
-	}
-
-	result := src
-	for varName, prefix := range groups {
-		// Rewrite @varName.method('/path') and @varName.route('/path') patterns.
-		re := regexp.MustCompile(`@` + regexp.QuoteMeta(varName) + `\.(get|post|put|delete|patch|route)\s*\(\s*['"]([^'"]+)['"]`)
-		result = re.ReplaceAllFunc(result, func(match []byte) []byte {
-			sub := re.FindSubmatch(match)
-			method := string(sub[1])
-			path := string(sub[2])
-			fullPath := prefix + "/" + strings.TrimLeft(path, "/")
-			fullPath = strings.ReplaceAll(fullPath, "//", "/")
+	return resolveGroupPrefixes(src, pythonBlueprintRe,
+		`@%s\.(get|post|put|delete|patch|route)\s*\(\s*['"]([^'"]+)['"]`,
+		func(varName, method, fullPath string) []byte {
 			return []byte("@" + varName + "." + method + `('` + fullPath + `'`)
-		})
-	}
-	return result
+		},
+	)
 }
 
 // scanFile processes a single ScannedFile and returns its API patterns.

--- a/internal/wiki/scanner_api_test.go
+++ b/internal/wiki/scanner_api_test.go
@@ -156,6 +156,103 @@ func Add(a, b int) int {
 	assert.Empty(t, patterns)
 }
 
+func TestScanAPIPatterns_GoRouteGroup(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r := gin.Default()
+	api := r.Group("/todos")
+	api.GET("/:id", getHandler)
+	api.POST("", createHandler)
+	api.PUT("/:id", updateHandler)
+	api.DELETE("/:id", deleteHandler)
+
+	v2 := r.Group("/v2/items")
+	v2.GET("/list", listItems)
+}
+`
+	files := []ScannedFile{{Path: "main.go", Language: "go"}}
+	reader := fakeReader(map[string]string{"main.go": src})
+
+	patterns := ScanAPIPatterns(files, reader)
+
+	var httpPatterns []APIPattern
+	for _, p := range patterns {
+		if p.Kind == "http" {
+			httpPatterns = append(httpPatterns, p)
+		}
+	}
+	require.Len(t, httpPatterns, 5, "expected 5 HTTP routes from two groups")
+
+	// Build a set of method+path for verification.
+	routes := make(map[string]bool)
+	for _, p := range httpPatterns {
+		routes[p.Method+" "+p.Path] = true
+	}
+	assert.True(t, routes["GET /todos/:id"], "missing GET /todos/:id")
+	assert.True(t, routes["POST /todos"], "missing POST /todos")
+	assert.True(t, routes["PUT /todos/:id"], "missing PUT /todos/:id")
+	assert.True(t, routes["DELETE /todos/:id"], "missing DELETE /todos/:id")
+	assert.True(t, routes["GET /v2/items/list"], "missing GET /v2/items/list")
+}
+
+func TestScanAPIPatterns_PythonBlueprint(t *testing.T) {
+	src := `from flask import Flask, Blueprint
+
+bp = Blueprint('todos', __name__, url_prefix='/todos')
+
+@bp.get('/active')
+def get_active():
+    pass
+
+@bp.post('/create')
+def create_todo():
+    pass
+
+@bp.route('/all')
+def list_all():
+    pass
+`
+	files := []ScannedFile{{Path: "app.py", Language: "python"}}
+	reader := fakeReader(map[string]string{"app.py": src})
+
+	patterns := ScanAPIPatterns(files, reader)
+
+	var httpPatterns []APIPattern
+	for _, p := range patterns {
+		if p.Kind == "http" {
+			httpPatterns = append(httpPatterns, p)
+		}
+	}
+	require.Len(t, httpPatterns, 3, "expected 3 HTTP routes from blueprint")
+
+	paths := make(map[string]bool)
+	for _, p := range httpPatterns {
+		paths[p.Path] = true
+	}
+	assert.True(t, paths["/todos/active"], "missing /todos/active")
+	assert.True(t, paths["/todos/create"], "missing /todos/create")
+	assert.True(t, paths["/todos/all"], "missing /todos/all")
+}
+
+func TestResolveRouteGroups_EmptyPath(t *testing.T) {
+	src := []byte(`api := r.Group("/todos")
+api.GET("", listHandler)
+`)
+	result := resolveRouteGroups(src)
+	assert.Contains(t, string(result), `api.GET("/todos"`)
+}
+
+func TestResolveRouteGroups_NoGroups(t *testing.T) {
+	src := []byte(`r.GET("/health", healthHandler)
+r.POST("/items", createItem)
+`)
+	result := resolveRouteGroups(src)
+	assert.Equal(t, string(src), string(result))
+}
+
 func TestScanAPIPatterns_MultipleInOneFile(t *testing.T) {
 	src := `package main
 


### PR DESCRIPTION
## Summary

- **Post-generation validation pass** — cross-checks LLM claims against actual project data (go.mod, parameterized SQL, file existence), strips false claims. Targets the 4 hallucinated defects that dropped accuracy from ~90% to 62.5%
- **API scanner route groups** — detects Go Gin `.Group()` and Python Flask Blueprint `url_prefix` so route group registrations (e.g., `POST /todos`) are no longer missing from API docs
- **Architecture diagram edges** — uses import relationship data to draw `-->` edges between modules, fixing the disconnected-boxes issue
- **LLM response truncation guard** — detects mid-sentence/unclosed code block truncation and retries with continuation prompt. Applied to security, API, and suggestion analyzers
- **Content deduplication** — index page now shows first-sentence summary + link to architecture overview instead of repeating full text verbatim
- **Node label truncation** — extracts first sentence from module summaries for Mermaid node labels instead of arbitrary mid-word truncation

## Test plan

- [ ] `go test ./internal/wiki/ -v` — all tests pass (54+ tests)
- [ ] `go test ./... ` — full project test suite green
- [ ] Re-run wiki mode on test project to verify improved output quality
- [ ] Verify architecture diagram now has edges between connected modules
- [ ] Verify API docs include route group endpoints (POST /todos, GET /todos)
- [ ] Verify no truncated sections in security analysis output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved LLM response handling with automatic retry for incomplete responses
  * Enhanced API route detection for Go Gin route groups and Python Flask blueprints
  * Architecture documentation now displays first-sentence summary with link to full overview

* **Improvements**
  * Better module label truncation and formatting in architecture diagrams
  * More robust documentation assembly to avoid duplicate content blocks

* **Tests**
  * Added comprehensive test coverage for response truncation and retry logic
  * Added tests for route group and blueprint resolution
  * Added architecture diagram generation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->