### PR TITLE
cmux terminal integration: JSON-RPC socket client + tools + TUI wiring

### DIFF
--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1369,16 +1369,23 @@ func applyAPIKeyFlag(cfg *config.Config) {
 	}
 }
 
+// dialCmux connects to the cmux daemon if running inside cmux.
+// Returns a Caller (nil if not in cmux) and a cleanup function.
+func dialCmux(caps *terminal.Caps) (cmux.Caller, func()) {
+	if !caps.CmuxSocket {
+		return nil, func() {}
+	}
+	cc, err := cmux.Dial(cmux.SocketPath())
+	if err != nil {
+		return nil, func() {}
+	}
+	return cc, func() { cc.Close() }
+}
+
 func runInteractive() error {
 	caps := terminal.Detect()
-
-	var cmuxClient cmux.Caller
-	if caps.CmuxSocket {
-		if cc, err := cmux.Dial(cmux.SocketPath()); err == nil {
-			cmuxClient = cc
-			defer cc.Close()
-		}
-	}
+	cmuxClient, closeCmux := dialCmux(caps)
+	defer closeCmux()
 
 	// Resolve config path early for bootstrap check.
 	cfgDir, err := configDir()
@@ -1928,14 +1935,8 @@ func runHeadless() error {
 	}
 
 	caps := terminal.Detect()
-
-	var cmuxClient cmux.Caller
-	if caps.CmuxSocket {
-		if cc, err := cmux.Dial(cmux.SocketPath()); err == nil {
-			cmuxClient = cc
-			defer cc.Close()
-		}
-	}
+	cmuxClient, closeCmux := dialCmux(caps)
+	defer closeCmux()
 
 	if maxTurnsFlag > 0 {
 		cfg.Agent.MaxTurns = maxTurnsFlag
@@ -2314,19 +2315,12 @@ func runHeadless() error {
 
 	// Terminal notifications for headless completion.
 	if cmuxClient != nil {
-		cmuxClient.Call("notification.create", map[string]string{
-			"title": "Rubichan",
-			"subtitle": "Code Review",
-			"body": "Code review complete",
-		})
+		cmux.CallerNotify(cmuxClient, "Rubichan", "Code Review", "Code review complete")
 		if secReport != nil {
 			summary := secReport.Summary()
 			highSeverityCount := summary.Critical + summary.High
 			if highSeverityCount > 0 {
-				cmuxClient.Call("notification.create", map[string]string{
-					"title": "Rubichan",
-					"body": fmt.Sprintf("%d high-severity security findings detected", highSeverityCount),
-				})
+				cmux.CallerNotify(cmuxClient, "Rubichan", "", fmt.Sprintf("%d high-severity security findings detected", highSeverityCount))
 			}
 		}
 	} else if caps.Notifications {
@@ -3163,14 +3157,8 @@ func postResultsToPR(ctx context.Context, result *output.RunResult, secReport *s
 // progress updates to stderr.
 func runWikiHeadless(cfg *config.Config, cwd, outDir, format string, concurrency int) error {
 	caps := terminal.Detect()
-
-	var cmuxClient cmux.Caller
-	if caps.CmuxSocket {
-		if cc, err := cmux.Dial(cmux.SocketPath()); err == nil {
-			cmuxClient = cc
-			defer cc.Close()
-		}
-	}
+	cmuxClient, closeCmux := dialCmux(caps)
+	defer closeCmux()
 
 	p, err := provider.NewProviderWithDebug(cfg, debugMode)
 	if err != nil {
@@ -3190,20 +3178,14 @@ func runWikiHeadless(cfg *config.Config, cwd, outDir, format string, concurrency
 				fmt.Fprintf(os.Stderr, "[%s] %d/%d\n", stage, current, total)
 				percent := current * 100 / total
 				if cmuxClient != nil {
-					cmuxClient.Call("set-progress", map[string]any{
-						"value": float64(percent) / 100.0,
-						"label": stage,
-					})
+					cmux.CallerSetProgress(cmuxClient, float64(percent)/100.0, stage)
 				} else if caps.ProgressBar {
 					terminal.SetProgress(os.Stderr, terminal.ProgressNormal, percent)
 				}
 			} else {
 				fmt.Fprintf(os.Stderr, "[%s]\n", stage)
 				if cmuxClient != nil {
-					cmuxClient.Call("set-progress", map[string]any{
-						"value": 0.0,
-						"label": stage,
-					})
+					cmux.CallerSetProgress(cmuxClient, 0.0, stage)
 				} else if caps.ProgressBar {
 					terminal.SetProgress(os.Stderr, terminal.ProgressIndeterminate, 0)
 				}
@@ -3214,16 +3196,14 @@ func runWikiHeadless(cfg *config.Config, cwd, outDir, format string, concurrency
 	result, err := wiki.Run(context.Background(), wikiCfg, llm, par)
 
 	if cmuxClient != nil {
-		cmuxClient.Call("clear-progress", map[string]any{})
+		cmux.CallerClearProgress(cmuxClient)
 	} else if caps.ProgressBar {
 		terminal.ClearProgress(os.Stderr)
 	}
 
 	if err != nil {
 		if cmuxClient != nil {
-			cmuxClient.Call("notification.create", map[string]string{
-				"title": "Rubichan", "body": "Wiki generation failed",
-			})
+			cmux.CallerNotify(cmuxClient, "Rubichan", "", "Wiki generation failed")
 		} else if caps.Notifications {
 			terminal.Notify(os.Stderr, "Wiki generation failed")
 		}
@@ -3231,11 +3211,7 @@ func runWikiHeadless(cfg *config.Config, cwd, outDir, format string, concurrency
 	}
 
 	if cmuxClient != nil {
-		cmuxClient.Call("notification.create", map[string]string{
-			"title":    "Rubichan",
-			"subtitle": "Wiki Generation",
-			"body":     fmt.Sprintf("Wiki complete — %d documents rendered", result.Documents),
-		})
+		cmux.CallerNotify(cmuxClient, "Rubichan", "Wiki Generation", fmt.Sprintf("Wiki complete — %d documents rendered", result.Documents))
 	} else if caps.Notifications {
 		terminal.Notify(os.Stderr, fmt.Sprintf("Wiki complete — %d documents rendered", result.Documents))
 	}

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sourcegraph/conc"
 
 	"github.com/julianshen/rubichan/internal/agent"
+	"github.com/julianshen/rubichan/internal/cmux"
 	"github.com/julianshen/rubichan/internal/commands"
 	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/hooks"
@@ -58,7 +59,6 @@ import (
 	"github.com/julianshen/rubichan/internal/store"
 	"github.com/julianshen/rubichan/internal/terminal"
 	"github.com/julianshen/rubichan/internal/toolexec"
-	"github.com/julianshen/rubichan/internal/cmux"
 	"github.com/julianshen/rubichan/internal/tools"
 	"github.com/julianshen/rubichan/internal/tools/browser"
 	dbtools "github.com/julianshen/rubichan/internal/tools/db"
@@ -1873,8 +1873,10 @@ func runInteractive() error {
 			tools.NewCmuxOrchestrate(cmuxClient),
 		}
 		for _, t := range cmuxTools {
-			if err := registry.Register(t); err != nil {
-				log.Printf("warning: registering cmux tool %q: %v", t.Name(), err)
+			if toolsCfg.ShouldEnable(t.Name()) {
+				if err := registry.Register(t); err != nil {
+					log.Printf("warning: registering cmux tool %q: %v", t.Name(), err)
+				}
 			}
 		}
 	}
@@ -2315,16 +2317,16 @@ func runHeadless() error {
 	}
 
 	// Terminal notifications for headless completion.
-	if cmuxClient != nil {
-		cmux.CallerNotify(cmuxClient, "Rubichan", "Code Review", "Code review complete")
-		if secReport != nil {
-			summary := secReport.Summary()
-			highSeverityCount := summary.Critical + summary.High
-			if highSeverityCount > 0 {
-				cmux.CallerNotify(cmuxClient, "Rubichan", "", fmt.Sprintf("%d high-severity security findings detected", highSeverityCount))
-			}
+	// Try cmux first; fall back to OSC terminal notifications on failure.
+	notified := cmuxClient != nil && cmux.CallerNotify(cmuxClient, "Rubichan", "Code Review", "Code review complete")
+	if cmuxClient != nil && secReport != nil {
+		summary := secReport.Summary()
+		highSeverityCount := summary.Critical + summary.High
+		if highSeverityCount > 0 {
+			cmux.CallerNotify(cmuxClient, "Rubichan", "", fmt.Sprintf("%d high-severity security findings detected", highSeverityCount))
 		}
-	} else if caps.Notifications {
+	}
+	if !notified && caps.Notifications {
 		terminal.Notify(os.Stderr, "Code review complete")
 		if secReport != nil {
 			summary := secReport.Summary()

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1377,6 +1377,7 @@ func dialCmux(caps *terminal.Caps) (cmux.Caller, func()) {
 	}
 	cc, err := cmux.Dial(cmux.SocketPath())
 	if err != nil {
+		log.Printf("warning: cmux socket detected but dial failed: %v — cmux features disabled", err)
 		return nil, func() {}
 	}
 	return cc, func() { cc.Close() }

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -3214,7 +3214,7 @@ func runWikiHeadless(cfg *config.Config, cwd, outDir, format string, concurrency
 	result, err := wiki.Run(context.Background(), wikiCfg, llm, par)
 
 	if cmuxClient != nil {
-		cmuxClient.Call("clear-progress", nil)
+		cmuxClient.Call("clear-progress", map[string]any{})
 	} else if caps.ProgressBar {
 		terminal.ClearProgress(os.Stderr)
 	}

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -58,6 +58,7 @@ import (
 	"github.com/julianshen/rubichan/internal/store"
 	"github.com/julianshen/rubichan/internal/terminal"
 	"github.com/julianshen/rubichan/internal/toolexec"
+	"github.com/julianshen/rubichan/internal/cmux"
 	"github.com/julianshen/rubichan/internal/tools"
 	"github.com/julianshen/rubichan/internal/tools/browser"
 	dbtools "github.com/julianshen/rubichan/internal/tools/db"
@@ -1370,6 +1371,15 @@ func applyAPIKeyFlag(cfg *config.Config) {
 
 func runInteractive() error {
 	caps := terminal.Detect()
+
+	var cmuxClient cmux.Caller
+	if caps.CmuxSocket {
+		if cc, err := cmux.Dial(cmux.SocketPath()); err == nil {
+			cmuxClient = cc
+			defer cc.Close()
+		}
+	}
+
 	// Resolve config path early for bootstrap check.
 	cfgDir, err := configDir()
 	if err != nil {
@@ -1680,6 +1690,7 @@ func runInteractive() error {
 	// interactive approval function before constructing the agent.
 	model := tui.NewModel(nil, "rubichan", cfg.Provider.Model, cfg.Agent.MaxTurns, cfgPath, cfg, cmdRegistry)
 	model.SetTermCaps(caps)
+	model.SetCmuxClient(cmuxClient)
 	model.SetDebug(debugMode)
 	if rt != nil {
 		model.SetSkillSummaryProvider(rt)
@@ -1841,6 +1852,25 @@ func runInteractive() error {
 		}
 	}
 
+	// Register cmux tools when running inside cmux terminal.
+	if cmuxClient != nil {
+		cmuxTools := []tools.Tool{
+			tools.NewCmuxBrowserNavigate(cmuxClient),
+			tools.NewCmuxBrowserSnapshot(cmuxClient),
+			tools.NewCmuxBrowserClick(cmuxClient),
+			tools.NewCmuxBrowserType(cmuxClient),
+			tools.NewCmuxBrowserWait(cmuxClient),
+			tools.NewCmuxSplit(cmuxClient),
+			tools.NewCmuxSend(cmuxClient),
+			tools.NewCmuxOrchestrate(cmuxClient),
+		}
+		for _, t := range cmuxTools {
+			if err := registry.Register(t); err != nil {
+				log.Printf("warning: registering cmux tool %q: %v", t.Name(), err)
+			}
+		}
+	}
+
 	// Wire the agent into the TUI model now that both exist.
 	model.SetAgent(a)
 	model.SetWikiConfig(tui.WikiCommandConfig{
@@ -1898,6 +1928,14 @@ func runHeadless() error {
 	}
 
 	caps := terminal.Detect()
+
+	var cmuxClient cmux.Caller
+	if caps.CmuxSocket {
+		if cc, err := cmux.Dial(cmux.SocketPath()); err == nil {
+			cmuxClient = cc
+			defer cc.Close()
+		}
+	}
 
 	if maxTurnsFlag > 0 {
 		cfg.Agent.MaxTurns = maxTurnsFlag
@@ -2275,7 +2313,23 @@ func runHeadless() error {
 	}
 
 	// Terminal notifications for headless completion.
-	if caps.Notifications {
+	if cmuxClient != nil {
+		cmuxClient.Call("notification.create", map[string]string{
+			"title": "Rubichan",
+			"subtitle": "Code Review",
+			"body": "Code review complete",
+		})
+		if secReport != nil {
+			summary := secReport.Summary()
+			highSeverityCount := summary.Critical + summary.High
+			if highSeverityCount > 0 {
+				cmuxClient.Call("notification.create", map[string]string{
+					"title": "Rubichan",
+					"body": fmt.Sprintf("%d high-severity security findings detected", highSeverityCount),
+				})
+			}
+		}
+	} else if caps.Notifications {
 		terminal.Notify(os.Stderr, "Code review complete")
 		if secReport != nil {
 			summary := secReport.Summary()
@@ -3110,6 +3164,14 @@ func postResultsToPR(ctx context.Context, result *output.RunResult, secReport *s
 func runWikiHeadless(cfg *config.Config, cwd, outDir, format string, concurrency int) error {
 	caps := terminal.Detect()
 
+	var cmuxClient cmux.Caller
+	if caps.CmuxSocket {
+		if cc, err := cmux.Dial(cmux.SocketPath()); err == nil {
+			cmuxClient = cc
+			defer cc.Close()
+		}
+	}
+
 	p, err := provider.NewProviderWithDebug(cfg, debugMode)
 	if err != nil {
 		return fmt.Errorf("creating provider: %w", err)
@@ -3126,13 +3188,23 @@ func runWikiHeadless(cfg *config.Config, cwd, outDir, format string, concurrency
 		ProgressFunc: func(stage string, current, total int) {
 			if total > 0 {
 				fmt.Fprintf(os.Stderr, "[%s] %d/%d\n", stage, current, total)
-				if caps.ProgressBar {
-					percent := current * 100 / total
+				percent := current * 100 / total
+				if cmuxClient != nil {
+					cmuxClient.Call("set-progress", map[string]any{
+						"value": float64(percent) / 100.0,
+						"label": stage,
+					})
+				} else if caps.ProgressBar {
 					terminal.SetProgress(os.Stderr, terminal.ProgressNormal, percent)
 				}
 			} else {
 				fmt.Fprintf(os.Stderr, "[%s]\n", stage)
-				if caps.ProgressBar {
+				if cmuxClient != nil {
+					cmuxClient.Call("set-progress", map[string]any{
+						"value": 0.0,
+						"label": stage,
+					})
+				} else if caps.ProgressBar {
 					terminal.SetProgress(os.Stderr, terminal.ProgressIndeterminate, 0)
 				}
 			}
@@ -3141,18 +3213,30 @@ func runWikiHeadless(cfg *config.Config, cwd, outDir, format string, concurrency
 
 	result, err := wiki.Run(context.Background(), wikiCfg, llm, par)
 
-	if caps.ProgressBar {
+	if cmuxClient != nil {
+		cmuxClient.Call("clear-progress", nil)
+	} else if caps.ProgressBar {
 		terminal.ClearProgress(os.Stderr)
 	}
 
 	if err != nil {
-		if caps.Notifications {
+		if cmuxClient != nil {
+			cmuxClient.Call("notification.create", map[string]string{
+				"title": "Rubichan", "body": "Wiki generation failed",
+			})
+		} else if caps.Notifications {
 			terminal.Notify(os.Stderr, "Wiki generation failed")
 		}
 		return err
 	}
 
-	if caps.Notifications {
+	if cmuxClient != nil {
+		cmuxClient.Call("notification.create", map[string]string{
+			"title":    "Rubichan",
+			"subtitle": "Wiki Generation",
+			"body":     fmt.Sprintf("Wiki complete — %d documents rendered", result.Documents),
+		})
+	} else if caps.Notifications {
 		terminal.Notify(os.Stderr, fmt.Sprintf("Wiki complete — %d documents rendered", result.Documents))
 	}
 

--- a/docs/superpowers/plans/2026-04-10-cmux-integration.md
+++ b/docs/superpowers/plans/2026-04-10-cmux-integration.md
@@ -1,0 +1,3062 @@
+# cmux Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Integrate Rubichan with cmux's Unix socket JSON-RPC API for rich sidebar feedback, native notifications, browser automation tools, and active multi-agent orchestration.
+
+**Architecture:** A thin JSON-RPC socket client (`internal/cmux/client.go`) with feature modules for sidebar, notifications, workspace, surface, browser, and orchestration. Detection extends the existing `terminal.Caps` struct. Agent tools are conditionally registered when running inside cmux.
+
+**Tech Stack:** Go `net` (Unix sockets), `encoding/json`, existing `internal/tools` registry, `internal/terminal` caps detection.
+
+---
+
+## File Structure
+
+```
+internal/cmux/
+  client.go          — JSON-RPC socket client (Dial, Call, Close, Identity)
+  client_test.go     — tests with fake Unix socket server
+  workspace.go       — workspace CRUD methods
+  workspace_test.go
+  surface.go         — split, send_text, send_key, list, focus
+  surface_test.go
+  sidebar.go         — set-status, set-progress, log, sidebar-state
+  sidebar_test.go
+  notification.go    — notification.create/list/clear
+  notification_test.go
+  browser.go         — navigate, snapshot, click, type, wait
+  browser_test.go
+  orchestrator.go    — dispatch sub-agents, poll logs, collect results
+  orchestrator_test.go
+  cmuxtest/
+    mock.go          — MockClient for consumer tests
+
+internal/terminal/
+  caps.go            — add CmuxSocket bool (modify existing)
+  caps_test.go       — add cmux detection tests (modify existing)
+
+internal/tools/
+  cmux_browser.go    — 5 browser tools
+  cmux_browser_test.go
+  cmux_surface.go    — split + send tools
+  cmux_surface_test.go
+  cmux_orchestrate.go — orchestrate tool
+  cmux_orchestrate_test.go
+
+cmd/rubichan/
+  main.go            — wire cmux client into all 3 modes (modify existing)
+
+internal/tui/
+  model.go           — add SetCmuxClient, cmux dispatch (modify existing)
+  update.go          — cmux notification dispatch (modify existing)
+```
+
+---
+
+### Task 1: JSON-RPC Socket Client
+
+**Files:**
+- Create: `internal/cmux/client.go`
+- Create: `internal/cmux/client_test.go`
+
+- [ ] **Step 1: Write the failing test for Dial + system.ping**
+
+```go
+// internal/cmux/client_test.go
+package cmux
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeServer accepts one connection and handles JSON-RPC requests.
+func fakeServer(t *testing.T, ln net.Listener, handlers map[string]any) {
+	t.Helper()
+	conn, err := ln.Accept()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	dec := json.NewDecoder(conn)
+	enc := json.NewEncoder(conn)
+
+	for {
+		var req struct {
+			ID     string          `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := dec.Decode(&req); err != nil {
+			return
+		}
+		result, ok := handlers[req.Method]
+		if !ok {
+			enc.Encode(map[string]any{"id": req.ID, "ok": false, "error": fmt.Sprintf("unknown method: %s", req.Method)})
+			continue
+		}
+		enc.Encode(map[string]any{"id": req.ID, "ok": true, "result": result})
+	}
+}
+
+func newTestServer(t *testing.T, handlers map[string]any) string {
+	t.Helper()
+	sock := filepath.Join(t.TempDir(), "test.sock")
+	ln, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+	go fakeServer(t, ln, handlers)
+	return sock
+}
+
+func TestDial_Ping(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping": map[string]bool{"pong": true},
+		"system.identify": map[string]string{
+			"window_id":    "win-1",
+			"workspace_id": "ws-1",
+			"pane_id":      "pane-1",
+			"surface_id":   "surf-1",
+		},
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	assert.Equal(t, "win-1", c.Identity().WindowID)
+	assert.Equal(t, "ws-1", c.Identity().WorkspaceID)
+	assert.Equal(t, "surf-1", c.Identity().SurfaceID)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cmux/ -run TestDial_Ping -v`
+Expected: FAIL — package does not exist
+
+- [ ] **Step 3: Implement Client**
+
+```go
+// internal/cmux/client.go
+package cmux
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Response is a JSON-RPC response from cmux.
+type Response struct {
+	ID     string          `json:"id"`
+	OK     bool            `json:"ok"`
+	Result json.RawMessage `json:"result"`
+	Error  string          `json:"error,omitempty"`
+}
+
+// Identity contains the cmux context identifiers cached at Dial time.
+type Identity struct {
+	WindowID    string `json:"window_id"`
+	WorkspaceID string `json:"workspace_id"`
+	PaneID      string `json:"pane_id"`
+	SurfaceID   string `json:"surface_id"`
+}
+
+// Client communicates with cmux over a Unix domain socket.
+type Client struct {
+	conn    net.Conn
+	enc     *json.Encoder
+	dec     *json.Decoder
+	mu      sync.Mutex
+	nextID  atomic.Int64
+	timeout time.Duration
+	ident   *Identity
+}
+
+// SocketPath returns the cmux socket path from the environment or default.
+func SocketPath() string {
+	if p := os.Getenv("CMUX_SOCKET_PATH"); p != "" {
+		return p
+	}
+	return "/tmp/cmux.sock"
+}
+
+// Dial connects to the cmux socket and caches the identity.
+func Dial(socketPath string) (*Client, error) {
+	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("cmux dial: %w", err)
+	}
+	c := &Client{
+		conn:    conn,
+		enc:     json.NewEncoder(conn),
+		dec:     json.NewDecoder(conn),
+		timeout: 5 * time.Second,
+	}
+
+	// Verify connectivity.
+	if _, err := c.Call("system.ping", nil); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("cmux ping: %w", err)
+	}
+
+	// Cache identity.
+	resp, err := c.Call("system.identify", nil)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("cmux identify: %w", err)
+	}
+	var ident Identity
+	if err := json.Unmarshal(resp.Result, &ident); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("cmux parse identity: %w", err)
+	}
+	c.ident = &ident
+
+	return c, nil
+}
+
+// Call sends a JSON-RPC request and reads the response.
+func (c *Client) Call(method string, params any) (*Response, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.conn.SetDeadline(time.Now().Add(c.timeout)); err != nil {
+		return nil, fmt.Errorf("cmux set deadline: %w", err)
+	}
+
+	id := fmt.Sprintf("req-%d", c.nextID.Add(1))
+	req := struct {
+		ID     string `json:"id"`
+		Method string `json:"method"`
+		Params any    `json:"params"`
+	}{ID: id, Method: method, Params: params}
+
+	if params == nil {
+		req.Params = struct{}{}
+	}
+
+	if err := c.enc.Encode(req); err != nil {
+		return nil, fmt.Errorf("cmux send %s: %w", method, err)
+	}
+
+	var resp Response
+	if err := c.dec.Decode(&resp); err != nil {
+		return nil, fmt.Errorf("cmux recv %s: %w", method, err)
+	}
+
+	if !resp.OK {
+		return &resp, fmt.Errorf("cmux %s: %s", method, resp.Error)
+	}
+
+	return &resp, nil
+}
+
+// Identity returns the cached cmux context identifiers.
+func (c *Client) Identity() *Identity {
+	return c.ident
+}
+
+// Close closes the socket connection.
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/cmux/ -run TestDial_Ping -v`
+Expected: PASS
+
+- [ ] **Step 5: Write test for Call error handling**
+
+```go
+// internal/cmux/client_test.go — append
+
+func TestCall_ErrorResponse(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":     map[string]bool{"pong": true},
+		"system.identify": map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = c.Call("nonexistent.method", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown method")
+}
+
+func TestSocketPath_Default(t *testing.T) {
+	t.Setenv("CMUX_SOCKET_PATH", "")
+	assert.Equal(t, "/tmp/cmux.sock", SocketPath())
+}
+
+func TestSocketPath_Override(t *testing.T) {
+	t.Setenv("CMUX_SOCKET_PATH", "/custom/path.sock")
+	assert.Equal(t, "/custom/path.sock", SocketPath())
+}
+
+func TestDial_BadSocket(t *testing.T) {
+	_, err := Dial("/nonexistent/path.sock")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cmux dial")
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./internal/cmux/ -v`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/cmux/client.go internal/cmux/client_test.go
+git commit -m "[BEHAVIORAL] Add cmux JSON-RPC socket client
+
+Dial connects to cmux Unix socket, verifies with system.ping,
+caches identity via system.identify. Thread-safe Call with timeout.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: MockClient for Consumer Tests
+
+**Files:**
+- Create: `internal/cmux/cmuxtest/mock.go`
+- Create: `internal/cmux/cmuxtest/mock_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/cmux/cmuxtest/mock_test.go
+package cmuxtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockClient_RecordsCalls(t *testing.T) {
+	m := NewMockClient()
+	m.SetResult("system.ping", map[string]bool{"pong": true})
+
+	resp, err := m.Call("system.ping", nil)
+	require.NoError(t, err)
+	assert.True(t, resp.OK)
+	assert.Len(t, m.Calls(), 1)
+	assert.Equal(t, "system.ping", m.Calls()[0].Method)
+}
+
+func TestMockClient_UnknownMethodErrors(t *testing.T) {
+	m := NewMockClient()
+	_, err := m.Call("unknown.method", nil)
+	require.Error(t, err)
+}
+
+func TestMockClient_Identity(t *testing.T) {
+	m := NewMockClient()
+	assert.Equal(t, "mock-surface", m.Identity().SurfaceID)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cmux/cmuxtest/ -v`
+Expected: FAIL — package does not exist
+
+- [ ] **Step 3: Implement MockClient**
+
+The mock needs to satisfy the same API that consumer code uses. Define a `Caller` interface in the cmux package that both `Client` and `MockClient` satisfy:
+
+```go
+// internal/cmux/caller.go
+package cmux
+
+// Caller is the interface for making cmux JSON-RPC calls.
+// Both Client and cmuxtest.MockClient implement this.
+type Caller interface {
+	Call(method string, params any) (*Response, error)
+	Identity() *Identity
+}
+```
+
+```go
+// internal/cmux/cmuxtest/mock.go
+package cmuxtest
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+)
+
+// Call records a single JSON-RPC call made to the mock.
+type Call struct {
+	Method string
+	Params any
+}
+
+// MockClient is a test double for cmux.Client that records calls
+// and returns canned responses.
+type MockClient struct {
+	mu        sync.Mutex
+	calls     []Call
+	results   map[string]any
+	identity  *cmux.Identity
+}
+
+// NewMockClient creates a MockClient with a default identity.
+func NewMockClient() *MockClient {
+	return &MockClient{
+		results: make(map[string]any),
+		identity: &cmux.Identity{
+			WindowID:    "mock-window",
+			WorkspaceID: "mock-workspace",
+			PaneID:      "mock-pane",
+			SurfaceID:   "mock-surface",
+		},
+	}
+}
+
+// SetResult sets the canned result for a method.
+func (m *MockClient) SetResult(method string, result any) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.results[method] = result
+}
+
+// Call records the call and returns the canned result.
+func (m *MockClient) Call(method string, params any) (*cmux.Response, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, Call{Method: method, Params: params})
+
+	result, ok := m.results[method]
+	if !ok {
+		return nil, fmt.Errorf("mock: no result for %s", method)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("mock: marshal result for %s: %w", method, err)
+	}
+
+	return &cmux.Response{
+		ID:     fmt.Sprintf("mock-%d", len(m.calls)),
+		OK:     true,
+		Result: data,
+	}, nil
+}
+
+// Identity returns the mock identity.
+func (m *MockClient) Identity() *cmux.Identity {
+	return m.identity
+}
+
+// Calls returns all recorded calls.
+func (m *MockClient) Calls() []Call {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]Call, len(m.calls))
+	copy(cp, m.calls)
+	return cp
+}
+
+// Reset clears recorded calls and results.
+func (m *MockClient) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = nil
+	m.results = make(map[string]any)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cmux/... -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cmux/caller.go internal/cmux/cmuxtest/mock.go internal/cmux/cmuxtest/mock_test.go
+git commit -m "[BEHAVIORAL] Add cmux Caller interface and MockClient for testing
+
+Caller interface abstracts Client for testability. MockClient records
+calls and returns canned responses.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Sidebar Metadata
+
+**Files:**
+- Create: `internal/cmux/sidebar.go`
+- Create: `internal/cmux/sidebar_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/cmux/sidebar_test.go
+package cmux
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetStatus(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":     map[string]bool{"pong": true},
+		"system.identify": map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"set-status":      true,
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.SetStatus("phase", "analyzing", "magnifyingglass", "#007aff")
+	assert.NoError(t, err)
+}
+
+func TestSetProgress(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":     map[string]bool{"pong": true},
+		"system.identify": map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"set-progress":    true,
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.SetProgress(0.5, "Building...")
+	assert.NoError(t, err)
+}
+
+func TestClearProgress(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":      map[string]bool{"pong": true},
+		"system.identify":  map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"clear-progress":   true,
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.ClearProgress()
+	assert.NoError(t, err)
+}
+
+func TestLog(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":     map[string]bool{"pong": true},
+		"system.identify": map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"log":             true,
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.Log("Running tests...", "progress", "tools")
+	assert.NoError(t, err)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cmux/ -run TestSet -v`
+Expected: FAIL — methods not defined
+
+- [ ] **Step 3: Implement sidebar methods**
+
+```go
+// internal/cmux/sidebar.go
+package cmux
+
+// SetStatus sets a labeled status in the cmux sidebar tab.
+// icon is an SF Symbol name (e.g., "hammer", "checkmark.circle").
+// color is a hex string (e.g., "#ff9500").
+func (c *Client) SetStatus(key, value, icon, color string) error {
+	_, err := c.Call("set-status", map[string]string{
+		"key":   key,
+		"value": value,
+		"icon":  icon,
+		"color": color,
+	})
+	return err
+}
+
+// ClearStatus removes a status entry by key.
+func (c *Client) ClearStatus(key string) error {
+	_, err := c.Call("clear-status", map[string]string{"key": key})
+	return err
+}
+
+// SetProgress sets the sidebar progress bar.
+// fraction is 0.0–1.0. label describes the current operation.
+func (c *Client) SetProgress(fraction float64, label string) error {
+	_, err := c.Call("set-progress", map[string]any{
+		"value": fraction,
+		"label": label,
+	})
+	return err
+}
+
+// ClearProgress removes the sidebar progress bar.
+func (c *Client) ClearProgress() error {
+	_, err := c.Call("clear-progress", nil)
+	return err
+}
+
+// Log appends a log entry to the sidebar.
+// level: "info", "progress", "success", "warning", "error".
+func (c *Client) Log(message, level, source string) error {
+	_, err := c.Call("log", map[string]string{
+		"message": message,
+		"level":   level,
+		"source":  source,
+	})
+	return err
+}
+
+// ClearLog clears all sidebar log entries.
+func (c *Client) ClearLog() error {
+	_, err := c.Call("clear-log", nil)
+	return err
+}
+
+// SidebarState returns the current sidebar metadata for the workspace.
+func (c *Client) SidebarState() (*SidebarState, error) {
+	resp, err := c.Call("sidebar-state", nil)
+	if err != nil {
+		return nil, err
+	}
+	var state SidebarState
+	if err := unmarshalResult(resp, &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+// SidebarState represents the sidebar metadata dump.
+type SidebarState struct {
+	CWD       string     `json:"cwd"`
+	GitBranch string     `json:"git_branch"`
+	Ports     []int      `json:"ports"`
+	Status    []Status   `json:"status"`
+	Progress  *Progress  `json:"progress"`
+	Logs      []LogEntry `json:"logs"`
+}
+
+// Status is a sidebar status entry.
+type Status struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Icon  string `json:"icon"`
+	Color string `json:"color"`
+}
+
+// Progress is the sidebar progress bar state.
+type Progress struct {
+	Value float64 `json:"value"`
+	Label string  `json:"label"`
+}
+
+// LogEntry is a sidebar log item.
+type LogEntry struct {
+	Message string `json:"message"`
+	Level   string `json:"level"`
+	Source  string `json:"source"`
+}
+```
+
+Also add a helper to `client.go`:
+
+```go
+// unmarshalResult unmarshals a Response's Result into dst.
+func unmarshalResult(resp *Response, dst any) error {
+	return json.Unmarshal(resp.Result, dst)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cmux/ -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cmux/sidebar.go internal/cmux/sidebar_test.go internal/cmux/client.go
+git commit -m "[BEHAVIORAL] Add cmux sidebar metadata methods
+
+SetStatus, SetProgress, Log with levels, ClearProgress, ClearLog,
+and SidebarState for reading current sidebar metadata.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Notifications
+
+**Files:**
+- Create: `internal/cmux/notification.go`
+- Create: `internal/cmux/notification_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/cmux/notification_test.go
+package cmux
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotify(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":         map[string]bool{"pong": true},
+		"system.identify":     map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"notification.create": map[string]string{"id": "notif-1"},
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.Notify("Rubichan", "Code Review", "3 findings")
+	assert.NoError(t, err)
+}
+
+func TestClearNotifications(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":         map[string]bool{"pong": true},
+		"system.identify":     map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"notification.clear":  true,
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.ClearNotifications()
+	assert.NoError(t, err)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cmux/ -run TestNotify -v`
+Expected: FAIL — methods not defined
+
+- [ ] **Step 3: Implement notification methods**
+
+```go
+// internal/cmux/notification.go
+package cmux
+
+// Notification represents a cmux notification.
+type Notification struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	Subtitle string `json:"subtitle"`
+	Body     string `json:"body"`
+}
+
+// Notify sends a native macOS notification via cmux.
+func (c *Client) Notify(title, subtitle, body string) error {
+	_, err := c.Call("notification.create", map[string]string{
+		"title":    title,
+		"subtitle": subtitle,
+		"body":     body,
+	})
+	return err
+}
+
+// ListNotifications returns all active notifications.
+func (c *Client) ListNotifications() ([]Notification, error) {
+	resp, err := c.Call("notification.list", nil)
+	if err != nil {
+		return nil, err
+	}
+	var notifs []Notification
+	if err := unmarshalResult(resp, &notifs); err != nil {
+		return nil, err
+	}
+	return notifs, nil
+}
+
+// ClearNotifications clears all notifications.
+func (c *Client) ClearNotifications() error {
+	_, err := c.Call("notification.clear", nil)
+	return err
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cmux/ -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cmux/notification.go internal/cmux/notification_test.go
+git commit -m "[BEHAVIORAL] Add cmux notification methods
+
+Notify sends native macOS notifications with title/subtitle/body.
+ListNotifications and ClearNotifications for notification management.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Workspace Management
+
+**Files:**
+- Create: `internal/cmux/workspace.go`
+- Create: `internal/cmux/workspace_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/cmux/workspace_test.go
+package cmux
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListWorkspaces(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":    map[string]bool{"pong": true},
+		"system.identify": map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"workspace.list": map[string]any{
+			"workspaces": []map[string]string{
+				{"id": "ws-1", "name": "project-a"},
+				{"id": "ws-2", "name": "project-b"},
+			},
+		},
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	workspaces, err := c.ListWorkspaces()
+	require.NoError(t, err)
+	assert.Len(t, workspaces, 2)
+	assert.Equal(t, "ws-1", workspaces[0].ID)
+	assert.Equal(t, "project-a", workspaces[0].Name)
+}
+
+func TestCreateWorkspace(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":      map[string]bool{"pong": true},
+		"system.identify":  map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"workspace.create": map[string]string{"id": "ws-new", "name": ""},
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	ws, err := c.CreateWorkspace()
+	require.NoError(t, err)
+	assert.Equal(t, "ws-new", ws.ID)
+}
+
+func TestSelectWorkspace(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":      map[string]bool{"pong": true},
+		"system.identify":  map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"workspace.select": true,
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.SelectWorkspace("ws-1")
+	assert.NoError(t, err)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cmux/ -run TestListWorkspaces -v`
+Expected: FAIL — methods not defined
+
+- [ ] **Step 3: Implement workspace methods**
+
+```go
+// internal/cmux/workspace.go
+package cmux
+
+// Workspace represents a cmux workspace (vertical tab).
+type Workspace struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// ListWorkspaces returns all open workspaces.
+func (c *Client) ListWorkspaces() ([]Workspace, error) {
+	resp, err := c.Call("workspace.list", nil)
+	if err != nil {
+		return nil, err
+	}
+	var result struct {
+		Workspaces []Workspace `json:"workspaces"`
+	}
+	if err := unmarshalResult(resp, &result); err != nil {
+		return nil, err
+	}
+	return result.Workspaces, nil
+}
+
+// CreateWorkspace creates a new workspace.
+func (c *Client) CreateWorkspace() (*Workspace, error) {
+	resp, err := c.Call("workspace.create", nil)
+	if err != nil {
+		return nil, err
+	}
+	var ws Workspace
+	if err := unmarshalResult(resp, &ws); err != nil {
+		return nil, err
+	}
+	return &ws, nil
+}
+
+// SelectWorkspace switches to a specific workspace.
+func (c *Client) SelectWorkspace(id string) error {
+	_, err := c.Call("workspace.select", map[string]string{"workspace_id": id})
+	return err
+}
+
+// CurrentWorkspace returns the active workspace.
+func (c *Client) CurrentWorkspace() (*Workspace, error) {
+	resp, err := c.Call("workspace.current", nil)
+	if err != nil {
+		return nil, err
+	}
+	var ws Workspace
+	if err := unmarshalResult(resp, &ws); err != nil {
+		return nil, err
+	}
+	return &ws, nil
+}
+
+// CloseWorkspace closes a workspace by ID.
+func (c *Client) CloseWorkspace(id string) error {
+	_, err := c.Call("workspace.close", map[string]string{"workspace_id": id})
+	return err
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cmux/ -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cmux/workspace.go internal/cmux/workspace_test.go
+git commit -m "[BEHAVIORAL] Add cmux workspace management methods
+
+ListWorkspaces, CreateWorkspace, SelectWorkspace, CurrentWorkspace,
+CloseWorkspace for managing cmux vertical tabs.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Surface Management
+
+**Files:**
+- Create: `internal/cmux/surface.go`
+- Create: `internal/cmux/surface_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/cmux/surface_test.go
+package cmux
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplit(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":    map[string]bool{"pong": true},
+		"system.identify": map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"surface.split":  map[string]string{"id": "surf-new", "type": "terminal"},
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	surf, err := c.Split("right")
+	require.NoError(t, err)
+	assert.Equal(t, "surf-new", surf.ID)
+	assert.Equal(t, "terminal", surf.Type)
+}
+
+func TestSendText(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":       map[string]bool{"pong": true},
+		"system.identify":   map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"surface.send_text": true,
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.SendText("surf-1", "echo hello")
+	assert.NoError(t, err)
+}
+
+func TestSendKey(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":      map[string]bool{"pong": true},
+		"system.identify":  map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"surface.send_key": true,
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.SendKey("surf-1", "enter")
+	assert.NoError(t, err)
+}
+
+func TestListSurfaces(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":    map[string]bool{"pong": true},
+		"system.identify": map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"surface.list": map[string]any{
+			"surfaces": []map[string]string{
+				{"id": "surf-1", "type": "terminal"},
+				{"id": "surf-2", "type": "browser"},
+			},
+		},
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	surfaces, err := c.ListSurfaces()
+	require.NoError(t, err)
+	assert.Len(t, surfaces, 2)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cmux/ -run TestSplit -v`
+Expected: FAIL — methods not defined
+
+- [ ] **Step 3: Implement surface methods**
+
+```go
+// internal/cmux/surface.go
+package cmux
+
+// Surface represents a cmux surface (terminal or browser pane).
+type Surface struct {
+	ID   string `json:"id"`
+	Type string `json:"type"` // "terminal" or "browser"
+}
+
+// Split creates a new split pane in the given direction.
+// direction: "left", "right", "up", "down".
+func (c *Client) Split(direction string) (*Surface, error) {
+	resp, err := c.Call("surface.split", map[string]string{"direction": direction})
+	if err != nil {
+		return nil, err
+	}
+	var surf Surface
+	if err := unmarshalResult(resp, &surf); err != nil {
+		return nil, err
+	}
+	return &surf, nil
+}
+
+// ListSurfaces returns all surfaces in the current workspace.
+func (c *Client) ListSurfaces() ([]Surface, error) {
+	resp, err := c.Call("surface.list", nil)
+	if err != nil {
+		return nil, err
+	}
+	var result struct {
+		Surfaces []Surface `json:"surfaces"`
+	}
+	if err := unmarshalResult(resp, &result); err != nil {
+		return nil, err
+	}
+	return result.Surfaces, nil
+}
+
+// FocusSurface switches focus to a specific surface.
+func (c *Client) FocusSurface(id string) error {
+	_, err := c.Call("surface.focus", map[string]string{"surface_id": id})
+	return err
+}
+
+// SendText types text into the target surface.
+func (c *Client) SendText(surfaceID, text string) error {
+	_, err := c.Call("surface.send_text", map[string]string{
+		"surface_id": surfaceID,
+		"text":       text,
+	})
+	return err
+}
+
+// SendKey sends a key press to the target surface.
+// key: "enter", "tab", "escape", "backspace", "delete", "up", "down", "left", "right".
+func (c *Client) SendKey(surfaceID, key string) error {
+	_, err := c.Call("surface.send_key", map[string]string{
+		"surface_id": surfaceID,
+		"key":        key,
+	})
+	return err
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cmux/ -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cmux/surface.go internal/cmux/surface_test.go
+git commit -m "[BEHAVIORAL] Add cmux surface management methods
+
+Split, ListSurfaces, FocusSurface, SendText, SendKey for managing
+cmux split panes and sending input to terminal surfaces.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Browser Automation
+
+**Files:**
+- Create: `internal/cmux/browser.go`
+- Create: `internal/cmux/browser_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/cmux/browser_test.go
+package cmux
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrowserNavigate(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":       map[string]bool{"pong": true},
+		"system.identify":   map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"browser.navigate":  true,
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.BrowserNavigate("surf-1", "https://example.com")
+	assert.NoError(t, err)
+}
+
+func TestBrowserSnapshot(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":       map[string]bool{"pong": true},
+		"system.identify":   map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"browser.snapshot":  map[string]string{"dom": "<html>e10: button 'Submit'</html>"},
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	dom, err := c.BrowserSnapshot("surf-1")
+	require.NoError(t, err)
+	assert.Contains(t, dom, "e10")
+}
+
+func TestBrowserClick(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":     map[string]bool{"pong": true},
+		"system.identify": map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"browser.click":   true,
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.BrowserClick("surf-1", "e10")
+	assert.NoError(t, err)
+}
+
+func TestBrowserType(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":     map[string]bool{"pong": true},
+		"system.identify": map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"browser.type":    true,
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.BrowserType("surf-1", "e14", "hello world")
+	assert.NoError(t, err)
+}
+
+func TestBrowserWait(t *testing.T) {
+	sock := newTestServer(t, map[string]any{
+		"system.ping":     map[string]bool{"pong": true},
+		"system.identify": map[string]string{"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s"},
+		"browser.wait":    true,
+	})
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.BrowserWait("surf-1", "complete")
+	assert.NoError(t, err)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cmux/ -run TestBrowser -v`
+Expected: FAIL — methods not defined
+
+- [ ] **Step 3: Implement browser methods**
+
+```go
+// internal/cmux/browser.go
+package cmux
+
+// BrowserNavigate opens a URL in a browser surface.
+func (c *Client) BrowserNavigate(surfaceID, url string) error {
+	_, err := c.Call("browser.navigate", map[string]string{
+		"surface_id": surfaceID,
+		"url":        url,
+	})
+	return err
+}
+
+// BrowserSnapshot returns a text-based DOM representation with element references.
+func (c *Client) BrowserSnapshot(surfaceID string) (string, error) {
+	resp, err := c.Call("browser.snapshot", map[string]string{
+		"surface_id": surfaceID,
+	})
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		DOM string `json:"dom"`
+	}
+	if err := unmarshalResult(resp, &result); err != nil {
+		return "", err
+	}
+	return result.DOM, nil
+}
+
+// BrowserClick clicks an element by its snapshot reference.
+func (c *Client) BrowserClick(surfaceID, ref string) error {
+	_, err := c.Call("browser.click", map[string]string{
+		"surface_id": surfaceID,
+		"ref":        ref,
+	})
+	return err
+}
+
+// BrowserType types text into an element by its snapshot reference.
+func (c *Client) BrowserType(surfaceID, ref, text string) error {
+	_, err := c.Call("browser.type", map[string]string{
+		"surface_id": surfaceID,
+		"ref":        ref,
+		"text":       text,
+	})
+	return err
+}
+
+// BrowserWait waits for a page load state.
+// loadState: "complete" or "domcontentloaded".
+func (c *Client) BrowserWait(surfaceID, loadState string) error {
+	_, err := c.Call("browser.wait", map[string]string{
+		"surface_id": surfaceID,
+		"load_state": loadState,
+	})
+	return err
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cmux/ -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cmux/browser.go internal/cmux/browser_test.go
+git commit -m "[BEHAVIORAL] Add cmux browser automation methods
+
+BrowserNavigate, BrowserSnapshot, BrowserClick, BrowserType,
+BrowserWait for interacting with cmux browser surfaces.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Orchestrator
+
+**Files:**
+- Create: `internal/cmux/orchestrator.go`
+- Create: `internal/cmux/orchestrator_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/cmux/orchestrator_test.go
+package cmux
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeOrchestratorServer handles split + send_text + sidebar-state with evolving state.
+func fakeOrchestratorServer(t *testing.T, ln net.Listener, logSequence [][]LogEntry) {
+	t.Helper()
+	conn, err := ln.Accept()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	dec := json.NewDecoder(conn)
+	enc := json.NewEncoder(conn)
+	pollCount := 0
+	splitCount := 0
+
+	for {
+		var req struct {
+			ID     string          `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := dec.Decode(&req); err != nil {
+			return
+		}
+
+		switch req.Method {
+		case "system.ping":
+			enc.Encode(map[string]any{"id": req.ID, "ok": true, "result": map[string]bool{"pong": true}})
+		case "system.identify":
+			enc.Encode(map[string]any{"id": req.ID, "ok": true, "result": map[string]string{
+				"window_id": "w", "workspace_id": "w", "pane_id": "p", "surface_id": "s",
+			}})
+		case "surface.split":
+			splitCount++
+			enc.Encode(map[string]any{"id": req.ID, "ok": true, "result": map[string]string{
+				"id": fmt.Sprintf("surf-%d", splitCount), "type": "terminal",
+			}})
+		case "surface.send_text":
+			enc.Encode(map[string]any{"id": req.ID, "ok": true, "result": true})
+		case "sidebar-state":
+			idx := pollCount
+			if idx >= len(logSequence) {
+				idx = len(logSequence) - 1
+			}
+			pollCount++
+			enc.Encode(map[string]any{"id": req.ID, "ok": true, "result": map[string]any{
+				"logs": logSequence[idx],
+			}})
+		default:
+			enc.Encode(map[string]any{"id": req.ID, "ok": true, "result": true})
+		}
+	}
+}
+
+func TestOrchestrator_DispatchAndWait(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "test.sock")
+	ln, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	// Poll 1: no completion. Poll 2: task 1 done. Poll 3: task 2 error.
+	go fakeOrchestratorServer(t, ln, [][]LogEntry{
+		{},
+		{{Message: "[DONE] scan complete", Level: "success", Source: "surf-1"}},
+		{
+			{Message: "[DONE] scan complete", Level: "success", Source: "surf-1"},
+			{Message: "[ERROR] review failed", Level: "error", Source: "surf-2"},
+		},
+	})
+
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	orch := NewOrchestrator(c)
+	orch.SetPollRate(50 * time.Millisecond) // fast polling for tests
+
+	task1, err := orch.Dispatch("right", "run security scan")
+	require.NoError(t, err)
+	assert.Equal(t, "surf-1", task1.SurfaceID)
+	assert.Equal(t, "running", task1.Status)
+
+	task2, err := orch.Dispatch("down", "run code review")
+	require.NoError(t, err)
+	assert.Equal(t, "surf-2", task2.SurfaceID)
+
+	results, err := orch.Wait(5 * time.Second)
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	// Find results by surface ID.
+	var r1, r2 *Task
+	for i := range results {
+		switch results[i].SurfaceID {
+		case "surf-1":
+			r1 = &results[i]
+		case "surf-2":
+			r2 = &results[i]
+		}
+	}
+	require.NotNil(t, r1)
+	require.NotNil(t, r2)
+	assert.Equal(t, "done", r1.Status)
+	assert.Equal(t, "error", r2.Status)
+}
+
+func TestOrchestrator_Timeout(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "test.sock")
+	ln, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	// Never complete — always return empty logs.
+	go fakeOrchestratorServer(t, ln, [][]LogEntry{{}})
+
+	c, err := Dial(sock)
+	require.NoError(t, err)
+	defer c.Close()
+
+	orch := NewOrchestrator(c)
+	orch.SetPollRate(50 * time.Millisecond)
+
+	_, err = orch.Dispatch("right", "hang forever")
+	require.NoError(t, err)
+
+	_, err = orch.Wait(200 * time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cmux/ -run TestOrchestrator -v`
+Expected: FAIL — types/methods not defined
+
+- [ ] **Step 3: Implement orchestrator**
+
+```go
+// internal/cmux/orchestrator.go
+package cmux
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Task represents a dispatched sub-agent task.
+type Task struct {
+	ID        string
+	SurfaceID string
+	Command   string
+	Status    string // "running", "done", "error"
+	Logs      []LogEntry
+}
+
+// Orchestrator coordinates sub-agents across split panes.
+type Orchestrator struct {
+	client   *Client
+	tasks    map[string]*Task // task ID (surface ID) → task
+	pollRate time.Duration
+}
+
+// NewOrchestrator creates an Orchestrator with a default 2-second poll rate.
+func NewOrchestrator(client *Client) *Orchestrator {
+	return &Orchestrator{
+		client:   client,
+		tasks:    make(map[string]*Task),
+		pollRate: 2 * time.Second,
+	}
+}
+
+// SetPollRate configures the polling interval for log checks.
+func (o *Orchestrator) SetPollRate(d time.Duration) {
+	o.pollRate = d
+}
+
+// Dispatch creates a split pane, sends a command, and tracks it as a task.
+func (o *Orchestrator) Dispatch(direction, command string) (*Task, error) {
+	surf, err := o.client.Split(direction)
+	if err != nil {
+		return nil, fmt.Errorf("orchestrator split: %w", err)
+	}
+
+	if err := o.client.SendText(surf.ID, command); err != nil {
+		return nil, fmt.Errorf("orchestrator send: %w", err)
+	}
+	if err := o.client.SendKey(surf.ID, "enter"); err != nil {
+		return nil, fmt.Errorf("orchestrator send enter: %w", err)
+	}
+
+	task := &Task{
+		ID:        surf.ID,
+		SurfaceID: surf.ID,
+		Command:   command,
+		Status:    "running",
+	}
+	o.tasks[surf.ID] = task
+	return task, nil
+}
+
+// Wait blocks until all tasks reach "done" or "error", or timeout.
+func (o *Orchestrator) Wait(timeout time.Duration) ([]Task, error) {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		if err := o.pollLogs(); err != nil {
+			return nil, err
+		}
+
+		allDone := true
+		for _, task := range o.tasks {
+			if task.Status == "running" {
+				allDone = false
+				break
+			}
+		}
+		if allDone {
+			return o.results(), nil
+		}
+
+		time.Sleep(o.pollRate)
+	}
+
+	return nil, fmt.Errorf("orchestrator: timeout waiting for %d tasks", o.runningCount())
+}
+
+// WaitAny blocks until at least one task completes, or timeout.
+func (o *Orchestrator) WaitAny(timeout time.Duration) (*Task, error) {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		if err := o.pollLogs(); err != nil {
+			return nil, err
+		}
+
+		for _, task := range o.tasks {
+			if task.Status != "running" {
+				return task, nil
+			}
+		}
+
+		time.Sleep(o.pollRate)
+	}
+
+	return nil, fmt.Errorf("orchestrator: timeout waiting for any task")
+}
+
+// pollLogs fetches sidebar-state and updates task statuses from log entries.
+func (o *Orchestrator) pollLogs() error {
+	state, err := o.client.SidebarState()
+	if err != nil {
+		return fmt.Errorf("orchestrator poll: %w", err)
+	}
+
+	for _, entry := range state.Logs {
+		task, ok := o.tasks[entry.Source]
+		if !ok || task.Status != "running" {
+			continue
+		}
+
+		task.Logs = append(task.Logs, entry)
+
+		if strings.HasPrefix(entry.Message, "[DONE]") {
+			task.Status = "done"
+		} else if strings.HasPrefix(entry.Message, "[ERROR]") {
+			task.Status = "error"
+		}
+	}
+
+	return nil
+}
+
+func (o *Orchestrator) results() []Task {
+	tasks := make([]Task, 0, len(o.tasks))
+	for _, t := range o.tasks {
+		tasks = append(tasks, *t)
+	}
+	return tasks
+}
+
+func (o *Orchestrator) runningCount() int {
+	count := 0
+	for _, t := range o.tasks {
+		if t.Status == "running" {
+			count++
+		}
+	}
+	return count
+}
+```
+
+- [ ] **Step 4: Add missing imports to test file**
+
+The test file needs `encoding/json`, `fmt`, `net`, and `path/filepath` imports. Add them to the import block of `orchestrator_test.go`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/cmux/ -run TestOrchestrator -v -timeout 30s`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/cmux/orchestrator.go internal/cmux/orchestrator_test.go
+git commit -m "[BEHAVIORAL] Add cmux orchestrator for multi-pane coordination
+
+Dispatch splits panes and sends commands. Wait polls sidebar-state
+for [DONE]/[ERROR] log entries. Configurable poll rate for testing.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: CmuxSocket Detection in Caps
+
+**Files:**
+- Modify: `internal/terminal/caps.go`
+- Modify: `internal/terminal/caps_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/terminal/caps_test.go — append
+
+func TestDetectWithEnv_CmuxSocket_Detected(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "ws-123")
+
+	// Create a fake cmux socket that responds to system.ping.
+	sock := filepath.Join(t.TempDir(), "cmux.sock")
+	ln, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		dec := json.NewDecoder(conn)
+		enc := json.NewEncoder(conn)
+		for {
+			var req map[string]any
+			if err := dec.Decode(&req); err != nil {
+				return
+			}
+			enc.Encode(map[string]any{"id": req["id"], "ok": true, "result": map[string]bool{"pong": true}})
+		}
+	}()
+
+	t.Setenv("CMUX_SOCKET_PATH", sock)
+	caps := DetectWithEnv("ghostty", nil)
+	assert.True(t, caps.CmuxSocket)
+}
+
+func TestDetectWithEnv_CmuxSocket_NoEnvVar(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "")
+	caps := DetectWithEnv("ghostty", nil)
+	assert.False(t, caps.CmuxSocket)
+}
+
+func TestDetectWithEnv_CmuxSocket_BadSocket(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "ws-123")
+	t.Setenv("CMUX_SOCKET_PATH", "/nonexistent/cmux.sock")
+	caps := DetectWithEnv("ghostty", nil)
+	assert.False(t, caps.CmuxSocket)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/terminal/ -run TestDetectWithEnv_CmuxSocket -v`
+Expected: FAIL — `CmuxSocket` field does not exist
+
+- [ ] **Step 3: Add CmuxSocket to Caps and detection logic**
+
+In `internal/terminal/caps.go`, add the field:
+
+```go
+type Caps struct {
+	Hyperlinks      bool // OSC 8
+	KittyGraphics   bool // Kitty graphics protocol
+	KittyKeyboard   bool // Kitty keyboard protocol
+	ProgressBar     bool // OSC 9;4 (ConEmu/Ghostty)
+	Notifications   bool // OSC 9
+	SyncRendering   bool // Mode 2026
+	LightDarkMode   bool // OSC 11 background color query
+	ClipboardAccess bool // OSC 52
+	FocusEvents     bool // Mode 1004
+	DarkBackground  bool // detected via OSC 11 query (defaults true)
+	CmuxSocket      bool // cmux Unix socket API available
+}
+```
+
+At the end of `DetectWithEnv`, before the final return, add cmux detection:
+
+```go
+func DetectWithEnv(termProgram string, prober Prober) *Caps {
+	// ... existing code ...
+
+	// Detect cmux socket availability.
+	caps.CmuxSocket = detectCmuxSocket()
+
+	return caps
+}
+
+// detectCmuxSocket checks if running inside cmux by verifying the
+// CMUX_WORKSPACE_ID env var is set and the socket responds to ping.
+func detectCmuxSocket() bool {
+	if os.Getenv("CMUX_WORKSPACE_ID") == "" {
+		return false
+	}
+	socketPath := os.Getenv("CMUX_SOCKET_PATH")
+	if socketPath == "" {
+		socketPath = "/tmp/cmux.sock"
+	}
+	return pingCmuxSocket(socketPath)
+}
+
+// pingCmuxSocket attempts a system.ping call to the cmux socket.
+// Returns false on any error (connection refused, timeout, etc.).
+func pingCmuxSocket(socketPath string) bool {
+	conn, err := net.DialTimeout("unix", socketPath, 500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+
+	conn.SetDeadline(time.Now().Add(500 * time.Millisecond))
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+
+	if err := enc.Encode(map[string]any{
+		"id": "detect-1", "method": "system.ping", "params": struct{}{},
+	}); err != nil {
+		return false
+	}
+
+	var resp struct {
+		OK bool `json:"ok"`
+	}
+	if err := dec.Decode(&resp); err != nil {
+		return false
+	}
+	return resp.OK
+}
+```
+
+Add imports: `"encoding/json"`, `"net"`, `"time"`.
+
+Note: The `detectCmuxSocket()` call needs to be placed at two points — once in the known-terminal early return path and once at the end of the function. Insert it just before each `return caps` statement.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/terminal/ -run TestDetectWithEnv_CmuxSocket -v`
+Expected: All PASS
+
+- [ ] **Step 5: Run full terminal test suite**
+
+Run: `go test ./internal/terminal/ -v`
+Expected: All PASS — no regressions
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/terminal/caps.go internal/terminal/caps_test.go
+git commit -m "[BEHAVIORAL] Add CmuxSocket detection to terminal Caps
+
+Checks CMUX_WORKSPACE_ID env var and pings the cmux socket to verify
+availability. 500ms timeout for startup detection.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Browser Tools
+
+**Files:**
+- Create: `internal/tools/cmux_browser.go`
+- Create: `internal/tools/cmux_browser_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/tools/cmux_browser_test.go
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+	"github.com/julianshen/rubichan/internal/cmux/cmuxtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmuxBrowserNavigateTool_Name(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	tool := NewCmuxBrowserNavigate(m)
+	assert.Equal(t, "cmux_browser_navigate", tool.Name())
+}
+
+func TestCmuxBrowserNavigateTool_Execute(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	m.SetResult("surface.split", map[string]string{"id": "surf-new", "type": "browser"})
+	m.SetResult("browser.navigate", true)
+	m.SetResult("browser.wait", true)
+
+	tool := NewCmuxBrowserNavigate(m)
+	input := json.RawMessage(`{"url":"https://example.com"}`)
+	result, err := tool.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content, "surf-new")
+}
+
+func TestCmuxBrowserNavigateTool_WithSurfaceID(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	m.SetResult("browser.navigate", true)
+	m.SetResult("browser.wait", true)
+
+	tool := NewCmuxBrowserNavigate(m)
+	input := json.RawMessage(`{"url":"https://example.com","surface_id":"existing-surf"}`)
+	result, err := tool.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	// Should NOT have called surface.split since surface_id was provided.
+	for _, call := range m.Calls() {
+		assert.NotEqual(t, "surface.split", call.Method)
+	}
+}
+
+func TestCmuxBrowserSnapshotTool_Execute(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	m.SetResult("browser.snapshot", map[string]string{"dom": "<html>e10: button</html>"})
+
+	tool := NewCmuxBrowserSnapshot(m)
+	input := json.RawMessage(`{"surface_id":"surf-1"}`)
+	result, err := tool.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.Contains(t, result.Content, "e10")
+}
+
+func TestCmuxBrowserClickTool_Execute(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	m.SetResult("browser.click", true)
+
+	tool := NewCmuxBrowserClick(m)
+	input := json.RawMessage(`{"surface_id":"surf-1","ref":"e10"}`)
+	result, err := tool.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestCmuxBrowserTypeTool_Execute(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	m.SetResult("browser.type", true)
+
+	tool := NewCmuxBrowserType(m)
+	input := json.RawMessage(`{"surface_id":"surf-1","ref":"e14","text":"hello"}`)
+	result, err := tool.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestCmuxBrowserWaitTool_Execute(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	m.SetResult("browser.wait", true)
+
+	tool := NewCmuxBrowserWait(m)
+	input := json.RawMessage(`{"surface_id":"surf-1","load_state":"complete"}`)
+	result, err := tool.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/tools/ -run TestCmuxBrowser -v`
+Expected: FAIL — types not defined
+
+- [ ] **Step 3: Implement browser tools**
+
+```go
+// internal/tools/cmux_browser.go
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+)
+
+// CmuxBrowserNavigateTool opens a URL in a cmux browser surface.
+type CmuxBrowserNavigateTool struct {
+	client cmux.Caller
+}
+
+func NewCmuxBrowserNavigate(client cmux.Caller) *CmuxBrowserNavigateTool {
+	return &CmuxBrowserNavigateTool{client: client}
+}
+
+func (t *CmuxBrowserNavigateTool) Name() string { return "cmux_browser_navigate" }
+
+func (t *CmuxBrowserNavigateTool) Description() string {
+	return "Open a URL in a cmux browser pane. If no surface_id is provided, " +
+		"a new right split is created automatically."
+}
+
+func (t *CmuxBrowserNavigateTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"url": {"type": "string", "description": "The URL to navigate to"},
+			"surface_id": {"type": "string", "description": "Browser surface ID (optional — creates new split if omitted)"}
+		},
+		"required": ["url"]
+	}`)
+}
+
+func (t *CmuxBrowserNavigateTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in struct {
+		URL       string `json:"url"`
+		SurfaceID string `json:"surface_id"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+	if in.URL == "" {
+		return ToolResult{Content: "url is required", IsError: true}, nil
+	}
+
+	surfaceID := in.SurfaceID
+	if surfaceID == "" {
+		resp, err := t.client.Call("surface.split", map[string]string{"direction": "right"})
+		if err != nil {
+			return ToolResult{Content: fmt.Sprintf("failed to create split: %s", err), IsError: true}, nil
+		}
+		var surf cmux.Surface
+		if err := json.Unmarshal(resp.Result, &surf); err != nil {
+			return ToolResult{Content: fmt.Sprintf("failed to parse surface: %s", err), IsError: true}, nil
+		}
+		surfaceID = surf.ID
+	}
+
+	if _, err := t.client.Call("browser.navigate", map[string]string{
+		"surface_id": surfaceID,
+		"url":        in.URL,
+	}); err != nil {
+		return ToolResult{Content: fmt.Sprintf("navigate failed: %s", err), IsError: true}, nil
+	}
+
+	if _, err := t.client.Call("browser.wait", map[string]string{
+		"surface_id": surfaceID,
+		"load_state": "complete",
+	}); err != nil {
+		return ToolResult{Content: fmt.Sprintf("wait failed: %s", err), IsError: true}, nil
+	}
+
+	return ToolResult{Content: fmt.Sprintf("Navigated to %s in surface %s", in.URL, surfaceID)}, nil
+}
+
+// CmuxBrowserSnapshotTool returns a DOM snapshot from a browser surface.
+type CmuxBrowserSnapshotTool struct {
+	client cmux.Caller
+}
+
+func NewCmuxBrowserSnapshot(client cmux.Caller) *CmuxBrowserSnapshotTool {
+	return &CmuxBrowserSnapshotTool{client: client}
+}
+
+func (t *CmuxBrowserSnapshotTool) Name() string { return "cmux_browser_snapshot" }
+
+func (t *CmuxBrowserSnapshotTool) Description() string {
+	return "Get a text-based DOM snapshot from a cmux browser surface. " +
+		"Returns element references (e.g., e10, e14) for use with click/type tools."
+}
+
+func (t *CmuxBrowserSnapshotTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"surface_id": {"type": "string", "description": "Browser surface ID"}
+		},
+		"required": ["surface_id"]
+	}`)
+}
+
+func (t *CmuxBrowserSnapshotTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in struct {
+		SurfaceID string `json:"surface_id"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+
+	resp, err := t.client.Call("browser.snapshot", map[string]string{"surface_id": in.SurfaceID})
+	if err != nil {
+		return ToolResult{Content: fmt.Sprintf("snapshot failed: %s", err), IsError: true}, nil
+	}
+	var result struct {
+		DOM string `json:"dom"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		return ToolResult{Content: fmt.Sprintf("parse failed: %s", err), IsError: true}, nil
+	}
+	return ToolResult{Content: result.DOM}, nil
+}
+
+// CmuxBrowserClickTool clicks an element in a browser surface.
+type CmuxBrowserClickTool struct {
+	client cmux.Caller
+}
+
+func NewCmuxBrowserClick(client cmux.Caller) *CmuxBrowserClickTool {
+	return &CmuxBrowserClickTool{client: client}
+}
+
+func (t *CmuxBrowserClickTool) Name() string { return "cmux_browser_click" }
+
+func (t *CmuxBrowserClickTool) Description() string {
+	return "Click an element in a cmux browser surface by its snapshot reference."
+}
+
+func (t *CmuxBrowserClickTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"surface_id": {"type": "string", "description": "Browser surface ID"},
+			"ref": {"type": "string", "description": "Element reference from snapshot (e.g., e10)"}
+		},
+		"required": ["surface_id", "ref"]
+	}`)
+}
+
+func (t *CmuxBrowserClickTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in struct {
+		SurfaceID string `json:"surface_id"`
+		Ref       string `json:"ref"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+
+	if _, err := t.client.Call("browser.click", map[string]string{
+		"surface_id": in.SurfaceID,
+		"ref":        in.Ref,
+	}); err != nil {
+		return ToolResult{Content: fmt.Sprintf("click failed: %s", err), IsError: true}, nil
+	}
+	return ToolResult{Content: fmt.Sprintf("Clicked %s in surface %s", in.Ref, in.SurfaceID)}, nil
+}
+
+// CmuxBrowserTypeTool types text into an element in a browser surface.
+type CmuxBrowserTypeTool struct {
+	client cmux.Caller
+}
+
+func NewCmuxBrowserType(client cmux.Caller) *CmuxBrowserTypeTool {
+	return &CmuxBrowserTypeTool{client: client}
+}
+
+func (t *CmuxBrowserTypeTool) Name() string { return "cmux_browser_type" }
+
+func (t *CmuxBrowserTypeTool) Description() string {
+	return "Type text into an element in a cmux browser surface by its snapshot reference."
+}
+
+func (t *CmuxBrowserTypeTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"surface_id": {"type": "string", "description": "Browser surface ID"},
+			"ref": {"type": "string", "description": "Element reference from snapshot (e.g., e14)"},
+			"text": {"type": "string", "description": "Text to type into the element"}
+		},
+		"required": ["surface_id", "ref", "text"]
+	}`)
+}
+
+func (t *CmuxBrowserTypeTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in struct {
+		SurfaceID string `json:"surface_id"`
+		Ref       string `json:"ref"`
+		Text      string `json:"text"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+
+	if _, err := t.client.Call("browser.type", map[string]string{
+		"surface_id": in.SurfaceID,
+		"ref":        in.Ref,
+		"text":       in.Text,
+	}); err != nil {
+		return ToolResult{Content: fmt.Sprintf("type failed: %s", err), IsError: true}, nil
+	}
+	return ToolResult{Content: fmt.Sprintf("Typed into %s in surface %s", in.Ref, in.SurfaceID)}, nil
+}
+
+// CmuxBrowserWaitTool waits for a page load state.
+type CmuxBrowserWaitTool struct {
+	client cmux.Caller
+}
+
+func NewCmuxBrowserWait(client cmux.Caller) *CmuxBrowserWaitTool {
+	return &CmuxBrowserWaitTool{client: client}
+}
+
+func (t *CmuxBrowserWaitTool) Name() string { return "cmux_browser_wait" }
+
+func (t *CmuxBrowserWaitTool) Description() string {
+	return "Wait for a page load state in a cmux browser surface."
+}
+
+func (t *CmuxBrowserWaitTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"surface_id": {"type": "string", "description": "Browser surface ID"},
+			"load_state": {"type": "string", "enum": ["complete", "domcontentloaded"], "description": "Page load state to wait for"}
+		},
+		"required": ["surface_id", "load_state"]
+	}`)
+}
+
+func (t *CmuxBrowserWaitTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in struct {
+		SurfaceID string `json:"surface_id"`
+		LoadState string `json:"load_state"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+
+	if _, err := t.client.Call("browser.wait", map[string]string{
+		"surface_id": in.SurfaceID,
+		"load_state": in.LoadState,
+	}); err != nil {
+		return ToolResult{Content: fmt.Sprintf("wait failed: %s", err), IsError: true}, nil
+	}
+	return ToolResult{Content: fmt.Sprintf("Page loaded (%s) in surface %s", in.LoadState, in.SurfaceID)}, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/tools/ -run TestCmuxBrowser -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tools/cmux_browser.go internal/tools/cmux_browser_test.go
+git commit -m "[BEHAVIORAL] Add cmux browser automation tools
+
+5 tools: navigate (auto-splits), snapshot, click, type, wait.
+All use cmux.Caller interface for testability.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Surface and Orchestrate Tools
+
+**Files:**
+- Create: `internal/tools/cmux_surface.go`
+- Create: `internal/tools/cmux_surface_test.go`
+- Create: `internal/tools/cmux_orchestrate.go`
+- Create: `internal/tools/cmux_orchestrate_test.go`
+
+- [ ] **Step 1: Write the failing tests for surface tools**
+
+```go
+// internal/tools/cmux_surface_test.go
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux/cmuxtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmuxSplitTool_Execute(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	m.SetResult("surface.split", map[string]string{"id": "surf-new", "type": "terminal"})
+
+	tool := NewCmuxSplit(m)
+	assert.Equal(t, "cmux_split", tool.Name())
+
+	input := json.RawMessage(`{"direction":"right"}`)
+	result, err := tool.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content, "surf-new")
+}
+
+func TestCmuxSendTool_Text(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	m.SetResult("surface.send_text", true)
+
+	tool := NewCmuxSend(m)
+	assert.Equal(t, "cmux_send", tool.Name())
+
+	input := json.RawMessage(`{"surface_id":"surf-1","text":"echo hello"}`)
+	result, err := tool.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestCmuxSendTool_Key(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	m.SetResult("surface.send_key", true)
+
+	tool := NewCmuxSend(m)
+	input := json.RawMessage(`{"surface_id":"surf-1","key":"enter"}`)
+	result, err := tool.Execute(context.Background(), input)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/tools/ -run TestCmuxS -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement surface tools**
+
+```go
+// internal/tools/cmux_surface.go
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+)
+
+// CmuxSplitTool creates a split pane in cmux.
+type CmuxSplitTool struct {
+	client cmux.Caller
+}
+
+func NewCmuxSplit(client cmux.Caller) *CmuxSplitTool {
+	return &CmuxSplitTool{client: client}
+}
+
+func (t *CmuxSplitTool) Name() string { return "cmux_split" }
+
+func (t *CmuxSplitTool) Description() string {
+	return "Create a split pane in cmux. Returns the new surface ID."
+}
+
+func (t *CmuxSplitTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"direction": {"type": "string", "enum": ["left", "right", "up", "down"], "description": "Split direction"}
+		},
+		"required": ["direction"]
+	}`)
+}
+
+func (t *CmuxSplitTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in struct {
+		Direction string `json:"direction"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+
+	resp, err := t.client.Call("surface.split", map[string]string{"direction": in.Direction})
+	if err != nil {
+		return ToolResult{Content: fmt.Sprintf("split failed: %s", err), IsError: true}, nil
+	}
+	var surf cmux.Surface
+	if err := json.Unmarshal(resp.Result, &surf); err != nil {
+		return ToolResult{Content: fmt.Sprintf("parse failed: %s", err), IsError: true}, nil
+	}
+	return ToolResult{Content: fmt.Sprintf("Created %s split — surface_id: %s", in.Direction, surf.ID)}, nil
+}
+
+// CmuxSendTool sends text or a key press to a cmux surface.
+type CmuxSendTool struct {
+	client cmux.Caller
+}
+
+func NewCmuxSend(client cmux.Caller) *CmuxSendTool {
+	return &CmuxSendTool{client: client}
+}
+
+func (t *CmuxSendTool) Name() string { return "cmux_send" }
+
+func (t *CmuxSendTool) Description() string {
+	return "Send text or a key press to a cmux surface. Provide either 'text' or 'key', not both."
+}
+
+func (t *CmuxSendTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"surface_id": {"type": "string", "description": "Target surface ID"},
+			"text": {"type": "string", "description": "Text to type (mutually exclusive with key)"},
+			"key": {"type": "string", "enum": ["enter", "tab", "escape", "backspace", "delete", "up", "down", "left", "right"], "description": "Key to press (mutually exclusive with text)"}
+		},
+		"required": ["surface_id"]
+	}`)
+}
+
+func (t *CmuxSendTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in struct {
+		SurfaceID string `json:"surface_id"`
+		Text      string `json:"text"`
+		Key       string `json:"key"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+
+	if in.Text != "" {
+		if _, err := t.client.Call("surface.send_text", map[string]string{
+			"surface_id": in.SurfaceID,
+			"text":       in.Text,
+		}); err != nil {
+			return ToolResult{Content: fmt.Sprintf("send_text failed: %s", err), IsError: true}, nil
+		}
+		return ToolResult{Content: fmt.Sprintf("Sent text to surface %s", in.SurfaceID)}, nil
+	}
+
+	if in.Key != "" {
+		if _, err := t.client.Call("surface.send_key", map[string]string{
+			"surface_id": in.SurfaceID,
+			"key":        in.Key,
+		}); err != nil {
+			return ToolResult{Content: fmt.Sprintf("send_key failed: %s", err), IsError: true}, nil
+		}
+		return ToolResult{Content: fmt.Sprintf("Sent key '%s' to surface %s", in.Key, in.SurfaceID)}, nil
+	}
+
+	return ToolResult{Content: "provide either 'text' or 'key'", IsError: true}, nil
+}
+```
+
+- [ ] **Step 4: Run surface tool tests**
+
+Run: `go test ./internal/tools/ -run TestCmuxS -v`
+Expected: All PASS
+
+- [ ] **Step 5: Write orchestrate tool tests**
+
+```go
+// internal/tools/cmux_orchestrate_test.go
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux/cmuxtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmuxOrchestrateTool_Name(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	tool := NewCmuxOrchestrate(m)
+	assert.Equal(t, "cmux_orchestrate", tool.Name())
+}
+```
+
+- [ ] **Step 6: Implement orchestrate tool**
+
+```go
+// internal/tools/cmux_orchestrate.go
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+)
+
+// CmuxOrchestrateTool runs commands in parallel cmux panes and collects results.
+type CmuxOrchestrateTool struct {
+	client cmux.Caller
+}
+
+func NewCmuxOrchestrate(client cmux.Caller) *CmuxOrchestrateTool {
+	return &CmuxOrchestrateTool{client: client}
+}
+
+func (t *CmuxOrchestrateTool) Name() string { return "cmux_orchestrate" }
+
+func (t *CmuxOrchestrateTool) Description() string {
+	return "Run commands in parallel cmux panes and collect results. " +
+		"Each task gets its own split pane. Results are collected via log-based signaling."
+}
+
+func (t *CmuxOrchestrateTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"tasks": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"direction": {"type": "string", "enum": ["left", "right", "up", "down"]},
+						"command": {"type": "string"}
+					},
+					"required": ["direction", "command"]
+				},
+				"description": "List of tasks to run in parallel panes"
+			},
+			"timeout": {"type": "string", "description": "Timeout duration (e.g., '5m', '30s'). Default: 5m"}
+		},
+		"required": ["tasks"]
+	}`)
+}
+
+func (t *CmuxOrchestrateTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in struct {
+		Tasks []struct {
+			Direction string `json:"direction"`
+			Command   string `json:"command"`
+		} `json:"tasks"`
+		Timeout string `json:"timeout"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+
+	if len(in.Tasks) == 0 {
+		return ToolResult{Content: "at least one task is required", IsError: true}, nil
+	}
+
+	timeout := 5 * time.Minute
+	if in.Timeout != "" {
+		d, err := time.ParseDuration(in.Timeout)
+		if err != nil {
+			return ToolResult{Content: fmt.Sprintf("invalid timeout: %s", err), IsError: true}, nil
+		}
+		timeout = d
+	}
+
+	// Build a real Client from the Caller — the orchestrator needs Client methods.
+	// If the caller is a MockClient (testing), we can't use the orchestrator directly.
+	// For now, dispatch tasks manually using the Caller interface.
+	var dispatched []struct {
+		surfaceID string
+		command   string
+	}
+
+	for _, task := range in.Tasks {
+		resp, err := t.client.Call("surface.split", map[string]string{"direction": task.Direction})
+		if err != nil {
+			return ToolResult{Content: fmt.Sprintf("split failed: %s", err), IsError: true}, nil
+		}
+		var surf cmux.Surface
+		if err := json.Unmarshal(resp.Result, &surf); err != nil {
+			return ToolResult{Content: fmt.Sprintf("parse surface failed: %s", err), IsError: true}, nil
+		}
+
+		if _, err := t.client.Call("surface.send_text", map[string]string{
+			"surface_id": surf.ID,
+			"text":       task.Command,
+		}); err != nil {
+			return ToolResult{Content: fmt.Sprintf("send failed: %s", err), IsError: true}, nil
+		}
+		if _, err := t.client.Call("surface.send_key", map[string]string{
+			"surface_id": surf.ID,
+			"key":        "enter",
+		}); err != nil {
+			return ToolResult{Content: fmt.Sprintf("send enter failed: %s", err), IsError: true}, nil
+		}
+
+		dispatched = append(dispatched, struct {
+			surfaceID string
+			command   string
+		}{surf.ID, task.Command})
+	}
+
+	// Poll for completion.
+	deadline := time.Now().Add(timeout)
+	completed := make(map[string]string) // surfaceID → status
+
+	for time.Now().Before(deadline) && len(completed) < len(dispatched) {
+		resp, err := t.client.Call("sidebar-state", nil)
+		if err != nil {
+			break
+		}
+		var state cmux.SidebarState
+		if err := json.Unmarshal(resp.Result, &state); err != nil {
+			break
+		}
+
+		for _, entry := range state.Logs {
+			if _, done := completed[entry.Source]; done {
+				continue
+			}
+			for _, d := range dispatched {
+				if d.surfaceID == entry.Source {
+					if strings.HasPrefix(entry.Message, "[DONE]") {
+						completed[entry.Source] = "done"
+					} else if strings.HasPrefix(entry.Message, "[ERROR]") {
+						completed[entry.Source] = "error"
+					}
+				}
+			}
+		}
+
+		if len(completed) < len(dispatched) {
+			time.Sleep(2 * time.Second)
+		}
+	}
+
+	// Format results.
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Orchestrated %d tasks:\n", len(dispatched)))
+	for _, d := range dispatched {
+		status := completed[d.surfaceID]
+		if status == "" {
+			status = "timeout"
+		}
+		sb.WriteString(fmt.Sprintf("  [%s] surface=%s cmd=%q\n", status, d.surfaceID, d.command))
+	}
+
+	hasError := false
+	for _, status := range completed {
+		if status == "error" {
+			hasError = true
+			break
+		}
+	}
+	if len(completed) < len(dispatched) {
+		hasError = true
+	}
+
+	return ToolResult{Content: sb.String(), IsError: hasError}, nil
+}
+```
+
+- [ ] **Step 7: Run all tool tests**
+
+Run: `go test ./internal/tools/ -run TestCmux -v`
+Expected: All PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/tools/cmux_surface.go internal/tools/cmux_surface_test.go internal/tools/cmux_orchestrate.go internal/tools/cmux_orchestrate_test.go
+git commit -m "[BEHAVIORAL] Add cmux surface and orchestrate tools
+
+cmux_split, cmux_send for pane management. cmux_orchestrate dispatches
+parallel commands and polls sidebar-state for log-based completion.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Wire cmux into TUI Model
+
+**Files:**
+- Modify: `internal/tui/model.go:142-417`
+- Modify: `internal/tui/update.go:162-181`
+- Modify: `internal/tui/bootstrapprogress.go:46-82`
+
+- [ ] **Step 1: Add cmuxClient field and SetCmuxClient to Model**
+
+In `internal/tui/model.go`, add import for `"github.com/julianshen/rubichan/internal/cmux"` and add the field after `termCaps`:
+
+```go
+type Model struct {
+	// ... existing fields ...
+	termCaps          *terminal.Caps
+	cmuxClient        cmux.Caller    // nil when not running in cmux
+	// ... rest of fields ...
+}
+```
+
+Add setter:
+
+```go
+// SetCmuxClient sets the cmux client for rich sidebar/notification dispatch.
+// Pass nil when not running inside cmux.
+func (m *Model) SetCmuxClient(client cmux.Caller) {
+	m.cmuxClient = client
+}
+```
+
+- [ ] **Step 2: Update notifyIfSupported to prefer cmux**
+
+Replace the existing `notifyIfSupported` method:
+
+```go
+func (m *Model) notifyIfSupported(message string) {
+	if m.cmuxClient != nil {
+		m.cmuxClient.Call("notification.create", map[string]string{
+			"title": "Rubichan",
+			"body":  message,
+		})
+		return
+	}
+	if m.termCaps != nil && m.termCaps.Notifications {
+		terminal.Notify(os.Stderr, message)
+	}
+}
+```
+
+- [ ] **Step 3: Update BootstrapProgressOverlay to use cmux**
+
+In `internal/tui/bootstrapprogress.go`, add `cmuxClient cmux.Caller` field to `BootstrapProgressOverlay`:
+
+```go
+type BootstrapProgressOverlay struct {
+	messages   []string
+	phase      string
+	done       bool
+	error      string
+	width      int
+	height     int
+	caps       *terminal.Caps
+	cmuxClient cmux.Caller
+}
+```
+
+Update `NewBootstrapProgressOverlay` to accept it:
+
+```go
+func NewBootstrapProgressOverlay(width, height int, caps *terminal.Caps, cmuxClient cmux.Caller) *BootstrapProgressOverlay {
+	return &BootstrapProgressOverlay{
+		messages:   []string{"🚀 Knowledge Graph Bootstrap Started"},
+		width:      width,
+		height:     height,
+		caps:       caps,
+		cmuxClient: cmuxClient,
+	}
+}
+```
+
+In the `Update` method, replace progress bar dispatch:
+
+```go
+// Replace:
+if b.caps != nil && b.caps.ProgressBar {
+	terminal.SetProgress(os.Stderr, terminal.ProgressNormal, percent)
+}
+
+// With:
+if b.cmuxClient != nil {
+	b.cmuxClient.Call("set-progress", map[string]any{
+		"value": float64(percent) / 100.0,
+		"label": msg.Message,
+	})
+} else if b.caps != nil && b.caps.ProgressBar {
+	terminal.SetProgress(os.Stderr, terminal.ProgressNormal, percent)
+}
+```
+
+Apply the same pattern for `ClearProgress` calls (error and complete branches).
+
+- [ ] **Step 4: Find and update all callers of NewBootstrapProgressOverlay**
+
+Search for `NewBootstrapProgressOverlay` calls and add the `cmuxClient` parameter. There should be one or two call sites in the TUI code.
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./internal/tui/ -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/tui/model.go internal/tui/update.go internal/tui/bootstrapprogress.go
+git commit -m "[BEHAVIORAL] Wire cmux client into TUI model
+
+SetCmuxClient setter. notifyIfSupported prefers cmux notifications.
+Bootstrap progress uses cmux sidebar when available.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Wire cmux into Mode Entrypoints
+
+**Files:**
+- Modify: `cmd/rubichan/main.go:1371-1372` (runInteractive)
+- Modify: `cmd/rubichan/main.go:1900` (runHeadless)
+- Modify: `cmd/rubichan/main.go:3110-3157` (runWikiHeadless)
+
+- [ ] **Step 1: Wire cmux into runInteractive**
+
+After `caps := terminal.Detect()` (line 1372) and before model creation (line 1681), add:
+
+```go
+var cmuxClient cmux.Caller
+if caps.CmuxSocket {
+	if cc, err := cmux.Dial(cmux.SocketPath()); err == nil {
+		cmuxClient = cc
+		defer cc.Close()
+	}
+}
+```
+
+After `model.SetTermCaps(caps)` (line 1682), add:
+
+```go
+model.SetCmuxClient(cmuxClient)
+```
+
+After tool registration, conditionally register cmux tools:
+
+```go
+if cmuxClient != nil {
+	for _, t := range []Tool{
+		NewCmuxBrowserNavigate(cmuxClient),
+		NewCmuxBrowserSnapshot(cmuxClient),
+		NewCmuxBrowserClick(cmuxClient),
+		NewCmuxBrowserType(cmuxClient),
+		NewCmuxBrowserWait(cmuxClient),
+		NewCmuxSplit(cmuxClient),
+		NewCmuxSend(cmuxClient),
+		NewCmuxOrchestrate(cmuxClient),
+	} {
+		if err := registry.Register(t); err != nil {
+			log.Printf("warning: registering cmux tool %q: %v", t.Name(), err)
+		}
+	}
+}
+```
+
+Add import: `"github.com/julianshen/rubichan/internal/cmux"`.
+
+- [ ] **Step 2: Wire cmux into runHeadless**
+
+After `caps := terminal.Detect()` (line 1900), add:
+
+```go
+var cmuxClient cmux.Caller
+if caps.CmuxSocket {
+	if cc, err := cmux.Dial(cmux.SocketPath()); err == nil {
+		cmuxClient = cc
+		defer cc.Close()
+	}
+}
+```
+
+Replace the notification block at line 2278:
+
+```go
+// Before:
+if caps.Notifications {
+	terminal.Notify(os.Stderr, "Code review complete")
+	// ...
+}
+
+// After:
+if cmuxClient != nil {
+	cmuxClient.Call("notification.create", map[string]string{
+		"title": "Rubichan",
+		"subtitle": "Code Review",
+		"body": "Code review complete",
+	})
+} else if caps.Notifications {
+	terminal.Notify(os.Stderr, "Code review complete")
+	// ...
+}
+```
+
+- [ ] **Step 3: Wire cmux into runWikiHeadless**
+
+After `caps := terminal.Detect()` (line 3111), add:
+
+```go
+var cmuxClient cmux.Caller
+if caps.CmuxSocket {
+	if cc, err := cmux.Dial(cmux.SocketPath()); err == nil {
+		cmuxClient = cc
+		defer cc.Close()
+	}
+}
+```
+
+In the ProgressFunc closure, replace progress dispatch:
+
+```go
+ProgressFunc: func(stage string, current, total int) {
+	if total > 0 {
+		fmt.Fprintf(os.Stderr, "[%s] %d/%d\n", stage, current, total)
+		percent := current * 100 / total
+		if cmuxClient != nil {
+			cmuxClient.Call("set-progress", map[string]any{
+				"value": float64(percent) / 100.0,
+				"label": stage,
+			})
+		} else if caps.ProgressBar {
+			terminal.SetProgress(os.Stderr, terminal.ProgressNormal, percent)
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "[%s]\n", stage)
+		if cmuxClient != nil {
+			cmuxClient.Call("set-progress", map[string]any{
+				"value": 0.0,
+				"label": stage,
+			})
+		} else if caps.ProgressBar {
+			terminal.SetProgress(os.Stderr, terminal.ProgressIndeterminate, 0)
+		}
+	}
+},
+```
+
+Replace the ClearProgress and notification blocks:
+
+```go
+if cmuxClient != nil {
+	cmuxClient.Call("clear-progress", nil)
+} else if caps.ProgressBar {
+	terminal.ClearProgress(os.Stderr)
+}
+
+if err != nil {
+	if cmuxClient != nil {
+		cmuxClient.Call("notification.create", map[string]string{
+			"title": "Rubichan", "body": "Wiki generation failed",
+		})
+	} else if caps.Notifications {
+		terminal.Notify(os.Stderr, "Wiki generation failed")
+	}
+	return err
+}
+
+if cmuxClient != nil {
+	cmuxClient.Call("notification.create", map[string]string{
+		"title": "Rubichan",
+		"subtitle": "Wiki Generation",
+		"body": fmt.Sprintf("Wiki complete — %d documents rendered", result.Documents),
+	})
+} else if caps.Notifications {
+	terminal.Notify(os.Stderr, fmt.Sprintf("Wiki complete — %d documents rendered", result.Documents))
+}
+```
+
+- [ ] **Step 4: Build to verify compilation**
+
+Run: `go build ./cmd/rubichan/`
+Expected: SUCCESS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `go test ./... 2>&1 | tail -30`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/rubichan/main.go
+git commit -m "[BEHAVIORAL] Wire cmux client into all three mode entrypoints
+
+Interactive: register cmux tools, set client on TUI model.
+Headless: cmux notifications for code review completion.
+Wiki: cmux sidebar progress and completion notifications.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 14: Integration Tests (opt-in)
+
+**Files:**
+- Create: `internal/cmux/integration_test.go`
+
+- [ ] **Step 1: Write opt-in integration tests**
+
+```go
+//go:build cmux_integration
+
+// internal/cmux/integration_test.go
+package cmux
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_Ping(t *testing.T) {
+	if os.Getenv("CMUX_WORKSPACE_ID") == "" {
+		t.Skip("not running inside cmux")
+	}
+	c, err := Dial(SocketPath())
+	require.NoError(t, err)
+	defer c.Close()
+
+	assert.NotEmpty(t, c.Identity().WorkspaceID)
+	assert.NotEmpty(t, c.Identity().SurfaceID)
+}
+
+func TestIntegration_Sidebar(t *testing.T) {
+	if os.Getenv("CMUX_WORKSPACE_ID") == "" {
+		t.Skip("not running inside cmux")
+	}
+	c, err := Dial(SocketPath())
+	require.NoError(t, err)
+	defer c.Close()
+
+	require.NoError(t, c.SetStatus("test", "integration", "checkmark.circle", "#00ff00"))
+	require.NoError(t, c.SetProgress(0.5, "Testing..."))
+	require.NoError(t, c.Log("Integration test running", "info", "test"))
+
+	state, err := c.SidebarState()
+	require.NoError(t, err)
+	assert.NotNil(t, state)
+
+	require.NoError(t, c.ClearStatus("test"))
+	require.NoError(t, c.ClearProgress())
+	require.NoError(t, c.ClearLog())
+}
+
+func TestIntegration_Notify(t *testing.T) {
+	if os.Getenv("CMUX_WORKSPACE_ID") == "" {
+		t.Skip("not running inside cmux")
+	}
+	c, err := Dial(SocketPath())
+	require.NoError(t, err)
+	defer c.Close()
+
+	require.NoError(t, c.Notify("Rubichan Test", "Integration", "This is a test notification"))
+	require.NoError(t, c.ClearNotifications())
+}
+
+func TestIntegration_ListWorkspaces(t *testing.T) {
+	if os.Getenv("CMUX_WORKSPACE_ID") == "" {
+		t.Skip("not running inside cmux")
+	}
+	c, err := Dial(SocketPath())
+	require.NoError(t, err)
+	defer c.Close()
+
+	workspaces, err := c.ListWorkspaces()
+	require.NoError(t, err)
+	assert.NotEmpty(t, workspaces)
+}
+```
+
+- [ ] **Step 2: Verify tests skip outside cmux**
+
+Run: `go test ./internal/cmux/ -run TestIntegration -v -tags cmux_integration`
+Expected: All SKIP (unless running inside cmux)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/cmux/integration_test.go
+git commit -m "[BEHAVIORAL] Add opt-in cmux integration tests
+
+Gated behind cmux_integration build tag. Tests skip when
+CMUX_WORKSPACE_ID is not set.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---

--- a/docs/superpowers/specs/2026-04-10-cmux-integration-design.md
+++ b/docs/superpowers/specs/2026-04-10-cmux-integration-design.md
@@ -222,7 +222,7 @@ Registered conditionally — only when `CmuxSocket` is true.
 |------|-----------|-------|
 | `cmux_orchestrate` | `tasks` (array of `{direction, command}`), `timeout` | Run commands in parallel, collect results |
 
-All cmux tools require `cmux:control` permission — user must approve.
+Cmux tools are gated by the standard `ToolsConfig.ShouldEnable` mechanism (same as all other tools). No separate `cmux:control` permission is needed — tool-level approval through the existing approval flow is sufficient.
 
 ## Mode Integration
 

--- a/docs/superpowers/specs/2026-04-10-cmux-integration-design.md
+++ b/docs/superpowers/specs/2026-04-10-cmux-integration-design.md
@@ -230,10 +230,9 @@ All cmux tools require `cmux:control` permission — user must approve.
 
 ```go
 caps := terminal.Detect()
-var cmuxClient *cmux.Client
-if caps.CmuxSocket {
-    cmuxClient, _ = cmux.Dial(cmux.SocketPath())
-    defer cmuxClient.Close()
+cmuxClient, closeCmux := dialCmux(caps) // returns (Caller, func())
+defer closeCmux()
+if cmuxClient != nil {
     registry.Register(tools.NewCmuxBrowserNavigate(cmuxClient))
     // ... register all cmux tools
 }

--- a/docs/superpowers/specs/2026-04-10-cmux-integration-design.md
+++ b/docs/superpowers/specs/2026-04-10-cmux-integration-design.md
@@ -1,0 +1,336 @@
+# cmux Integration Design
+
+**Date**: 2026-04-10
+**Status**: DRAFT
+
+## Goal
+
+Integrate Rubichan with cmux's Unix socket API to provide rich sidebar feedback, native notifications, browser automation tools, and active multi-agent orchestration when running inside cmux terminals.
+
+## Background
+
+cmux is a native macOS terminal built on Ghostty's `libghostty` rendering engine, designed for orchestrating AI coding agents. It exposes a JSON-RPC API over Unix sockets (`/tmp/cmux.sock`) with commands for workspace management, split panes, sidebar metadata, notifications, and browser automation.
+
+Rubichan already detects Ghostty via `TERM_PROGRAM` and supports OSC 9/9;4 escape sequences. cmux adds a richer control plane on top — this integration upgrades Rubichan's feedback and automation capabilities when cmux is the host terminal.
+
+## Architecture
+
+```
+internal/cmux/              — JSON-RPC socket client + feature modules
+  client.go                 — Dial, Call, Close, Identity
+  workspace.go              — workspace.list/create/select/close
+  surface.go                — surface.split/list/focus/send_text/send_key
+  sidebar.go                — set-status, set-progress, log, clear-*
+  notification.go           — notification.create/list/clear
+  browser.go                — browser navigate/click/type/snapshot/wait
+  orchestrator.go           — dispatch sub-agents, poll logs, collect results
+  cmuxtest/mock.go          — MockClient for unit tests
+
+internal/terminal/caps.go   — add CmuxSocket bool to Caps
+
+internal/tools/
+  cmux_browser.go           — 5 browser tools for the agent
+  cmux_surface.go           — split + send tools for the agent
+  cmux_orchestrate.go       — orchestrate tool for parallel pane execution
+```
+
+### Detection
+
+Add `CmuxSocket bool` to `terminal.Caps`. During `DetectWithEnv`, after the Ghostty fast path:
+
+1. Check `CMUX_WORKSPACE_ID` environment variable is set
+2. Verify socket at `CMUX_SOCKET_PATH` (or default `/tmp/cmux.sock`) responds to `system.ping`
+
+If both pass, `CmuxSocket = true`. One env check + one socket round-trip at startup.
+
+### Priority: cmux Replaces Escape Sequences
+
+When `CmuxSocket` is true, cmux's API replaces the equivalent escape sequences:
+
+| Feature | Without cmux | With cmux |
+|---------|-------------|-----------|
+| Progress | OSC 9;4 (titlebar) | `set-progress` (sidebar + label) |
+| Notifications | OSC 9 (simple text) | `notification.create` (title/subtitle/body + colored rings) |
+| Status | N/A | `set-status` (icon + color in sidebar tab) |
+| Logging | N/A | `log` (structured sidebar log entries) |
+
+No doubling — cmux is the preferred channel, OSC is the fallback.
+
+## Component Details
+
+### 1. JSON-RPC Socket Client (`internal/cmux/client.go`)
+
+Thin, stateless client over Unix domain sockets.
+
+```go
+type Client struct {
+    conn    net.Conn
+    mu      sync.Mutex
+    nextID  int64
+    timeout time.Duration  // default 5s
+    ident   *Identity      // cached from Dial
+}
+
+type Response struct {
+    ID     string          `json:"id"`
+    OK     bool            `json:"ok"`
+    Result json.RawMessage `json:"result"`
+    Error  string          `json:"error,omitempty"`
+}
+
+type Identity struct {
+    WindowID    string `json:"window_id"`
+    WorkspaceID string `json:"workspace_id"`
+    PaneID      string `json:"pane_id"`
+    SurfaceID   string `json:"surface_id"`
+}
+
+func SocketPath() string          // CMUX_SOCKET_PATH or /tmp/cmux.sock
+func Dial(socketPath string) (*Client, error)  // connect + system.identify
+func (c *Client) Call(method string, params any) (*Response, error)
+func (c *Client) Close() error
+func (c *Client) Identity() *Identity
+```
+
+Request format: `{"id":"req-1","method":"workspace.list","params":{}}` (newline-terminated).
+Thread-safe via mutex on socket writes. Auto-increments request IDs.
+
+### 2. Sidebar Metadata (`internal/cmux/sidebar.go`)
+
+```go
+func (c *Client) SetStatus(key, value, icon, color string) error
+func (c *Client) ClearStatus(key string) error
+func (c *Client) SetProgress(fraction float64, label string) error
+func (c *Client) ClearProgress() error
+func (c *Client) Log(message, level, source string) error  // level: info|progress|success|warning|error
+func (c *Client) ClearLog() error
+func (c *Client) SidebarState() (*SidebarState, error)
+```
+
+### 3. Notifications (`internal/cmux/notification.go`)
+
+```go
+func (c *Client) Notify(title, subtitle, body string) error
+func (c *Client) ListNotifications() ([]Notification, error)
+func (c *Client) ClearNotifications() error
+```
+
+### 4. Workspace Management (`internal/cmux/workspace.go`)
+
+```go
+type Workspace struct {
+    ID   string `json:"id"`
+    Name string `json:"name"`
+}
+
+func (c *Client) ListWorkspaces() ([]Workspace, error)
+func (c *Client) CreateWorkspace() (*Workspace, error)
+func (c *Client) SelectWorkspace(id string) error
+func (c *Client) CurrentWorkspace() (*Workspace, error)
+func (c *Client) CloseWorkspace(id string) error
+```
+
+### 5. Surface Management (`internal/cmux/surface.go`)
+
+```go
+type Surface struct {
+    ID   string `json:"id"`
+    Type string `json:"type"`  // "terminal" or "browser"
+}
+
+func (c *Client) Split(direction string) (*Surface, error)  // left|right|up|down
+func (c *Client) ListSurfaces() ([]Surface, error)
+func (c *Client) FocusSurface(id string) error
+func (c *Client) SendText(surfaceID, text string) error
+func (c *Client) SendKey(surfaceID, key string) error  // enter|tab|escape|backspace|delete|up|down|left|right
+```
+
+### 6. Browser Automation (`internal/cmux/browser.go`)
+
+```go
+func (c *Client) BrowserNavigate(surfaceID, url string) error
+func (c *Client) BrowserSnapshot(surfaceID string) (string, error)
+func (c *Client) BrowserClick(surfaceID, ref string) error
+func (c *Client) BrowserType(surfaceID, ref, text string) error
+func (c *Client) BrowserWait(surfaceID, loadState string) error  // "complete"|"domcontentloaded"
+```
+
+### 7. Active Orchestrator (`internal/cmux/orchestrator.go`)
+
+Coordinates sub-agents across split panes using log-based signaling.
+
+```go
+type Task struct {
+    ID        string
+    SurfaceID string
+    Command   string
+    Status    string     // "running", "done", "error"
+    Logs      []LogEntry
+}
+
+type Orchestrator struct {
+    client   *Client
+    tasks    map[string]*Task
+    pollRate time.Duration  // default 2s
+}
+
+func NewOrchestrator(client *Client) *Orchestrator
+func (o *Orchestrator) Dispatch(direction, command string) (*Task, error)
+func (o *Orchestrator) Wait(timeout time.Duration) ([]Task, error)
+func (o *Orchestrator) WaitAny(timeout time.Duration) (*Task, error)
+```
+
+**Log convention** — sub-agents signal via cmux `log` entries:
+
+| Log Entry | Meaning |
+|-----------|---------|
+| `[DONE] <summary>` | Task completed successfully |
+| `[ERROR] <message>` | Task failed |
+| `[PROGRESS] <0-100> <message>` | Interim progress update |
+
+The orchestrator polls `sidebar-state` every 2 seconds, parses log entries by surface ID, and updates task statuses.
+
+**Limitations:**
+- Sub-agents must cooperate by writing structured log entries
+- No stdout capture — cmux API doesn't expose terminal output
+- Polling at 2s means up to 2s latency in detecting completion
+
+### 8. Agent Tools
+
+Registered conditionally — only when `CmuxSocket` is true.
+
+**Browser tools** (`internal/tools/cmux_browser.go`):
+
+| Tool | Parameters | Notes |
+|------|-----------|-------|
+| `cmux_browser_navigate` | `url` (required), `surface_id` (optional) | Auto-creates right split if no surface_id |
+| `cmux_browser_snapshot` | `surface_id` | Returns DOM with element refs |
+| `cmux_browser_click` | `surface_id`, `ref` | Click by element ref |
+| `cmux_browser_type` | `surface_id`, `ref`, `text` | Type into element |
+| `cmux_browser_wait` | `surface_id`, `load_state` | Wait for page load |
+
+**Surface tools** (`internal/tools/cmux_surface.go`):
+
+| Tool | Parameters | Notes |
+|------|-----------|-------|
+| `cmux_split` | `direction` | Returns new surface_id |
+| `cmux_send` | `surface_id`, `text` or `key` | Send text/keypress to pane |
+
+**Orchestration tool** (`internal/tools/cmux_orchestrate.go`):
+
+| Tool | Parameters | Notes |
+|------|-----------|-------|
+| `cmux_orchestrate` | `tasks` (array of `{direction, command}`), `timeout` | Run commands in parallel, collect results |
+
+All cmux tools require `cmux:control` permission — user must approve.
+
+## Mode Integration
+
+### Interactive Mode
+
+```go
+caps := terminal.Detect()
+var cmuxClient *cmux.Client
+if caps.CmuxSocket {
+    cmuxClient, _ = cmux.Dial(cmux.SocketPath())
+    defer cmuxClient.Close()
+    registry.Register(tools.NewCmuxBrowserNavigate(cmuxClient))
+    // ... register all cmux tools
+}
+model := tui.NewModel(...)
+model.SetTermCaps(caps)
+model.SetCmuxClient(cmuxClient)  // nil-safe
+```
+
+TUI dispatches via cmux when available:
+- Approval requests: `Notify("Rubichan", "", "Needs approval to proceed")`
+- Bootstrap progress: `SetProgress(fraction, phase)`
+- Phase changes: `SetStatus("phase", "analyzing", "magnifyingglass", "#007aff")`
+- Tool execution: `Log("Running file_write...", "progress", "tools")`
+
+### Headless Mode
+
+```go
+if caps.CmuxSocket {
+    cmuxClient, _ = cmux.Dial(cmux.SocketPath())
+    cmuxClient.SetStatus("mode", "code-review", "shield", "#ff3b30")
+    cmuxClient.SetProgress(0.3, "Static analysis...")
+    // on completion:
+    cmuxClient.Notify("Rubichan", "Code Review", "3 findings, 1 critical")
+    cmuxClient.ClearProgress()
+}
+```
+
+### Wiki Mode
+
+```go
+if caps.CmuxSocket {
+    cmuxClient, _ = cmux.Dial(cmux.SocketPath())
+    opts.ProgressFunc = func(phase string, pct int) {
+        cmuxClient.SetProgress(float64(pct)/100.0, phase)
+        cmuxClient.Log(phase, "progress", "wiki")
+    }
+    cmuxClient.Notify("Rubichan", "Wiki Generation", "12 pages generated")
+}
+```
+
+## Testing Strategy
+
+### Unit Tests — Mock Client
+
+```go
+// internal/cmux/cmuxtest/mock.go
+type MockClient struct {
+    Calls     []Call
+    Responses map[string]any
+}
+```
+
+All feature modules tested against the mock. No real socket needed.
+
+### Socket Client Tests — Test Unix Socket
+
+```go
+func TestClientCall(t *testing.T) {
+    sock := filepath.Join(t.TempDir(), "test.sock")
+    ln, _ := net.Listen("unix", sock)
+    go fakeServer(ln)
+    c, _ := cmux.Dial(sock)
+    defer c.Close()
+    resp, err := c.Call("system.ping", nil)
+    require.True(t, resp.OK)
+}
+```
+
+### Integration Tests — Real cmux (opt-in)
+
+Gated behind build tag or environment variable. Only runs inside cmux:
+
+```go
+//go:build cmux_integration
+
+func TestRealCmuxPing(t *testing.T) {
+    if os.Getenv("CMUX_SOCKET_PATH") == "" {
+        t.Skip("not running inside cmux")
+    }
+    // ...
+}
+```
+
+### Tool Tests
+
+Each tool tested with mock client. Verify correct method names, parameters, error handling, and nil-client safety.
+
+### Orchestrator Tests
+
+Mock returns evolving `sidebar-state` responses across poll cycles:
+1. First poll: no `[DONE]` logs
+2. Second poll: task 1 logs `[DONE]`
+3. Third poll: task 2 logs `[ERROR]`
+4. Verify `Wait()` returns correct task statuses
+
+## Sources
+
+- [cmux API Documentation](https://cmux.com/zh-TW/docs/api)
+- [cmux Review — Vibe Coding App](https://vibecoding.app/blog/cmux-review)
+- [cmux Terminal Guide — Better Stack](https://betterstack.com/community/guides/ai/cmux-terminal/)

--- a/internal/cmux/browser.go
+++ b/internal/cmux/browser.go
@@ -1,82 +1,40 @@
 package cmux
 
-import "fmt"
-
 // BrowserNavigate navigates the browser surface to the given URL.
 func (c *Client) BrowserNavigate(surfaceID, url string) error {
-	resp, err := c.Call("browser.navigate", map[string]string{
-		"surface_id": surfaceID,
-		"url":        url,
+	return c.callVoid("browser.navigate", map[string]string{
+		"surface_id": surfaceID, "url": url,
 	})
-	if err != nil {
-		return fmt.Errorf("cmux: browser.navigate: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: browser.navigate: %s", resp.Error)
-	}
-	return nil
 }
 
 // BrowserSnapshot returns the DOM snapshot of the browser surface.
 func (c *Client) BrowserSnapshot(surfaceID string) (string, error) {
-	resp, err := c.Call("browser.snapshot", map[string]string{"surface_id": surfaceID})
-	if err != nil {
-		return "", fmt.Errorf("cmux: browser.snapshot: %w", err)
-	}
-	if !resp.OK {
-		return "", fmt.Errorf("cmux: browser.snapshot: %s", resp.Error)
-	}
 	var result struct {
 		DOM string `json:"dom"`
 	}
-	if err := unmarshalResult(resp, &result); err != nil {
-		return "", fmt.Errorf("cmux: decode snapshot: %w", err)
+	if err := c.callResult("browser.snapshot", map[string]string{"surface_id": surfaceID}, &result); err != nil {
+		return "", err
 	}
 	return result.DOM, nil
 }
 
 // BrowserClick clicks the element identified by ref in the browser surface.
 func (c *Client) BrowserClick(surfaceID, ref string) error {
-	resp, err := c.Call("browser.click", map[string]string{
-		"surface_id": surfaceID,
-		"ref":        ref,
+	return c.callVoid("browser.click", map[string]string{
+		"surface_id": surfaceID, "ref": ref,
 	})
-	if err != nil {
-		return fmt.Errorf("cmux: browser.click: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: browser.click: %s", resp.Error)
-	}
-	return nil
 }
 
 // BrowserType types text into the element identified by ref in the browser surface.
 func (c *Client) BrowserType(surfaceID, ref, text string) error {
-	resp, err := c.Call("browser.type", map[string]string{
-		"surface_id": surfaceID,
-		"ref":        ref,
-		"text":       text,
+	return c.callVoid("browser.type", map[string]string{
+		"surface_id": surfaceID, "ref": ref, "text": text,
 	})
-	if err != nil {
-		return fmt.Errorf("cmux: browser.type: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: browser.type: %s", resp.Error)
-	}
-	return nil
 }
 
 // BrowserWait waits for the browser surface to reach the given load state.
 func (c *Client) BrowserWait(surfaceID, loadState string) error {
-	resp, err := c.Call("browser.wait", map[string]string{
-		"surface_id": surfaceID,
-		"load_state": loadState,
+	return c.callVoid("browser.wait", map[string]string{
+		"surface_id": surfaceID, "load_state": loadState,
 	})
-	if err != nil {
-		return fmt.Errorf("cmux: browser.wait: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: browser.wait: %s", resp.Error)
-	}
-	return nil
 }

--- a/internal/cmux/browser.go
+++ b/internal/cmux/browser.go
@@ -1,0 +1,82 @@
+package cmux
+
+import "fmt"
+
+// BrowserNavigate navigates the browser surface to the given URL.
+func (c *Client) BrowserNavigate(surfaceID, url string) error {
+	resp, err := c.Call("browser.navigate", map[string]string{
+		"surface_id": surfaceID,
+		"url":        url,
+	})
+	if err != nil {
+		return fmt.Errorf("cmux: browser.navigate: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: browser.navigate: %s", resp.Error)
+	}
+	return nil
+}
+
+// BrowserSnapshot returns the DOM snapshot of the browser surface.
+func (c *Client) BrowserSnapshot(surfaceID string) (string, error) {
+	resp, err := c.Call("browser.snapshot", map[string]string{"surface_id": surfaceID})
+	if err != nil {
+		return "", fmt.Errorf("cmux: browser.snapshot: %w", err)
+	}
+	if !resp.OK {
+		return "", fmt.Errorf("cmux: browser.snapshot: %s", resp.Error)
+	}
+	var result struct {
+		DOM string `json:"dom"`
+	}
+	if err := unmarshalResult(resp, &result); err != nil {
+		return "", fmt.Errorf("cmux: decode snapshot: %w", err)
+	}
+	return result.DOM, nil
+}
+
+// BrowserClick clicks the element identified by ref in the browser surface.
+func (c *Client) BrowserClick(surfaceID, ref string) error {
+	resp, err := c.Call("browser.click", map[string]string{
+		"surface_id": surfaceID,
+		"ref":        ref,
+	})
+	if err != nil {
+		return fmt.Errorf("cmux: browser.click: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: browser.click: %s", resp.Error)
+	}
+	return nil
+}
+
+// BrowserType types text into the element identified by ref in the browser surface.
+func (c *Client) BrowserType(surfaceID, ref, text string) error {
+	resp, err := c.Call("browser.type", map[string]string{
+		"surface_id": surfaceID,
+		"ref":        ref,
+		"text":       text,
+	})
+	if err != nil {
+		return fmt.Errorf("cmux: browser.type: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: browser.type: %s", resp.Error)
+	}
+	return nil
+}
+
+// BrowserWait waits for the browser surface to reach the given load state.
+func (c *Client) BrowserWait(surfaceID, loadState string) error {
+	resp, err := c.Call("browser.wait", map[string]string{
+		"surface_id": surfaceID,
+		"load_state": loadState,
+	})
+	if err != nil {
+		return fmt.Errorf("cmux: browser.wait: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: browser.wait: %s", resp.Error)
+	}
+	return nil
+}

--- a/internal/cmux/browser_test.go
+++ b/internal/cmux/browser_test.go
@@ -54,6 +54,17 @@ func TestBrowserSnapshot(t *testing.T) {
 	assert.Equal(t, "surf-1", capturedSurfaceID)
 }
 
+func TestBrowserSnapshotError(t *testing.T) {
+	socketPath := newErrorServer(t, "browser.snapshot")
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = c.BrowserSnapshot("surf-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "browser.snapshot")
+}
+
 func TestBrowserClick(t *testing.T) {
 	handlers := defaultHandlers()
 	var capturedSurfaceID, capturedRef string

--- a/internal/cmux/browser_test.go
+++ b/internal/cmux/browser_test.go
@@ -1,0 +1,130 @@
+package cmux_test
+
+import (
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrowserNavigate(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedSurfaceID, capturedURL string
+	handlers["browser.navigate"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			SurfaceID string `json:"surface_id"`
+			URL       string `json:"url"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedSurfaceID = p.SurfaceID
+		capturedURL = p.URL
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.BrowserNavigate("surf-1", "https://example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "surf-1", capturedSurfaceID)
+	assert.Equal(t, "https://example.com", capturedURL)
+}
+
+func TestBrowserSnapshot(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedSurfaceID string
+	handlers["browser.snapshot"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			SurfaceID string `json:"surface_id"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedSurfaceID = p.SurfaceID
+		return map[string]string{"dom": "<html><body>Hello</body></html>"}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	dom, err := c.BrowserSnapshot("surf-1")
+	require.NoError(t, err)
+	assert.Equal(t, "<html><body>Hello</body></html>", dom)
+	assert.Equal(t, "surf-1", capturedSurfaceID)
+}
+
+func TestBrowserClick(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedSurfaceID, capturedRef string
+	handlers["browser.click"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			SurfaceID string `json:"surface_id"`
+			Ref       string `json:"ref"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedSurfaceID = p.SurfaceID
+		capturedRef = p.Ref
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.BrowserClick("surf-1", "#submit-btn")
+	require.NoError(t, err)
+	assert.Equal(t, "surf-1", capturedSurfaceID)
+	assert.Equal(t, "#submit-btn", capturedRef)
+}
+
+func TestBrowserType(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedSurfaceID, capturedRef, capturedText string
+	handlers["browser.type"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			SurfaceID string `json:"surface_id"`
+			Ref       string `json:"ref"`
+			Text      string `json:"text"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedSurfaceID = p.SurfaceID
+		capturedRef = p.Ref
+		capturedText = p.Text
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.BrowserType("surf-1", "#search-input", "rubichan")
+	require.NoError(t, err)
+	assert.Equal(t, "surf-1", capturedSurfaceID)
+	assert.Equal(t, "#search-input", capturedRef)
+	assert.Equal(t, "rubichan", capturedText)
+}
+
+func TestBrowserWait(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedSurfaceID, capturedLoadState string
+	handlers["browser.wait"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			SurfaceID string `json:"surface_id"`
+			LoadState string `json:"load_state"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedSurfaceID = p.SurfaceID
+		capturedLoadState = p.LoadState
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.BrowserWait("surf-1", "networkidle")
+	require.NoError(t, err)
+	assert.Equal(t, "surf-1", capturedSurfaceID)
+	assert.Equal(t, "networkidle", capturedLoadState)
+}

--- a/internal/cmux/caller.go
+++ b/internal/cmux/caller.go
@@ -1,0 +1,8 @@
+package cmux
+
+// Caller is the interface for making cmux JSON-RPC calls.
+// Both Client and cmuxtest.MockClient implement this.
+type Caller interface {
+	Call(method string, params any) (*Response, error)
+	Identity() *Identity
+}

--- a/internal/cmux/caller.go
+++ b/internal/cmux/caller.go
@@ -1,5 +1,8 @@
 package cmux
 
+// Ensure Client satisfies Caller at compile time.
+var _ Caller = (*Client)(nil)
+
 // Caller is the interface for making cmux JSON-RPC calls.
 // Both Client and cmuxtest.MockClient implement this.
 type Caller interface {

--- a/internal/cmux/caller.go
+++ b/internal/cmux/caller.go
@@ -6,3 +6,21 @@ type Caller interface {
 	Call(method string, params any) (*Response, error)
 	Identity() *Identity
 }
+
+// CallerNotify sends a notification via any Caller. Errors are intentionally
+// suppressed — notifications are best-effort.
+func CallerNotify(c Caller, title, subtitle, body string) {
+	c.Call("notification.create", map[string]string{ //nolint:errcheck
+		"title": title, "subtitle": subtitle, "body": body,
+	})
+}
+
+// CallerSetProgress sets the sidebar progress via any Caller. Best-effort.
+func CallerSetProgress(c Caller, fraction float64, label string) {
+	c.Call("set-progress", map[string]any{"value": fraction, "label": label}) //nolint:errcheck
+}
+
+// CallerClearProgress clears the sidebar progress via any Caller. Best-effort.
+func CallerClearProgress(c Caller) {
+	c.Call("clear-progress", map[string]any{}) //nolint:errcheck
+}

--- a/internal/cmux/caller.go
+++ b/internal/cmux/caller.go
@@ -10,12 +10,14 @@ type Caller interface {
 	Identity() *Identity
 }
 
-// CallerNotify sends a notification via any Caller. Errors are intentionally
-// suppressed — notifications are best-effort.
-func CallerNotify(c Caller, title, subtitle, body string) {
-	c.Call("notification.create", map[string]string{ //nolint:errcheck
+// CallerNotify sends a notification via any Caller.
+// Returns true if the notification was accepted (resp.OK), false on any failure.
+// Callers can use the return value to fall back to terminal notifications.
+func CallerNotify(c Caller, title, subtitle, body string) bool {
+	resp, err := c.Call("notification.create", map[string]string{
 		"title": title, "subtitle": subtitle, "body": body,
 	})
+	return err == nil && resp.OK
 }
 
 // CallerSetProgress sets the sidebar progress via any Caller. Best-effort.

--- a/internal/cmux/caller_test.go
+++ b/internal/cmux/caller_test.go
@@ -1,0 +1,52 @@
+package cmux_test
+
+import (
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+	"github.com/julianshen/rubichan/internal/cmux/cmuxtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallerNotify(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("notification.create", true)
+
+	cmux.CallerNotify(mc, "Test", "Sub", "Body text")
+
+	calls := mc.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "notification.create", calls[0].Method)
+	params, ok := calls[0].Params.(map[string]string)
+	require.True(t, ok)
+	assert.Equal(t, "Test", params["title"])
+	assert.Equal(t, "Sub", params["subtitle"])
+	assert.Equal(t, "Body text", params["body"])
+}
+
+func TestCallerSetProgress(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("set-progress", true)
+
+	cmux.CallerSetProgress(mc, 0.75, "Analyzing...")
+
+	calls := mc.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "set-progress", calls[0].Method)
+	params, ok := calls[0].Params.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 0.75, params["value"])
+	assert.Equal(t, "Analyzing...", params["label"])
+}
+
+func TestCallerClearProgress(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("clear-progress", true)
+
+	cmux.CallerClearProgress(mc)
+
+	calls := mc.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "clear-progress", calls[0].Method)
+}

--- a/internal/cmux/caller_test.go
+++ b/internal/cmux/caller_test.go
@@ -13,16 +13,25 @@ func TestCallerNotify(t *testing.T) {
 	mc := cmuxtest.NewMockClient()
 	mc.SetResult("notification.create", true)
 
-	cmux.CallerNotify(mc, "Test", "Sub", "Body text")
+	ok := cmux.CallerNotify(mc, "Test", "Sub", "Body text")
+	assert.True(t, ok)
 
 	calls := mc.Calls()
 	require.Len(t, calls, 1)
 	assert.Equal(t, "notification.create", calls[0].Method)
-	params, ok := calls[0].Params.(map[string]string)
-	require.True(t, ok)
+	params, paramsOK := calls[0].Params.(map[string]string)
+	require.True(t, paramsOK)
 	assert.Equal(t, "Test", params["title"])
 	assert.Equal(t, "Sub", params["subtitle"])
 	assert.Equal(t, "Body text", params["body"])
+}
+
+func TestCallerNotifyFailure(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetError("notification.create", "not allowed")
+
+	ok := cmux.CallerNotify(mc, "Test", "Sub", "Body text")
+	assert.False(t, ok)
 }
 
 func TestCallerSetProgress(t *testing.T) {

--- a/internal/cmux/client.go
+++ b/internal/cmux/client.go
@@ -69,13 +69,11 @@ func Dial(socketPath string) (*Client, error) {
 		dec:  json.NewDecoder(conn),
 	}
 
-	// Verify connectivity.
 	if _, err := c.Call("system.ping", map[string]any{}); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("cmux: ping failed: %w", err)
 	}
 
-	// Cache identity.
 	resp, err := c.Call("system.identify", map[string]any{})
 	if err != nil {
 		conn.Close()
@@ -86,7 +84,7 @@ func Dial(socketPath string) (*Client, error) {
 		return nil, fmt.Errorf("cmux: identify failed: %s", resp.Error)
 	}
 	var id Identity
-	if err := unmarshalResult(resp, &id); err != nil {
+	if err := json.Unmarshal(resp.Result, &id); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("cmux: decode identity: %w", err)
 	}
@@ -138,7 +136,26 @@ func (c *Client) Close() error {
 	return c.conn.Close()
 }
 
-// unmarshalResult decodes resp.Result into dst.
-func unmarshalResult(resp *Response, dst any) error {
+// callVoid sends a JSON-RPC call and returns an error if the call fails or resp.OK is false.
+func (c *Client) callVoid(method string, params any) error {
+	resp, err := c.Call(method, params)
+	if err != nil {
+		return fmt.Errorf("cmux: %s: %w", method, err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: %s: %s", method, resp.Error)
+	}
+	return nil
+}
+
+// callResult sends a JSON-RPC call, checks errors, and unmarshals the result into dst.
+func (c *Client) callResult(method string, params any, dst any) error {
+	resp, err := c.Call(method, params)
+	if err != nil {
+		return fmt.Errorf("cmux: %s: %w", method, err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: %s: %s", method, resp.Error)
+	}
 	return json.Unmarshal(resp.Result, dst)
 }

--- a/internal/cmux/client.go
+++ b/internal/cmux/client.go
@@ -34,7 +34,8 @@ type Identity struct {
 }
 
 // Client communicates with cmux over a Unix domain socket.
-// It is thread-safe via a mutex on socket writes.
+// It is safe for concurrent use: a mutex serializes each full request/response
+// round-trip so responses are always matched to their request.
 // Request IDs are auto-incremented. Default timeout is 5 s per call.
 type Client struct {
 	conn     net.Conn
@@ -69,9 +70,14 @@ func Dial(socketPath string) (*Client, error) {
 		dec:  json.NewDecoder(conn),
 	}
 
-	if _, err := c.Call("system.ping", map[string]any{}); err != nil {
+	pingResp, err := c.Call("system.ping", map[string]any{})
+	if err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("cmux: ping failed: %w", err)
+	}
+	if !pingResp.OK {
+		conn.Close()
+		return nil, fmt.Errorf("cmux: ping rejected: %s", pingResp.Error)
 	}
 
 	resp, err := c.Call("system.identify", map[string]any{})
@@ -94,7 +100,7 @@ func Dial(socketPath string) (*Client, error) {
 }
 
 // Call sends a JSON-RPC request and returns the response.
-// The connection is protected by a mutex so concurrent callers are safe.
+// Concurrent calls are safe but serialize behind a mutex — no pipelining.
 func (c *Client) Call(method string, params any) (*Response, error) {
 	id := fmt.Sprintf("req-%d", c.counter.Add(1))
 

--- a/internal/cmux/client.go
+++ b/internal/cmux/client.go
@@ -1,0 +1,144 @@
+// Package cmux provides a JSON-RPC client for communicating with cmux
+// over Unix domain sockets.
+package cmux
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	defaultSocketPath = "/tmp/cmux.sock"
+	defaultTimeout    = 5 * time.Second
+)
+
+// Response is a JSON-RPC response from cmux.
+type Response struct {
+	ID     string          `json:"id"`
+	OK     bool            `json:"ok"`
+	Result json.RawMessage `json:"result"`
+	Error  string          `json:"error,omitempty"`
+}
+
+// Identity contains the cmux context identifiers cached at Dial time.
+type Identity struct {
+	WindowID    string `json:"window_id"`
+	WorkspaceID string `json:"workspace_id"`
+	PaneID      string `json:"pane_id"`
+	SurfaceID   string `json:"surface_id"`
+}
+
+// Client communicates with cmux over a Unix domain socket.
+// It is thread-safe via a mutex on socket writes.
+// Request IDs are auto-incremented. Default timeout is 5 s per call.
+type Client struct {
+	conn     net.Conn
+	enc      *json.Encoder
+	dec      *json.Decoder
+	mu       sync.Mutex // guards enc/dec
+	counter  atomic.Int64
+	identity *Identity
+}
+
+// SocketPath returns the Unix socket path for cmux.
+// It reads the CMUX_SOCKET_PATH environment variable and falls back to
+// "/tmp/cmux.sock" when the variable is empty.
+func SocketPath() string {
+	if p := os.Getenv("CMUX_SOCKET_PATH"); p != "" {
+		return p
+	}
+	return defaultSocketPath
+}
+
+// Dial connects to the cmux daemon at socketPath, verifies the connection
+// with a system.ping, and caches the caller's identity via system.identify.
+func Dial(socketPath string) (*Client, error) {
+	conn, err := net.DialTimeout("unix", socketPath, defaultTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("cmux: dial %s: %w", socketPath, err)
+	}
+
+	c := &Client{
+		conn: conn,
+		enc:  json.NewEncoder(conn),
+		dec:  json.NewDecoder(conn),
+	}
+
+	// Verify connectivity.
+	if _, err := c.Call("system.ping", map[string]any{}); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("cmux: ping failed: %w", err)
+	}
+
+	// Cache identity.
+	resp, err := c.Call("system.identify", map[string]any{})
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("cmux: identify failed: %w", err)
+	}
+	if !resp.OK {
+		conn.Close()
+		return nil, fmt.Errorf("cmux: identify failed: %s", resp.Error)
+	}
+	var id Identity
+	if err := unmarshalResult(resp, &id); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("cmux: decode identity: %w", err)
+	}
+	c.identity = &id
+
+	return c, nil
+}
+
+// Call sends a JSON-RPC request and returns the response.
+// The connection is protected by a mutex so concurrent callers are safe.
+func (c *Client) Call(method string, params any) (*Response, error) {
+	id := fmt.Sprintf("req-%d", c.counter.Add(1))
+
+	req := struct {
+		ID     string `json:"id"`
+		Method string `json:"method"`
+		Params any    `json:"params"`
+	}{
+		ID:     id,
+		Method: method,
+		Params: params,
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.conn.SetDeadline(time.Now().Add(defaultTimeout)); err != nil {
+		return nil, fmt.Errorf("cmux: set deadline: %w", err)
+	}
+	if err := c.enc.Encode(req); err != nil {
+		return nil, fmt.Errorf("cmux: send request: %w", err)
+	}
+
+	var resp Response
+	if err := c.dec.Decode(&resp); err != nil {
+		return nil, fmt.Errorf("cmux: read response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+// Identity returns the cmux context identifiers cached at Dial time.
+func (c *Client) Identity() *Identity {
+	return c.identity
+}
+
+// Close closes the underlying socket connection.
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+// unmarshalResult decodes resp.Result into dst.
+func unmarshalResult(resp *Response, dst any) error {
+	return json.Unmarshal(resp.Result, dst)
+}

--- a/internal/cmux/client_test.go
+++ b/internal/cmux/client_test.go
@@ -184,6 +184,39 @@ func TestDial_BadSocket(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestDial_PingRejected verifies Dial returns an error when system.ping returns OK:false.
+func TestDial_PingRejected(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "cmux_ping_rej.sock")
+	ln, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err2 := ln.Accept()
+			if err2 != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				dec := json.NewDecoder(c)
+				enc := json.NewEncoder(c)
+				for {
+					var req jsonrpcRequest
+					if err3 := dec.Decode(&req); err3 != nil {
+						return
+					}
+					_ = enc.Encode(map[string]interface{}{"id": req.ID, "ok": false, "error": "ping rejected"})
+				}
+			}(conn)
+		}
+	}()
+
+	_, err = cmux.Dial(socketPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ping rejected")
+}
+
 // TestDial_PingFails verifies Dial returns an error when system.ping fails.
 func TestDial_PingFails(t *testing.T) {
 	socketPath := filepath.Join(t.TempDir(), "cmux_ping_fail.sock")

--- a/internal/cmux/client_test.go
+++ b/internal/cmux/client_test.go
@@ -1,0 +1,352 @@
+package cmux_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// jsonrpcRequest is the shape the client sends over the wire.
+type jsonrpcRequest struct {
+	ID     string          `json:"id"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+}
+
+// handlerFunc returns a raw JSON payload for a given request.
+type handlerFunc func(req jsonrpcRequest) interface{}
+
+// fakeServer accepts connections on ln and serves canned responses from handlers.
+// handlers maps method name → handlerFunc. Unrecognised methods return ok:false.
+func fakeServer(t *testing.T, ln net.Listener, handlers map[string]handlerFunc) {
+	t.Helper()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			go serveConn(t, conn, handlers)
+		}
+	}()
+}
+
+func serveConn(t *testing.T, conn net.Conn, handlers map[string]handlerFunc) {
+	t.Helper()
+	defer conn.Close()
+	dec := json.NewDecoder(conn)
+	enc := json.NewEncoder(conn)
+	for {
+		var req jsonrpcRequest
+		if err := dec.Decode(&req); err != nil {
+			return
+		}
+		h, ok := handlers[req.Method]
+		if !ok {
+			_ = enc.Encode(map[string]interface{}{
+				"id":    req.ID,
+				"ok":    false,
+				"error": "unknown method: " + req.Method,
+			})
+			continue
+		}
+		result := h(req)
+		resultBytes, _ := json.Marshal(result)
+		_ = enc.Encode(map[string]interface{}{
+			"id":     req.ID,
+			"ok":     true,
+			"result": json.RawMessage(resultBytes),
+		})
+	}
+}
+
+// newTestServer creates a temp Unix socket, starts fakeServer, and returns the socket path.
+func newTestServer(t *testing.T, handlers map[string]handlerFunc) string {
+	t.Helper()
+	socketPath := filepath.Join(t.TempDir(), "cmux_test.sock")
+	ln, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+	fakeServer(t, ln, handlers)
+	return socketPath
+}
+
+// defaultHandlers returns handlers that satisfy Dial (ping + identify).
+func defaultHandlers() map[string]handlerFunc {
+	return map[string]handlerFunc{
+		"system.ping": func(req jsonrpcRequest) interface{} {
+			return map[string]string{"pong": "ok"}
+		},
+		"system.identify": func(req jsonrpcRequest) interface{} {
+			return map[string]string{
+				"window_id":    "win-1",
+				"workspace_id": "ws-42",
+				"pane_id":      "pane-7",
+				"surface_id":   "surf-3",
+			}
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestDial_Ping(t *testing.T) {
+	socketPath := newTestServer(t, defaultHandlers())
+
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	id := c.Identity()
+	require.NotNil(t, id)
+	assert.Equal(t, "win-1", id.WindowID)
+	assert.Equal(t, "ws-42", id.WorkspaceID)
+	assert.Equal(t, "pane-7", id.PaneID)
+	assert.Equal(t, "surf-3", id.SurfaceID)
+}
+
+func TestCall_ErrorResponse(t *testing.T) {
+	handlers := defaultHandlers()
+	handlers["workspace.list"] = func(req jsonrpcRequest) interface{} {
+		// Return an error response by using a raw encoder override.
+		// We can't return ok:false from a handlerFunc that maps to ok:true,
+		// so we use a special sentinel that the test server turns into ok:false.
+		return nil // will be marshalled as null — but we need to test the error path
+	}
+	// Override serveConn logic by injecting an error-returning handler.
+	socketPath := filepath.Join(t.TempDir(), "cmux_error.sock")
+	ln, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	// Start a server that always returns ok:false for workspace.list.
+	go func() {
+		for {
+			conn, err2 := ln.Accept()
+			if err2 != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				dec := json.NewDecoder(c)
+				enc := json.NewEncoder(c)
+				for {
+					var req jsonrpcRequest
+					if err3 := dec.Decode(&req); err3 != nil {
+						return
+					}
+					switch req.Method {
+					case "system.ping":
+						resultBytes, _ := json.Marshal(map[string]string{"pong": "ok"})
+						_ = enc.Encode(map[string]interface{}{"id": req.ID, "ok": true, "result": json.RawMessage(resultBytes)})
+					case "system.identify":
+						resultBytes, _ := json.Marshal(map[string]string{"window_id": "w1", "workspace_id": "ws1", "pane_id": "p1", "surface_id": "s1"})
+						_ = enc.Encode(map[string]interface{}{"id": req.ID, "ok": true, "result": json.RawMessage(resultBytes)})
+					default:
+						_ = enc.Encode(map[string]interface{}{"id": req.ID, "ok": false, "error": "permission denied"})
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	resp, err := c.Call("workspace.list", map[string]string{})
+	require.NoError(t, err) // Call itself succeeded (transport-wise)
+	assert.False(t, resp.OK)
+	assert.Equal(t, "permission denied", resp.Error)
+}
+
+func TestSocketPath_Default(t *testing.T) {
+	t.Setenv("CMUX_SOCKET_PATH", "")
+	assert.Equal(t, "/tmp/cmux.sock", cmux.SocketPath())
+}
+
+func TestSocketPath_Override(t *testing.T) {
+	t.Setenv("CMUX_SOCKET_PATH", "/var/run/mycmux.sock")
+	assert.Equal(t, "/var/run/mycmux.sock", cmux.SocketPath())
+}
+
+func TestDial_BadSocket(t *testing.T) {
+	_, err := cmux.Dial("/tmp/nonexistent-cmux-test-socket-xyz.sock")
+	require.Error(t, err)
+}
+
+// TestDial_PingFails verifies Dial returns an error when system.ping fails.
+func TestDial_PingFails(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "cmux_ping_fail.sock")
+	ln, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	// Server that closes the connection immediately on any request.
+	go func() {
+		for {
+			conn, err2 := ln.Accept()
+			if err2 != nil {
+				return
+			}
+			conn.Close() // close before sending anything
+		}
+	}()
+
+	_, err = cmux.Dial(socketPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ping failed")
+}
+
+// TestDial_IdentifyFails verifies Dial returns an error when system.identify fails.
+func TestDial_IdentifyFails(t *testing.T) {
+	socketPath := filepath.Join(os.TempDir(), fmt.Sprintf("cmux_idf_%d.sock", os.Getpid()))
+	t.Cleanup(func() { os.Remove(socketPath) })
+	ln, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err2 := ln.Accept()
+			if err2 != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				dec := json.NewDecoder(c)
+				enc := json.NewEncoder(c)
+				for {
+					var req jsonrpcRequest
+					if err3 := dec.Decode(&req); err3 != nil {
+						return
+					}
+					if req.Method == "system.ping" {
+						resultBytes, _ := json.Marshal(map[string]string{"pong": "ok"})
+						_ = enc.Encode(map[string]interface{}{"id": req.ID, "ok": true, "result": json.RawMessage(resultBytes)})
+					} else {
+						// identify: return ok:false
+						_ = enc.Encode(map[string]interface{}{"id": req.ID, "ok": false, "error": "identify not allowed"})
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	_, err = cmux.Dial(socketPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identify failed")
+}
+
+// TestDial_IdentifyTransportError verifies Dial returns "identify failed" when the
+// identify call fails at the transport level (server closes connection mid-stream).
+func TestDial_IdentifyTransportError(t *testing.T) {
+	socketPath := filepath.Join(os.TempDir(), fmt.Sprintf("cmux_ite_%d.sock", os.Getpid()))
+	t.Cleanup(func() { os.Remove(socketPath) })
+	ln, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err2 := ln.Accept()
+			if err2 != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				dec := json.NewDecoder(c)
+				enc := json.NewEncoder(c)
+				var reqCount int
+				for {
+					var req jsonrpcRequest
+					if err3 := dec.Decode(&req); err3 != nil {
+						return
+					}
+					reqCount++
+					if reqCount == 1 {
+						// Answer ping.
+						resultBytes, _ := json.Marshal(map[string]string{"pong": "ok"})
+						_ = enc.Encode(map[string]interface{}{"id": req.ID, "ok": true, "result": json.RawMessage(resultBytes)})
+					} else {
+						// Close without answering identify.
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	_, err = cmux.Dial(socketPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identify failed")
+}
+
+// TestDial_IdentifyBadJSON verifies Dial returns a decode error when identity
+// result contains truly unparseable JSON.
+func TestDial_IdentifyBadJSON(t *testing.T) {
+	socketPath := filepath.Join(os.TempDir(), fmt.Sprintf("cmux_idj_%d.sock", os.Getpid()))
+	t.Cleanup(func() { os.Remove(socketPath) })
+	ln, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err2 := ln.Accept()
+			if err2 != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				dec := json.NewDecoder(c)
+				enc := json.NewEncoder(c)
+				for {
+					var req jsonrpcRequest
+					if err3 := dec.Decode(&req); err3 != nil {
+						return
+					}
+					switch req.Method {
+					case "system.ping":
+						resultBytes, _ := json.Marshal(map[string]string{"pong": "ok"})
+						_ = enc.Encode(map[string]interface{}{"id": req.ID, "ok": true, "result": json.RawMessage(resultBytes)})
+					case "system.identify":
+						// Send truly invalid JSON as the result field value.
+						// We write the framing manually to inject invalid bytes.
+						raw := fmt.Sprintf(`{"id":%q,"ok":true,"result":{"window_id":}}`+"\n", req.ID)
+						_, _ = c.Write([]byte(raw))
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	_, err = cmux.Dial(socketPath)
+	require.Error(t, err)
+	// The invalid JSON causes Decode to fail at the transport level — so we get
+	// "identify failed" (Call returns an error) rather than "decode identity".
+	assert.Contains(t, err.Error(), "identify failed")
+}
+
+// TestCall_AfterClose verifies that Call returns an error when the connection is closed.
+func TestCall_AfterClose(t *testing.T) {
+	socketPath := newTestServer(t, defaultHandlers())
+
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+
+	err = c.Close()
+	require.NoError(t, err)
+
+	_, err = c.Call("system.ping", map[string]string{})
+	require.Error(t, err)
+}

--- a/internal/cmux/cmuxtest/mock.go
+++ b/internal/cmux/cmuxtest/mock.go
@@ -20,6 +20,7 @@ type Call struct {
 type MockClient struct {
 	mu       sync.Mutex
 	results  map[string]any
+	errors   map[string]string // method → error message (returns OK:false)
 	calls    []Call
 	identity *cmux.Identity
 }
@@ -28,6 +29,7 @@ type MockClient struct {
 func NewMockClient() *MockClient {
 	return &MockClient{
 		results: make(map[string]any),
+		errors:  make(map[string]string),
 		identity: &cmux.Identity{
 			WindowID:    "mock-window",
 			WorkspaceID: "mock-workspace",
@@ -42,15 +44,32 @@ func (m *MockClient) SetResult(method string, result any) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.results[method] = result
+	delete(m.errors, method)
 }
 
-// Call records the call and returns the canned result.
-// It returns an error if no result has been set for method.
+// SetError configures the method to return an OK:false response with the given error message.
+func (m *MockClient) SetError(method, errMsg string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.errors[method] = errMsg
+	delete(m.results, method)
+}
+
+// Call records the call and returns the canned result or error.
+// It returns a transport error if neither result nor error has been set for method.
 func (m *MockClient) Call(method string, params any) (*cmux.Response, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	m.calls = append(m.calls, Call{Method: method, Params: params})
+
+	if errMsg, ok := m.errors[method]; ok {
+		return &cmux.Response{
+			ID:    "mock-id",
+			OK:    false,
+			Error: errMsg,
+		}, nil
+	}
 
 	result, ok := m.results[method]
 	if !ok {
@@ -89,4 +108,5 @@ func (m *MockClient) Reset() {
 	defer m.mu.Unlock()
 	m.calls = nil
 	m.results = make(map[string]any)
+	m.errors = make(map[string]string)
 }

--- a/internal/cmux/cmuxtest/mock.go
+++ b/internal/cmux/cmuxtest/mock.go
@@ -1,0 +1,92 @@
+// Package cmuxtest provides test helpers for code that depends on cmux.
+package cmuxtest
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+)
+
+// Call records a single invocation captured by MockClient.
+type Call struct {
+	Method string
+	Params any
+}
+
+// MockClient records calls and returns canned responses.
+// It implements the cmux.Caller interface.
+type MockClient struct {
+	mu       sync.Mutex
+	results  map[string]any
+	calls    []Call
+	identity *cmux.Identity
+}
+
+// NewMockClient creates a MockClient with a default mock identity.
+func NewMockClient() *MockClient {
+	return &MockClient{
+		results: make(map[string]any),
+		identity: &cmux.Identity{
+			WindowID:    "mock-window",
+			WorkspaceID: "mock-workspace",
+			PaneID:      "mock-pane",
+			SurfaceID:   "mock-surface",
+		},
+	}
+}
+
+// SetResult sets the canned result returned for method.
+func (m *MockClient) SetResult(method string, result any) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.results[method] = result
+}
+
+// Call records the call and returns the canned result.
+// It returns an error if no result has been set for method.
+func (m *MockClient) Call(method string, params any) (*cmux.Response, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls = append(m.calls, Call{Method: method, Params: params})
+
+	result, ok := m.results[method]
+	if !ok {
+		return nil, fmt.Errorf("cmuxtest: no result set for method %q", method)
+	}
+
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("cmuxtest: marshal result for %q: %w", method, err)
+	}
+
+	return &cmux.Response{
+		ID:     "mock-id",
+		OK:     true,
+		Result: json.RawMessage(raw),
+	}, nil
+}
+
+// Identity returns the mock identity.
+func (m *MockClient) Identity() *cmux.Identity {
+	return m.identity
+}
+
+// Calls returns a copy of all recorded calls.
+func (m *MockClient) Calls() []Call {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]Call, len(m.calls))
+	copy(cp, m.calls)
+	return cp
+}
+
+// Reset clears all recorded calls and canned results.
+func (m *MockClient) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = nil
+	m.results = make(map[string]any)
+}

--- a/internal/cmux/cmuxtest/mock_test.go
+++ b/internal/cmux/cmuxtest/mock_test.go
@@ -40,6 +40,36 @@ func TestMockClient_Identity(t *testing.T) {
 	assert.Equal(t, "mock-surface", id.SurfaceID)
 }
 
+func TestMockClient_SetError(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	m.SetError("workspace.list", "permission denied")
+
+	resp, err := m.Call("workspace.list", nil)
+	require.NoError(t, err) // no transport error
+	assert.False(t, resp.OK)
+	assert.Equal(t, "permission denied", resp.Error)
+}
+
+func TestMockClient_SetErrorThenSetResult(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	m.SetError("foo", "bad")
+	m.SetResult("foo", "good")
+
+	resp, err := m.Call("foo", nil)
+	require.NoError(t, err)
+	assert.True(t, resp.OK)
+}
+
+func TestMockClient_MarshalError(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	// Functions cannot be marshalled to JSON.
+	m.SetResult("bad", func() {})
+
+	_, err := m.Call("bad", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshal")
+}
+
 func TestMockClient_Reset(t *testing.T) {
 	m := cmuxtest.NewMockClient()
 	m.SetResult("foo", "bar")

--- a/internal/cmux/cmuxtest/mock_test.go
+++ b/internal/cmux/cmuxtest/mock_test.go
@@ -1,0 +1,53 @@
+package cmuxtest_test
+
+import (
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux/cmuxtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockClient_RecordsCalls(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	m.SetResult("workspace.list", map[string]any{"items": []string{"ws-1"}})
+
+	resp, err := m.Call("workspace.list", map[string]string{})
+	require.NoError(t, err)
+	assert.True(t, resp.OK)
+
+	calls := m.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "workspace.list", calls[0].Method)
+}
+
+func TestMockClient_UnknownMethodErrors(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+
+	_, err := m.Call("unknown.method", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown.method")
+}
+
+func TestMockClient_Identity(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+
+	id := m.Identity()
+	require.NotNil(t, id)
+	assert.Equal(t, "mock-window", id.WindowID)
+	assert.Equal(t, "mock-workspace", id.WorkspaceID)
+	assert.Equal(t, "mock-pane", id.PaneID)
+	assert.Equal(t, "mock-surface", id.SurfaceID)
+}
+
+func TestMockClient_Reset(t *testing.T) {
+	m := cmuxtest.NewMockClient()
+	m.SetResult("foo", "bar")
+	_, _ = m.Call("foo", nil)
+
+	m.Reset()
+	assert.Empty(t, m.Calls())
+
+	_, err := m.Call("foo", nil)
+	require.Error(t, err) // result was cleared
+}

--- a/internal/cmux/integration_test.go
+++ b/internal/cmux/integration_test.go
@@ -1,0 +1,69 @@
+//go:build cmux_integration
+
+package cmux
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_Ping(t *testing.T) {
+	if os.Getenv("CMUX_WORKSPACE_ID") == "" {
+		t.Skip("not running inside cmux")
+	}
+	c, err := Dial(SocketPath())
+	require.NoError(t, err)
+	defer c.Close()
+
+	assert.NotEmpty(t, c.Identity().WorkspaceID)
+	assert.NotEmpty(t, c.Identity().SurfaceID)
+}
+
+func TestIntegration_Sidebar(t *testing.T) {
+	if os.Getenv("CMUX_WORKSPACE_ID") == "" {
+		t.Skip("not running inside cmux")
+	}
+	c, err := Dial(SocketPath())
+	require.NoError(t, err)
+	defer c.Close()
+
+	require.NoError(t, c.SetStatus("test", "integration", "checkmark.circle", "#00ff00"))
+	require.NoError(t, c.SetProgress(0.5, "Testing..."))
+	require.NoError(t, c.Log("Integration test running", "info", "test"))
+
+	state, err := c.SidebarState()
+	require.NoError(t, err)
+	assert.NotNil(t, state)
+
+	require.NoError(t, c.ClearStatus("test"))
+	require.NoError(t, c.ClearProgress())
+	require.NoError(t, c.ClearLog())
+}
+
+func TestIntegration_Notify(t *testing.T) {
+	if os.Getenv("CMUX_WORKSPACE_ID") == "" {
+		t.Skip("not running inside cmux")
+	}
+	c, err := Dial(SocketPath())
+	require.NoError(t, err)
+	defer c.Close()
+
+	require.NoError(t, c.Notify("Rubichan Test", "Integration", "This is a test notification"))
+	require.NoError(t, c.ClearNotifications())
+}
+
+func TestIntegration_ListWorkspaces(t *testing.T) {
+	if os.Getenv("CMUX_WORKSPACE_ID") == "" {
+		t.Skip("not running inside cmux")
+	}
+	c, err := Dial(SocketPath())
+	require.NoError(t, err)
+	defer c.Close()
+
+	workspaces, err := c.ListWorkspaces()
+	require.NoError(t, err)
+	assert.NotEmpty(t, workspaces)
+}

--- a/internal/cmux/notification.go
+++ b/internal/cmux/notification.go
@@ -1,7 +1,5 @@
 package cmux
 
-import "fmt"
-
 // Notification represents a cmux notification entry.
 type Notification struct {
 	ID       string `json:"id"`
@@ -12,44 +10,21 @@ type Notification struct {
 
 // Notify creates a new notification via cmux.
 func (c *Client) Notify(title, subtitle, body string) error {
-	resp, err := c.Call("notification.create", map[string]string{
-		"title":    title,
-		"subtitle": subtitle,
-		"body":     body,
+	return c.callVoid("notification.create", map[string]string{
+		"title": title, "subtitle": subtitle, "body": body,
 	})
-	if err != nil {
-		return fmt.Errorf("cmux: notification.create: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: notification.create: %s", resp.Error)
-	}
-	return nil
 }
 
 // ListNotifications retrieves all current notifications from cmux.
 func (c *Client) ListNotifications() ([]Notification, error) {
-	resp, err := c.Call("notification.list", map[string]any{})
-	if err != nil {
-		return nil, fmt.Errorf("cmux: notification.list: %w", err)
-	}
-	if !resp.OK {
-		return nil, fmt.Errorf("cmux: notification.list: %s", resp.Error)
-	}
 	var notifications []Notification
-	if err := unmarshalResult(resp, &notifications); err != nil {
-		return nil, fmt.Errorf("cmux: decode notifications: %w", err)
+	if err := c.callResult("notification.list", map[string]any{}, &notifications); err != nil {
+		return nil, err
 	}
 	return notifications, nil
 }
 
 // ClearNotifications removes all notifications from cmux.
 func (c *Client) ClearNotifications() error {
-	resp, err := c.Call("notification.clear", map[string]any{})
-	if err != nil {
-		return fmt.Errorf("cmux: notification.clear: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: notification.clear: %s", resp.Error)
-	}
-	return nil
+	return c.callVoid("notification.clear", map[string]any{})
 }

--- a/internal/cmux/notification.go
+++ b/internal/cmux/notification.go
@@ -1,0 +1,55 @@
+package cmux
+
+import "fmt"
+
+// Notification represents a cmux notification entry.
+type Notification struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	Subtitle string `json:"subtitle"`
+	Body     string `json:"body"`
+}
+
+// Notify creates a new notification via cmux.
+func (c *Client) Notify(title, subtitle, body string) error {
+	resp, err := c.Call("notification.create", map[string]string{
+		"title":    title,
+		"subtitle": subtitle,
+		"body":     body,
+	})
+	if err != nil {
+		return fmt.Errorf("cmux: notification.create: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: notification.create: %s", resp.Error)
+	}
+	return nil
+}
+
+// ListNotifications retrieves all current notifications from cmux.
+func (c *Client) ListNotifications() ([]Notification, error) {
+	resp, err := c.Call("notification.list", map[string]any{})
+	if err != nil {
+		return nil, fmt.Errorf("cmux: notification.list: %w", err)
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("cmux: notification.list: %s", resp.Error)
+	}
+	var notifications []Notification
+	if err := unmarshalResult(resp, &notifications); err != nil {
+		return nil, fmt.Errorf("cmux: decode notifications: %w", err)
+	}
+	return notifications, nil
+}
+
+// ClearNotifications removes all notifications from cmux.
+func (c *Client) ClearNotifications() error {
+	resp, err := c.Call("notification.clear", map[string]any{})
+	if err != nil {
+		return fmt.Errorf("cmux: notification.clear: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: notification.clear: %s", resp.Error)
+	}
+	return nil
+}

--- a/internal/cmux/notification_test.go
+++ b/internal/cmux/notification_test.go
@@ -1,0 +1,76 @@
+package cmux_test
+
+import (
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotify(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedTitle, capturedSubtitle, capturedBody string
+	handlers["notification.create"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			Title    string `json:"title"`
+			Subtitle string `json:"subtitle"`
+			Body     string `json:"body"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedTitle = p.Title
+		capturedSubtitle = p.Subtitle
+		capturedBody = p.Body
+		return map[string]string{"id": "notif-1"}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.Notify("Build done", "CI passed", "All 42 tests passed.")
+	require.NoError(t, err)
+	assert.Equal(t, "Build done", capturedTitle)
+	assert.Equal(t, "CI passed", capturedSubtitle)
+	assert.Equal(t, "All 42 tests passed.", capturedBody)
+}
+
+func TestListNotifications(t *testing.T) {
+	handlers := defaultHandlers()
+	handlers["notification.list"] = func(req jsonrpcRequest) interface{} {
+		return []map[string]string{
+			{"id": "n1", "title": "Hello", "subtitle": "Sub", "body": "World"},
+			{"id": "n2", "title": "Alert", "subtitle": "", "body": "Disk full"},
+		}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	notifications, err := c.ListNotifications()
+	require.NoError(t, err)
+	require.Len(t, notifications, 2)
+	assert.Equal(t, "n1", notifications[0].ID)
+	assert.Equal(t, "Hello", notifications[0].Title)
+	assert.Equal(t, "Sub", notifications[0].Subtitle)
+	assert.Equal(t, "World", notifications[0].Body)
+	assert.Equal(t, "n2", notifications[1].ID)
+}
+
+func TestClearNotifications(t *testing.T) {
+	handlers := defaultHandlers()
+	cleared := false
+	handlers["notification.clear"] = func(req jsonrpcRequest) interface{} {
+		cleared = true
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.ClearNotifications()
+	require.NoError(t, err)
+	assert.True(t, cleared)
+}

--- a/internal/cmux/notification_test.go
+++ b/internal/cmux/notification_test.go
@@ -58,6 +58,17 @@ func TestListNotifications(t *testing.T) {
 	assert.Equal(t, "n2", notifications[1].ID)
 }
 
+func TestListNotificationsError(t *testing.T) {
+	socketPath := newErrorServer(t, "notification.list")
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = c.ListNotifications()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "notification.list")
+}
+
 func TestClearNotifications(t *testing.T) {
 	handlers := defaultHandlers()
 	cleared := false

--- a/internal/cmux/orchestrator.go
+++ b/internal/cmux/orchestrator.go
@@ -21,7 +21,7 @@ type Orchestrator struct {
 	client    Caller
 	tasks     map[string]*Task // surface ID → task
 	pollRate  time.Duration    // default 2s
-	logOffset int              // tracks processed log entries to avoid duplicates
+	logOffset int              // server log entries already processed; assumes append-only log
 }
 
 // NewOrchestrator creates a new Orchestrator backed by the given Caller.
@@ -54,16 +54,24 @@ func (o *Orchestrator) Dispatch(direction, command string) (*Task, error) {
 		return nil, fmt.Errorf("cmux: orchestrator: decode surface: %w", err)
 	}
 
-	if _, err := o.client.Call("surface.send_text", map[string]string{
+	resp, err = o.client.Call("surface.send_text", map[string]string{
 		"surface_id": surf.ID, "text": command,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, fmt.Errorf("cmux: orchestrator: send_text: %w", err)
 	}
+	if !resp.OK {
+		return nil, fmt.Errorf("cmux: orchestrator: send_text: %s", resp.Error)
+	}
 
-	if _, err := o.client.Call("surface.send_key", map[string]string{
+	resp, err = o.client.Call("surface.send_key", map[string]string{
 		"surface_id": surf.ID, "key": "enter",
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, fmt.Errorf("cmux: orchestrator: send_key: %w", err)
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("cmux: orchestrator: send_key: %s", resp.Error)
 	}
 
 	task := &Task{

--- a/internal/cmux/orchestrator.go
+++ b/internal/cmux/orchestrator.go
@@ -18,9 +18,10 @@ type Task struct {
 
 // Orchestrator coordinates sub-agents across split panes using log-based signaling.
 type Orchestrator struct {
-	client   Caller
-	tasks    map[string]*Task // surface ID → task
-	pollRate time.Duration    // default 2s
+	client    Caller
+	tasks     map[string]*Task // surface ID → task
+	pollRate  time.Duration    // default 2s
+	logOffset int              // tracks processed log entries to avoid duplicates
 }
 
 // NewOrchestrator creates a new Orchestrator backed by the given Caller.
@@ -149,7 +150,16 @@ func (o *Orchestrator) poll() error {
 		return fmt.Errorf("cmux: orchestrator: decode sidebar state: %w", err)
 	}
 
-	for _, entry := range state.Logs {
+	// Only process new log entries since the last poll to avoid duplicates.
+	newEntries := state.Logs
+	if o.logOffset < len(newEntries) {
+		newEntries = newEntries[o.logOffset:]
+	} else {
+		newEntries = nil
+	}
+	o.logOffset = len(state.Logs)
+
+	for _, entry := range newEntries {
 		task, ok := o.tasks[entry.Source]
 		if !ok {
 			continue

--- a/internal/cmux/orchestrator.go
+++ b/internal/cmux/orchestrator.go
@@ -1,0 +1,175 @@
+package cmux
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Task represents a sub-agent command dispatched to a cmux surface.
+type Task struct {
+	ID        string
+	SurfaceID string
+	Command   string
+	Status    string     // "running", "done", "error"
+	Logs      []LogEntry // accumulated log entries from sidebar
+}
+
+// Orchestrator coordinates sub-agents across split panes using log-based signaling.
+type Orchestrator struct {
+	client   *Client
+	tasks    map[string]*Task // surface ID → task
+	pollRate time.Duration    // default 2s
+}
+
+// NewOrchestrator creates a new Orchestrator backed by the given Client.
+func NewOrchestrator(client *Client) *Orchestrator {
+	return &Orchestrator{
+		client:   client,
+		tasks:    make(map[string]*Task),
+		pollRate: 2 * time.Second,
+	}
+}
+
+// SetPollRate sets the polling interval used by Wait and WaitAny.
+func (o *Orchestrator) SetPollRate(d time.Duration) {
+	o.pollRate = d
+}
+
+// Dispatch splits a new pane in the given direction, sends the command to it,
+// and registers a Task with Status "running". The task is stored keyed by
+// the new surface's ID.
+func (o *Orchestrator) Dispatch(direction, command string) (*Task, error) {
+	surf, err := o.client.Split(direction)
+	if err != nil {
+		return nil, fmt.Errorf("cmux: orchestrator: split: %w", err)
+	}
+
+	if err := o.client.SendText(surf.ID, command); err != nil {
+		return nil, fmt.Errorf("cmux: orchestrator: send_text: %w", err)
+	}
+
+	if err := o.client.SendKey(surf.ID, "enter"); err != nil {
+		return nil, fmt.Errorf("cmux: orchestrator: send_key: %w", err)
+	}
+
+	task := &Task{
+		ID:        surf.ID,
+		SurfaceID: surf.ID,
+		Command:   command,
+		Status:    "running",
+	}
+	o.tasks[surf.ID] = task
+	return task, nil
+}
+
+// Wait polls SidebarState every pollRate and updates task statuses based on
+// log entries whose Source matches a task's SurfaceID. A log entry with a
+// "[DONE]" prefix marks the task done; "[ERROR]" marks it errored. All entries
+// are appended to the matching task's Logs.
+//
+// Wait returns when all tasks have finished (status != "running"), or returns
+// an error if timeout elapses first.
+func (o *Orchestrator) Wait(timeout time.Duration) ([]Task, error) {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		if err := o.poll(); err != nil {
+			return nil, err
+		}
+		if o.allDone() {
+			return o.snapshot(), nil
+		}
+		remaining := time.Until(deadline)
+		sleep := o.pollRate
+		if sleep > remaining {
+			sleep = remaining
+		}
+		time.Sleep(sleep)
+	}
+
+	// Final check after timeout.
+	if o.allDone() {
+		return o.snapshot(), nil
+	}
+	return nil, fmt.Errorf("cmux: orchestrator: timeout waiting for tasks")
+}
+
+// WaitAny polls SidebarState every pollRate and returns as soon as any task
+// completes (status != "running"). Returns an error if timeout elapses before
+// any task completes.
+func (o *Orchestrator) WaitAny(timeout time.Duration) (*Task, error) {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		if err := o.poll(); err != nil {
+			return nil, err
+		}
+		if t := o.firstDone(); t != nil {
+			return t, nil
+		}
+		remaining := time.Until(deadline)
+		sleep := o.pollRate
+		if sleep > remaining {
+			sleep = remaining
+		}
+		time.Sleep(sleep)
+	}
+
+	// Final check after timeout.
+	if t := o.firstDone(); t != nil {
+		return t, nil
+	}
+	return nil, fmt.Errorf("cmux: orchestrator: timeout waiting for tasks")
+}
+
+// poll fetches sidebar state and updates all running tasks from log entries.
+func (o *Orchestrator) poll() error {
+	state, err := o.client.SidebarState()
+	if err != nil {
+		return fmt.Errorf("cmux: orchestrator: poll: %w", err)
+	}
+
+	for _, entry := range state.Logs {
+		task, ok := o.tasks[entry.Source]
+		if !ok {
+			continue
+		}
+		task.Logs = append(task.Logs, entry)
+		if strings.HasPrefix(entry.Message, "[DONE]") {
+			task.Status = "done"
+		} else if strings.HasPrefix(entry.Message, "[ERROR]") {
+			task.Status = "error"
+		}
+	}
+	return nil
+}
+
+// allDone returns true when every task has a non-"running" status.
+func (o *Orchestrator) allDone() bool {
+	for _, t := range o.tasks {
+		if t.Status == "running" {
+			return false
+		}
+	}
+	return true
+}
+
+// firstDone returns the first task that is no longer running, or nil.
+func (o *Orchestrator) firstDone() *Task {
+	for _, t := range o.tasks {
+		if t.Status != "running" {
+			return t
+		}
+	}
+	return nil
+}
+
+// snapshot returns a copy of all tasks as a slice.
+func (o *Orchestrator) snapshot() []Task {
+	result := make([]Task, 0, len(o.tasks))
+	for _, t := range o.tasks {
+		result = append(result, *t)
+	}
+	return result
+}

--- a/internal/cmux/orchestrator.go
+++ b/internal/cmux/orchestrator.go
@@ -1,6 +1,7 @@
 package cmux
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -90,11 +91,14 @@ func (o *Orchestrator) Dispatch(direction, command string) (*Task, error) {
 // are appended to the matching task's Logs.
 //
 // Wait returns when all tasks have finished (status != "running"), or returns
-// an error if timeout elapses first.
-func (o *Orchestrator) Wait(timeout time.Duration) ([]Task, error) {
+// an error if the context is cancelled or timeout elapses first.
+func (o *Orchestrator) Wait(ctx context.Context, timeout time.Duration) ([]Task, error) {
 	deadline := time.Now().Add(timeout)
 
 	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("cmux: orchestrator: %w", err)
+		}
 		if err := o.poll(); err != nil {
 			return nil, err
 		}
@@ -117,12 +121,15 @@ func (o *Orchestrator) Wait(timeout time.Duration) ([]Task, error) {
 }
 
 // WaitAny polls SidebarState every pollRate and returns as soon as any task
-// completes (status != "running"). Returns an error if timeout elapses before
-// any task completes.
-func (o *Orchestrator) WaitAny(timeout time.Duration) (*Task, error) {
+// completes (status != "running"). Returns an error if the context is cancelled
+// or timeout elapses before any task completes.
+func (o *Orchestrator) WaitAny(ctx context.Context, timeout time.Duration) (*Task, error) {
 	deadline := time.Now().Add(timeout)
 
 	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("cmux: orchestrator: %w", err)
+		}
 		if err := o.poll(); err != nil {
 			return nil, err
 		}

--- a/internal/cmux/orchestrator.go
+++ b/internal/cmux/orchestrator.go
@@ -1,6 +1,7 @@
 package cmux
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -17,13 +18,13 @@ type Task struct {
 
 // Orchestrator coordinates sub-agents across split panes using log-based signaling.
 type Orchestrator struct {
-	client   *Client
+	client   Caller
 	tasks    map[string]*Task // surface ID → task
 	pollRate time.Duration    // default 2s
 }
 
-// NewOrchestrator creates a new Orchestrator backed by the given Client.
-func NewOrchestrator(client *Client) *Orchestrator {
+// NewOrchestrator creates a new Orchestrator backed by the given Caller.
+func NewOrchestrator(client Caller) *Orchestrator {
 	return &Orchestrator{
 		client:   client,
 		tasks:    make(map[string]*Task),
@@ -40,16 +41,27 @@ func (o *Orchestrator) SetPollRate(d time.Duration) {
 // and registers a Task with Status "running". The task is stored keyed by
 // the new surface's ID.
 func (o *Orchestrator) Dispatch(direction, command string) (*Task, error) {
-	surf, err := o.client.Split(direction)
+	resp, err := o.client.Call("surface.split", map[string]string{"direction": direction})
 	if err != nil {
 		return nil, fmt.Errorf("cmux: orchestrator: split: %w", err)
 	}
+	if !resp.OK {
+		return nil, fmt.Errorf("cmux: orchestrator: split: %s", resp.Error)
+	}
+	var surf Surface
+	if err := json.Unmarshal(resp.Result, &surf); err != nil {
+		return nil, fmt.Errorf("cmux: orchestrator: decode surface: %w", err)
+	}
 
-	if err := o.client.SendText(surf.ID, command); err != nil {
+	if _, err := o.client.Call("surface.send_text", map[string]string{
+		"surface_id": surf.ID, "text": command,
+	}); err != nil {
 		return nil, fmt.Errorf("cmux: orchestrator: send_text: %w", err)
 	}
 
-	if err := o.client.SendKey(surf.ID, "enter"); err != nil {
+	if _, err := o.client.Call("surface.send_key", map[string]string{
+		"surface_id": surf.ID, "key": "enter",
+	}); err != nil {
 		return nil, fmt.Errorf("cmux: orchestrator: send_key: %w", err)
 	}
 
@@ -125,9 +137,16 @@ func (o *Orchestrator) WaitAny(timeout time.Duration) (*Task, error) {
 
 // poll fetches sidebar state and updates all running tasks from log entries.
 func (o *Orchestrator) poll() error {
-	state, err := o.client.SidebarState()
+	resp, err := o.client.Call("sidebar-state", map[string]any{})
 	if err != nil {
 		return fmt.Errorf("cmux: orchestrator: poll: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: orchestrator: poll: %s", resp.Error)
+	}
+	var state SidebarState
+	if err := json.Unmarshal(resp.Result, &state); err != nil {
+		return fmt.Errorf("cmux: orchestrator: decode sidebar state: %w", err)
 	}
 
 	for _, entry := range state.Logs {

--- a/internal/cmux/orchestrator.go
+++ b/internal/cmux/orchestrator.go
@@ -166,7 +166,12 @@ func (o *Orchestrator) poll() error {
 	}
 
 	// Only process new log entries since the last poll to avoid duplicates.
+	// If the log was truncated externally (e.g. clear-log), reset offset to
+	// avoid silently dropping all future signals.
 	newEntries := state.Logs
+	if o.logOffset > len(newEntries) {
+		o.logOffset = 0
+	}
 	if o.logOffset < len(newEntries) {
 		newEntries = newEntries[o.logOffset:]
 	} else {

--- a/internal/cmux/orchestrator_test.go
+++ b/internal/cmux/orchestrator_test.go
@@ -226,6 +226,46 @@ func TestOrchestrator_WaitContextCancelled(t *testing.T) {
 	assert.Contains(t, err.Error(), "canceled")
 }
 
+// TestOrchestrator_LogTruncation verifies that the orchestrator recovers when
+// sidebar logs are truncated (e.g. by an external clear-log call).
+func TestOrchestrator_LogTruncation(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.split", cmux.Surface{ID: "surf-1", Type: "terminal"})
+	mc.SetResult("surface.send_text", true)
+	mc.SetResult("surface.send_key", true)
+
+	// First poll: 3 log entries (none matching our task).
+	mc.SetResult("sidebar-state", cmux.SidebarState{
+		Logs: []cmux.LogEntry{
+			{Message: "noise1", Level: "info", Source: "other"},
+			{Message: "noise2", Level: "info", Source: "other"},
+			{Message: "noise3", Level: "info", Source: "other"},
+		},
+	})
+
+	orch := cmux.NewOrchestrator(mc)
+	orch.SetPollRate(10 * time.Millisecond)
+
+	_, err := orch.Dispatch("right", "echo task1")
+	require.NoError(t, err)
+
+	// Trigger first poll to advance logOffset to 3.
+	// Then simulate log truncation: only 1 entry now, with [DONE].
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		mc.SetResult("sidebar-state", cmux.SidebarState{
+			Logs: []cmux.LogEntry{
+				{Message: "[DONE] completed after truncation", Level: "info", Source: "surf-1"},
+			},
+		})
+	}()
+
+	results, err := orch.Wait(context.Background(), 2*time.Second)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "done", results[0].Status)
+}
+
 // TestOrchestrator_PollOKFalse verifies Wait returns an error when poll gets OK:false.
 func TestOrchestrator_PollOKFalse(t *testing.T) {
 	mc := cmuxtest.NewMockClient()

--- a/internal/cmux/orchestrator_test.go
+++ b/internal/cmux/orchestrator_test.go
@@ -1,0 +1,162 @@
+package cmux_test
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeOrchestratorServer handles split + send_text + send_key + sidebar-state
+// with a logSequence that returns different logs on each sidebar-state poll.
+//
+// Methods handled:
+//   - system.ping → {"pong": true}
+//   - system.identify → standard identity
+//   - surface.split → incrementing surface IDs ("surf-1", "surf-2", …)
+//   - surface.send_text, surface.send_key → true
+//   - sidebar-state → returns {"logs": logSequence[pollCount]} cycling through the sequence
+func fakeOrchestratorServer(t *testing.T, ln net.Listener, logSequence [][]cmux.LogEntry) {
+	t.Helper()
+
+	var splitCounter atomic.Int64
+	var pollCounter atomic.Int64
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			go serveConn(t, conn, map[string]handlerFunc{
+				"system.ping": func(req jsonrpcRequest) interface{} {
+					return map[string]bool{"pong": true}
+				},
+				"system.identify": func(req jsonrpcRequest) interface{} {
+					return map[string]string{
+						"window_id":    "win-1",
+						"workspace_id": "ws-1",
+						"pane_id":      "pane-1",
+						"surface_id":   "surf-0",
+					}
+				},
+				"surface.split": func(req jsonrpcRequest) interface{} {
+					n := splitCounter.Add(1)
+					return map[string]string{
+						"id":   fmt.Sprintf("surf-%d", n),
+						"type": "terminal",
+					}
+				},
+				"surface.send_text": func(req jsonrpcRequest) interface{} {
+					return true
+				},
+				"surface.send_key": func(req jsonrpcRequest) interface{} {
+					return true
+				},
+				"sidebar-state": func(req jsonrpcRequest) interface{} {
+					idx := int(pollCounter.Add(1)) - 1
+					if idx >= len(logSequence) {
+						idx = len(logSequence) - 1
+					}
+					return map[string]interface{}{
+						"logs": logSequence[idx],
+					}
+				},
+			})
+		}
+	}()
+}
+
+// newOrchestratorTestServer starts a fakeOrchestratorServer and returns
+// a dialled client registered for cleanup.
+// Uses os.TempDir() + short name to stay within the 104-char macOS socket-path limit.
+func newOrchestratorTestServer(t *testing.T, logSequence [][]cmux.LogEntry) *cmux.Client {
+	t.Helper()
+	socketPath := filepath.Join(os.TempDir(), fmt.Sprintf("co_%d_%s.sock", os.Getpid(), t.Name()[:min(len(t.Name()), 10)]))
+	_ = os.Remove(socketPath)
+	t.Cleanup(func() { os.Remove(socketPath) })
+	ln, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	fakeOrchestratorServer(t, ln, logSequence)
+
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// TestOrchestrator_DispatchAndWait dispatches two tasks and verifies that Wait
+// correctly resolves both tasks when the log sequence delivers their signals.
+//
+// logSequence:
+//   - poll 1: empty
+//   - poll 2: surf-1 DONE
+//   - poll 3: surf-1 DONE + surf-2 ERROR
+func TestOrchestrator_DispatchAndWait(t *testing.T) {
+	seq := [][]cmux.LogEntry{
+		// poll 1: empty
+		{},
+		// poll 2: surf-1 done
+		{
+			{Message: "[DONE] task finished", Level: "info", Source: "surf-1"},
+		},
+		// poll 3: surf-1 done + surf-2 error
+		{
+			{Message: "[DONE] task finished", Level: "info", Source: "surf-1"},
+			{Message: "[ERROR] task failed", Level: "error", Source: "surf-2"},
+		},
+	}
+
+	client := newOrchestratorTestServer(t, seq)
+	orch := cmux.NewOrchestrator(client)
+	orch.SetPollRate(50 * time.Millisecond)
+
+	task1, err := orch.Dispatch("right", "echo task1")
+	require.NoError(t, err)
+	assert.Equal(t, "surf-1", task1.SurfaceID)
+
+	task2, err := orch.Dispatch("down", "echo task2")
+	require.NoError(t, err)
+	assert.Equal(t, "surf-2", task2.SurfaceID)
+
+	results, err := orch.Wait(5 * time.Second)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	byID := make(map[string]cmux.Task, len(results))
+	for _, r := range results {
+		byID[r.SurfaceID] = r
+	}
+
+	assert.Equal(t, "done", byID["surf-1"].Status)
+	assert.Equal(t, "error", byID["surf-2"].Status)
+}
+
+// TestOrchestrator_Timeout verifies that Wait returns an error containing
+// "timeout" when no tasks complete within the deadline.
+func TestOrchestrator_Timeout(t *testing.T) {
+	// Always empty — tasks never complete.
+	seq := [][]cmux.LogEntry{
+		{},
+	}
+
+	client := newOrchestratorTestServer(t, seq)
+	orch := cmux.NewOrchestrator(client)
+	orch.SetPollRate(50 * time.Millisecond)
+
+	_, err := orch.Dispatch("right", "sleep 999")
+	require.NoError(t, err)
+
+	_, err = orch.Wait(200 * time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+}

--- a/internal/cmux/orchestrator_test.go
+++ b/internal/cmux/orchestrator_test.go
@@ -1,6 +1,7 @@
 package cmux_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -10,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestOrchestrator_DispatchAndWait dispatches two tasks and verifies that Wait
-// correctly resolves both tasks when the log sequence delivers their signals.
+// TestOrchestrator_DispatchAndWait dispatches one task and verifies that Wait
+// correctly resolves it when the log sequence delivers the completion signal.
 func TestOrchestrator_DispatchAndWait(t *testing.T) {
 	mc := cmuxtest.NewMockClient()
 	mc.SetResult("surface.split", cmux.Surface{ID: "surf-1", Type: "terminal"})
@@ -38,7 +39,7 @@ func TestOrchestrator_DispatchAndWait(t *testing.T) {
 	assert.Equal(t, "surface.send_text", calls[1].Method)
 	assert.Equal(t, "surface.send_key", calls[2].Method)
 
-	results, err := orch.Wait(5 * time.Second)
+	results, err := orch.Wait(context.Background(), 5*time.Second)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "done", results[0].Status)
@@ -76,7 +77,7 @@ func TestOrchestrator_DispatchMultiple(t *testing.T) {
 		},
 	})
 
-	results, err := orch.Wait(5 * time.Second)
+	results, err := orch.Wait(context.Background(), 5*time.Second)
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
@@ -104,7 +105,7 @@ func TestOrchestrator_Timeout(t *testing.T) {
 	_, err := orch.Dispatch("right", "sleep 999")
 	require.NoError(t, err)
 
-	_, err = orch.Wait(100 * time.Millisecond)
+	_, err = orch.Wait(context.Background(), 100*time.Millisecond)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timeout")
 }
@@ -127,7 +128,7 @@ func TestOrchestrator_WaitAny(t *testing.T) {
 	_, err := orch.Dispatch("right", "echo task1")
 	require.NoError(t, err)
 
-	task, err := orch.WaitAny(5 * time.Second)
+	task, err := orch.WaitAny(context.Background(), 5*time.Second)
 	require.NoError(t, err)
 	assert.Equal(t, "done", task.Status)
 }
@@ -198,9 +199,31 @@ func TestOrchestrator_WaitAnyTimeout(t *testing.T) {
 	_, err := orch.Dispatch("right", "sleep 999")
 	require.NoError(t, err)
 
-	_, err = orch.WaitAny(100 * time.Millisecond)
+	_, err = orch.WaitAny(context.Background(), 100*time.Millisecond)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timeout")
+}
+
+// TestOrchestrator_WaitContextCancelled verifies Wait returns on context cancellation.
+func TestOrchestrator_WaitContextCancelled(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.split", cmux.Surface{ID: "surf-1", Type: "terminal"})
+	mc.SetResult("surface.send_text", true)
+	mc.SetResult("surface.send_key", true)
+	mc.SetResult("sidebar-state", cmux.SidebarState{})
+
+	orch := cmux.NewOrchestrator(mc)
+	orch.SetPollRate(10 * time.Millisecond)
+
+	_, err := orch.Dispatch("right", "sleep 999")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err = orch.Wait(ctx, 5*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "canceled")
 }
 
 // TestOrchestrator_PollOKFalse verifies Wait returns an error when poll gets OK:false.
@@ -217,7 +240,7 @@ func TestOrchestrator_PollOKFalse(t *testing.T) {
 	_, err := orch.Dispatch("right", "echo task1")
 	require.NoError(t, err)
 
-	_, err = orch.Wait(5 * time.Second)
+	_, err = orch.Wait(context.Background(), 5*time.Second)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "poll")
 	assert.Contains(t, err.Error(), "sidebar unavailable")

--- a/internal/cmux/orchestrator_test.go
+++ b/internal/cmux/orchestrator_test.go
@@ -1,132 +1,80 @@
 package cmux_test
 
 import (
-	"fmt"
-	"net"
-	"os"
-	"path/filepath"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/julianshen/rubichan/internal/cmux"
+	"github.com/julianshen/rubichan/internal/cmux/cmuxtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// fakeOrchestratorServer handles split + send_text + send_key + sidebar-state
-// with a logSequence that returns different logs on each sidebar-state poll.
-//
-// Methods handled:
-//   - system.ping → {"pong": true}
-//   - system.identify → standard identity
-//   - surface.split → incrementing surface IDs ("surf-1", "surf-2", …)
-//   - surface.send_text, surface.send_key → true
-//   - sidebar-state → returns {"logs": logSequence[pollCount]} cycling through the sequence
-func fakeOrchestratorServer(t *testing.T, ln net.Listener, logSequence [][]cmux.LogEntry) {
-	t.Helper()
-
-	var splitCounter atomic.Int64
-	var pollCounter atomic.Int64
-
-	go func() {
-		for {
-			conn, err := ln.Accept()
-			if err != nil {
-				return // listener closed
-			}
-			go serveConn(t, conn, map[string]handlerFunc{
-				"system.ping": func(req jsonrpcRequest) interface{} {
-					return map[string]bool{"pong": true}
-				},
-				"system.identify": func(req jsonrpcRequest) interface{} {
-					return map[string]string{
-						"window_id":    "win-1",
-						"workspace_id": "ws-1",
-						"pane_id":      "pane-1",
-						"surface_id":   "surf-0",
-					}
-				},
-				"surface.split": func(req jsonrpcRequest) interface{} {
-					n := splitCounter.Add(1)
-					return map[string]string{
-						"id":   fmt.Sprintf("surf-%d", n),
-						"type": "terminal",
-					}
-				},
-				"surface.send_text": func(req jsonrpcRequest) interface{} {
-					return true
-				},
-				"surface.send_key": func(req jsonrpcRequest) interface{} {
-					return true
-				},
-				"sidebar-state": func(req jsonrpcRequest) interface{} {
-					idx := int(pollCounter.Add(1)) - 1
-					if idx >= len(logSequence) {
-						idx = len(logSequence) - 1
-					}
-					return map[string]interface{}{
-						"logs": logSequence[idx],
-					}
-				},
-			})
-		}
-	}()
-}
-
-// newOrchestratorTestServer starts a fakeOrchestratorServer and returns
-// a dialled client registered for cleanup.
-// Uses os.TempDir() + short name to stay within the 104-char macOS socket-path limit.
-func newOrchestratorTestServer(t *testing.T, logSequence [][]cmux.LogEntry) *cmux.Client {
-	t.Helper()
-	socketPath := filepath.Join(os.TempDir(), fmt.Sprintf("co_%d_%s.sock", os.Getpid(), t.Name()[:min(len(t.Name()), 10)]))
-	_ = os.Remove(socketPath)
-	t.Cleanup(func() { os.Remove(socketPath) })
-	ln, err := net.Listen("unix", socketPath)
-	require.NoError(t, err)
-	t.Cleanup(func() { ln.Close() })
-
-	fakeOrchestratorServer(t, ln, logSequence)
-
-	c, err := cmux.Dial(socketPath)
-	require.NoError(t, err)
-	t.Cleanup(func() { c.Close() })
-	return c
-}
-
 // TestOrchestrator_DispatchAndWait dispatches two tasks and verifies that Wait
 // correctly resolves both tasks when the log sequence delivers their signals.
-//
-// logSequence:
-//   - poll 1: empty
-//   - poll 2: surf-1 DONE
-//   - poll 3: surf-1 DONE + surf-2 ERROR
 func TestOrchestrator_DispatchAndWait(t *testing.T) {
-	seq := [][]cmux.LogEntry{
-		// poll 1: empty
-		{},
-		// poll 2: surf-1 done
-		{
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.split", cmux.Surface{ID: "surf-1", Type: "terminal"})
+	mc.SetResult("surface.send_text", true)
+	mc.SetResult("surface.send_key", true)
+	mc.SetResult("sidebar-state", cmux.SidebarState{
+		Logs: []cmux.LogEntry{
 			{Message: "[DONE] task finished", Level: "info", Source: "surf-1"},
 		},
-		// poll 3: surf-1 done + surf-2 error
-		{
-			{Message: "[DONE] task finished", Level: "info", Source: "surf-1"},
-			{Message: "[ERROR] task failed", Level: "error", Source: "surf-2"},
-		},
-	}
+	})
 
-	client := newOrchestratorTestServer(t, seq)
-	orch := cmux.NewOrchestrator(client)
-	orch.SetPollRate(50 * time.Millisecond)
+	orch := cmux.NewOrchestrator(mc)
+	orch.SetPollRate(10 * time.Millisecond)
 
 	task1, err := orch.Dispatch("right", "echo task1")
 	require.NoError(t, err)
 	assert.Equal(t, "surf-1", task1.SurfaceID)
+	assert.Equal(t, "running", task1.Status)
 
-	task2, err := orch.Dispatch("down", "echo task2")
+	// Verify the correct RPC calls were made.
+	calls := mc.Calls()
+	require.Len(t, calls, 3)
+	assert.Equal(t, "surface.split", calls[0].Method)
+	assert.Equal(t, "surface.send_text", calls[1].Method)
+	assert.Equal(t, "surface.send_key", calls[2].Method)
+
+	results, err := orch.Wait(5 * time.Second)
 	require.NoError(t, err)
-	assert.Equal(t, "surf-2", task2.SurfaceID)
+	require.Len(t, results, 1)
+	assert.Equal(t, "done", results[0].Status)
+	assert.Equal(t, "echo task1", results[0].Command)
+}
+
+// TestOrchestrator_DispatchMultiple verifies two tasks complete with different statuses.
+func TestOrchestrator_DispatchMultiple(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+
+	// MockClient returns the same result for repeated calls to the same method.
+	// We need the second split to return a different ID. Use a custom approach:
+	// set the result before each dispatch.
+	mc.SetResult("surface.send_text", true)
+	mc.SetResult("surface.send_key", true)
+
+	// First dispatch.
+	mc.SetResult("surface.split", cmux.Surface{ID: "surf-1", Type: "terminal"})
+	orch := cmux.NewOrchestrator(mc)
+	orch.SetPollRate(10 * time.Millisecond)
+
+	_, err := orch.Dispatch("right", "echo task1")
+	require.NoError(t, err)
+
+	// Second dispatch — change the surface ID result.
+	mc.SetResult("surface.split", cmux.Surface{ID: "surf-2", Type: "terminal"})
+	_, err = orch.Dispatch("down", "echo task2")
+	require.NoError(t, err)
+
+	// Both tasks complete.
+	mc.SetResult("sidebar-state", cmux.SidebarState{
+		Logs: []cmux.LogEntry{
+			{Message: "[DONE] task finished", Level: "info", Source: "surf-1"},
+			{Message: "[ERROR] task failed", Level: "error", Source: "surf-2"},
+		},
+	})
 
 	results, err := orch.Wait(5 * time.Second)
 	require.NoError(t, err)
@@ -136,7 +84,6 @@ func TestOrchestrator_DispatchAndWait(t *testing.T) {
 	for _, r := range results {
 		byID[r.SurfaceID] = r
 	}
-
 	assert.Equal(t, "done", byID["surf-1"].Status)
 	assert.Equal(t, "error", byID["surf-2"].Status)
 }
@@ -144,19 +91,55 @@ func TestOrchestrator_DispatchAndWait(t *testing.T) {
 // TestOrchestrator_Timeout verifies that Wait returns an error containing
 // "timeout" when no tasks complete within the deadline.
 func TestOrchestrator_Timeout(t *testing.T) {
-	// Always empty — tasks never complete.
-	seq := [][]cmux.LogEntry{
-		{},
-	}
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.split", cmux.Surface{ID: "surf-1", Type: "terminal"})
+	mc.SetResult("surface.send_text", true)
+	mc.SetResult("surface.send_key", true)
+	// Empty sidebar — tasks never complete.
+	mc.SetResult("sidebar-state", cmux.SidebarState{})
 
-	client := newOrchestratorTestServer(t, seq)
-	orch := cmux.NewOrchestrator(client)
-	orch.SetPollRate(50 * time.Millisecond)
+	orch := cmux.NewOrchestrator(mc)
+	orch.SetPollRate(10 * time.Millisecond)
 
 	_, err := orch.Dispatch("right", "sleep 999")
 	require.NoError(t, err)
 
-	_, err = orch.Wait(200 * time.Millisecond)
+	_, err = orch.Wait(100 * time.Millisecond)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timeout")
+}
+
+// TestOrchestrator_WaitAny returns the first completed task.
+func TestOrchestrator_WaitAny(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.split", cmux.Surface{ID: "surf-1", Type: "terminal"})
+	mc.SetResult("surface.send_text", true)
+	mc.SetResult("surface.send_key", true)
+	mc.SetResult("sidebar-state", cmux.SidebarState{
+		Logs: []cmux.LogEntry{
+			{Message: "[DONE] first done", Level: "info", Source: "surf-1"},
+		},
+	})
+
+	orch := cmux.NewOrchestrator(mc)
+	orch.SetPollRate(10 * time.Millisecond)
+
+	_, err := orch.Dispatch("right", "echo task1")
+	require.NoError(t, err)
+
+	task, err := orch.WaitAny(5 * time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "done", task.Status)
+}
+
+// TestOrchestrator_DispatchError verifies Dispatch handles split failures.
+func TestOrchestrator_DispatchError(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	// Set a result that cannot be decoded as Surface.
+	mc.SetResult("surface.split", "not-a-surface")
+
+	orch := cmux.NewOrchestrator(mc)
+	_, err := orch.Dispatch("right", "echo hello")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "orchestrator")
 }

--- a/internal/cmux/orchestrator_test.go
+++ b/internal/cmux/orchestrator_test.go
@@ -143,3 +143,82 @@ func TestOrchestrator_DispatchError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "orchestrator")
 }
+
+// TestOrchestrator_DispatchSplitOKFalse verifies Dispatch handles split returning OK:false.
+func TestOrchestrator_DispatchSplitOKFalse(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetError("surface.split", "no space left")
+
+	orch := cmux.NewOrchestrator(mc)
+	_, err := orch.Dispatch("right", "echo hello")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "split")
+	assert.Contains(t, err.Error(), "no space left")
+}
+
+// TestOrchestrator_DispatchSendTextOKFalse verifies Dispatch handles send_text OK:false.
+func TestOrchestrator_DispatchSendTextOKFalse(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.split", cmux.Surface{ID: "surf-1", Type: "terminal"})
+	mc.SetError("surface.send_text", "surface not found")
+	mc.SetResult("surface.send_key", true)
+
+	orch := cmux.NewOrchestrator(mc)
+	_, err := orch.Dispatch("right", "echo hello")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "send_text")
+	assert.Contains(t, err.Error(), "surface not found")
+}
+
+// TestOrchestrator_DispatchSendKeyOKFalse verifies Dispatch handles send_key OK:false.
+func TestOrchestrator_DispatchSendKeyOKFalse(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.split", cmux.Surface{ID: "surf-1", Type: "terminal"})
+	mc.SetResult("surface.send_text", true)
+	mc.SetError("surface.send_key", "key rejected")
+
+	orch := cmux.NewOrchestrator(mc)
+	_, err := orch.Dispatch("right", "echo hello")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "send_key")
+	assert.Contains(t, err.Error(), "key rejected")
+}
+
+// TestOrchestrator_WaitAnyTimeout verifies WaitAny returns a timeout error.
+func TestOrchestrator_WaitAnyTimeout(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.split", cmux.Surface{ID: "surf-1", Type: "terminal"})
+	mc.SetResult("surface.send_text", true)
+	mc.SetResult("surface.send_key", true)
+	mc.SetResult("sidebar-state", cmux.SidebarState{})
+
+	orch := cmux.NewOrchestrator(mc)
+	orch.SetPollRate(10 * time.Millisecond)
+
+	_, err := orch.Dispatch("right", "sleep 999")
+	require.NoError(t, err)
+
+	_, err = orch.WaitAny(100 * time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+}
+
+// TestOrchestrator_PollOKFalse verifies Wait returns an error when poll gets OK:false.
+func TestOrchestrator_PollOKFalse(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.split", cmux.Surface{ID: "surf-1", Type: "terminal"})
+	mc.SetResult("surface.send_text", true)
+	mc.SetResult("surface.send_key", true)
+	mc.SetError("sidebar-state", "sidebar unavailable")
+
+	orch := cmux.NewOrchestrator(mc)
+	orch.SetPollRate(10 * time.Millisecond)
+
+	_, err := orch.Dispatch("right", "echo task1")
+	require.NoError(t, err)
+
+	_, err = orch.Wait(5 * time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "poll")
+	assert.Contains(t, err.Error(), "sidebar unavailable")
+}

--- a/internal/cmux/sidebar.go
+++ b/internal/cmux/sidebar.go
@@ -1,7 +1,5 @@
 package cmux
 
-import "fmt"
-
 // SidebarState holds the current state of the cmux sidebar panel.
 type SidebarState struct {
 	CWD       string     `json:"cwd"`
@@ -35,100 +33,43 @@ type LogEntry struct {
 
 // SetStatus sets a named status entry in the sidebar.
 func (c *Client) SetStatus(key, value, icon, color string) error {
-	resp, err := c.Call("set-status", map[string]string{
-		"key":   key,
-		"value": value,
-		"icon":  icon,
-		"color": color,
+	return c.callVoid("set-status", map[string]string{
+		"key": key, "value": value, "icon": icon, "color": color,
 	})
-	if err != nil {
-		return fmt.Errorf("cmux: set-status: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: set-status: %s", resp.Error)
-	}
-	return nil
 }
 
 // ClearStatus removes the named status entry from the sidebar.
 func (c *Client) ClearStatus(key string) error {
-	resp, err := c.Call("clear-status", map[string]string{"key": key})
-	if err != nil {
-		return fmt.Errorf("cmux: clear-status: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: clear-status: %s", resp.Error)
-	}
-	return nil
+	return c.callVoid("clear-status", map[string]string{"key": key})
 }
 
 // SetProgress sets the sidebar progress indicator.
 func (c *Client) SetProgress(fraction float64, label string) error {
-	resp, err := c.Call("set-progress", map[string]any{
-		"value": fraction,
-		"label": label,
-	})
-	if err != nil {
-		return fmt.Errorf("cmux: set-progress: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: set-progress: %s", resp.Error)
-	}
-	return nil
+	return c.callVoid("set-progress", map[string]any{"value": fraction, "label": label})
 }
 
 // ClearProgress removes the sidebar progress indicator.
 func (c *Client) ClearProgress() error {
-	resp, err := c.Call("clear-progress", map[string]any{})
-	if err != nil {
-		return fmt.Errorf("cmux: clear-progress: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: clear-progress: %s", resp.Error)
-	}
-	return nil
+	return c.callVoid("clear-progress", map[string]any{})
 }
 
 // Log appends a message to the sidebar log section.
 func (c *Client) Log(message, level, source string) error {
-	resp, err := c.Call("log", map[string]string{
-		"message": message,
-		"level":   level,
-		"source":  source,
+	return c.callVoid("log", map[string]string{
+		"message": message, "level": level, "source": source,
 	})
-	if err != nil {
-		return fmt.Errorf("cmux: log: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: log: %s", resp.Error)
-	}
-	return nil
 }
 
 // ClearLog removes all entries from the sidebar log section.
 func (c *Client) ClearLog() error {
-	resp, err := c.Call("clear-log", map[string]any{})
-	if err != nil {
-		return fmt.Errorf("cmux: clear-log: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: clear-log: %s", resp.Error)
-	}
-	return nil
+	return c.callVoid("clear-log", map[string]any{})
 }
 
 // SidebarState retrieves the current state of the sidebar panel.
 func (c *Client) SidebarState() (*SidebarState, error) {
-	resp, err := c.Call("sidebar-state", map[string]any{})
-	if err != nil {
-		return nil, fmt.Errorf("cmux: sidebar-state: %w", err)
-	}
-	if !resp.OK {
-		return nil, fmt.Errorf("cmux: sidebar-state: %s", resp.Error)
-	}
 	var state SidebarState
-	if err := unmarshalResult(resp, &state); err != nil {
-		return nil, fmt.Errorf("cmux: decode sidebar-state: %w", err)
+	if err := c.callResult("sidebar-state", map[string]any{}, &state); err != nil {
+		return nil, err
 	}
 	return &state, nil
 }

--- a/internal/cmux/sidebar.go
+++ b/internal/cmux/sidebar.go
@@ -1,0 +1,134 @@
+package cmux
+
+import "fmt"
+
+// SidebarState holds the current state of the cmux sidebar panel.
+type SidebarState struct {
+	CWD       string     `json:"cwd"`
+	GitBranch string     `json:"git_branch"`
+	Ports     []int      `json:"ports"`
+	Status    []Status   `json:"status"`
+	Progress  *Progress  `json:"progress"`
+	Logs      []LogEntry `json:"logs"`
+}
+
+// Status is a named key/value pair shown in the sidebar status section.
+type Status struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Icon  string `json:"icon"`
+	Color string `json:"color"`
+}
+
+// Progress represents a progress indicator shown in the sidebar.
+type Progress struct {
+	Value float64 `json:"value"`
+	Label string  `json:"label"`
+}
+
+// LogEntry is a single log message shown in the sidebar log section.
+type LogEntry struct {
+	Message string `json:"message"`
+	Level   string `json:"level"`
+	Source  string `json:"source"`
+}
+
+// SetStatus sets a named status entry in the sidebar.
+func (c *Client) SetStatus(key, value, icon, color string) error {
+	resp, err := c.Call("set-status", map[string]string{
+		"key":   key,
+		"value": value,
+		"icon":  icon,
+		"color": color,
+	})
+	if err != nil {
+		return fmt.Errorf("cmux: set-status: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: set-status: %s", resp.Error)
+	}
+	return nil
+}
+
+// ClearStatus removes the named status entry from the sidebar.
+func (c *Client) ClearStatus(key string) error {
+	resp, err := c.Call("clear-status", map[string]string{"key": key})
+	if err != nil {
+		return fmt.Errorf("cmux: clear-status: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: clear-status: %s", resp.Error)
+	}
+	return nil
+}
+
+// SetProgress sets the sidebar progress indicator.
+func (c *Client) SetProgress(fraction float64, label string) error {
+	resp, err := c.Call("set-progress", map[string]any{
+		"value": fraction,
+		"label": label,
+	})
+	if err != nil {
+		return fmt.Errorf("cmux: set-progress: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: set-progress: %s", resp.Error)
+	}
+	return nil
+}
+
+// ClearProgress removes the sidebar progress indicator.
+func (c *Client) ClearProgress() error {
+	resp, err := c.Call("clear-progress", map[string]any{})
+	if err != nil {
+		return fmt.Errorf("cmux: clear-progress: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: clear-progress: %s", resp.Error)
+	}
+	return nil
+}
+
+// Log appends a message to the sidebar log section.
+func (c *Client) Log(message, level, source string) error {
+	resp, err := c.Call("log", map[string]string{
+		"message": message,
+		"level":   level,
+		"source":  source,
+	})
+	if err != nil {
+		return fmt.Errorf("cmux: log: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: log: %s", resp.Error)
+	}
+	return nil
+}
+
+// ClearLog removes all entries from the sidebar log section.
+func (c *Client) ClearLog() error {
+	resp, err := c.Call("clear-log", map[string]any{})
+	if err != nil {
+		return fmt.Errorf("cmux: clear-log: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: clear-log: %s", resp.Error)
+	}
+	return nil
+}
+
+// SidebarState retrieves the current state of the sidebar panel.
+func (c *Client) SidebarState() (*SidebarState, error) {
+	resp, err := c.Call("sidebar-state", map[string]any{})
+	if err != nil {
+		return nil, fmt.Errorf("cmux: sidebar-state: %w", err)
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("cmux: sidebar-state: %s", resp.Error)
+	}
+	var state SidebarState
+	if err := unmarshalResult(resp, &state); err != nil {
+		return nil, fmt.Errorf("cmux: decode sidebar-state: %w", err)
+	}
+	return &state, nil
+}

--- a/internal/cmux/sidebar_test.go
+++ b/internal/cmux/sidebar_test.go
@@ -139,6 +139,30 @@ func TestClearLog(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestSetStatusError verifies SetStatus returns an error when the server responds with OK:false.
+func TestSetStatusError(t *testing.T) {
+	socketPath := newErrorServer(t, "set-status")
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.SetStatus("build", "fail", "✗", "red")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "set-status")
+}
+
+// TestSidebarStateError verifies SidebarState returns an error when the server responds with OK:false.
+func TestSidebarStateError(t *testing.T) {
+	socketPath := newErrorServer(t, "sidebar-state")
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = c.SidebarState()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sidebar-state")
+}
+
 func TestSidebarState(t *testing.T) {
 	handlers := defaultHandlers()
 	handlers["sidebar-state"] = func(req jsonrpcRequest) interface{} {

--- a/internal/cmux/sidebar_test.go
+++ b/internal/cmux/sidebar_test.go
@@ -1,0 +1,175 @@
+package cmux_test
+
+import (
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetStatus(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedKey, capturedValue, capturedIcon, capturedColor string
+	handlers["set-status"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			Key   string `json:"key"`
+			Value string `json:"value"`
+			Icon  string `json:"icon"`
+			Color string `json:"color"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedKey = p.Key
+		capturedValue = p.Value
+		capturedIcon = p.Icon
+		capturedColor = p.Color
+		return map[string]string{"ok": "true"}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.SetStatus("build", "passing", "✓", "green")
+	require.NoError(t, err)
+	assert.Equal(t, "build", capturedKey)
+	assert.Equal(t, "passing", capturedValue)
+	assert.Equal(t, "✓", capturedIcon)
+	assert.Equal(t, "green", capturedColor)
+}
+
+func TestClearStatus(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedKey string
+	handlers["clear-status"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			Key string `json:"key"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedKey = p.Key
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.ClearStatus("build")
+	require.NoError(t, err)
+	assert.Equal(t, "build", capturedKey)
+}
+
+func TestSetProgress(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedFraction float64
+	var capturedLabel string
+	handlers["set-progress"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			Value float64 `json:"value"`
+			Label string  `json:"label"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedFraction = p.Value
+		capturedLabel = p.Label
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.SetProgress(0.75, "Building…")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.75, capturedFraction, 0.001)
+	assert.Equal(t, "Building…", capturedLabel)
+}
+
+func TestClearProgress(t *testing.T) {
+	handlers := defaultHandlers()
+	handlers["clear-progress"] = func(req jsonrpcRequest) interface{} {
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.ClearProgress()
+	require.NoError(t, err)
+}
+
+func TestLog(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedMsg, capturedLevel, capturedSource string
+	handlers["log"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			Message string `json:"message"`
+			Level   string `json:"level"`
+			Source  string `json:"source"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedMsg = p.Message
+		capturedLevel = p.Level
+		capturedSource = p.Source
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.Log("build succeeded", "info", "agent")
+	require.NoError(t, err)
+	assert.Equal(t, "build succeeded", capturedMsg)
+	assert.Equal(t, "info", capturedLevel)
+	assert.Equal(t, "agent", capturedSource)
+}
+
+func TestClearLog(t *testing.T) {
+	handlers := defaultHandlers()
+	handlers["clear-log"] = func(req jsonrpcRequest) interface{} {
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.ClearLog()
+	require.NoError(t, err)
+}
+
+func TestSidebarState(t *testing.T) {
+	handlers := defaultHandlers()
+	handlers["sidebar-state"] = func(req jsonrpcRequest) interface{} {
+		return map[string]interface{}{
+			"cwd":        "/home/user/project",
+			"git_branch": "main",
+			"ports":      []int{8080, 9090},
+			"status": []map[string]string{
+				{"key": "ci", "value": "pass", "icon": "✓", "color": "green"},
+			},
+			"progress": map[string]interface{}{"value": 0.5, "label": "half"},
+			"logs": []map[string]string{
+				{"message": "done", "level": "info", "source": "agent"},
+			},
+		}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	state, err := c.SidebarState()
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, "/home/user/project", state.CWD)
+	assert.Equal(t, "main", state.GitBranch)
+	assert.Equal(t, []int{8080, 9090}, state.Ports)
+	require.Len(t, state.Status, 1)
+	assert.Equal(t, "ci", state.Status[0].Key)
+	require.NotNil(t, state.Progress)
+	assert.InDelta(t, 0.5, state.Progress.Value, 0.001)
+	require.Len(t, state.Logs, 1)
+	assert.Equal(t, "done", state.Logs[0].Message)
+}

--- a/internal/cmux/surface.go
+++ b/internal/cmux/surface.go
@@ -1,0 +1,85 @@
+package cmux
+
+import "fmt"
+
+// Surface represents a cmux surface (pane, browser, etc.).
+type Surface struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+// Split creates a new surface by splitting in the given direction.
+func (c *Client) Split(direction string) (*Surface, error) {
+	resp, err := c.Call("surface.split", map[string]string{"direction": direction})
+	if err != nil {
+		return nil, fmt.Errorf("cmux: surface.split: %w", err)
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("cmux: surface.split: %s", resp.Error)
+	}
+	var surf Surface
+	if err := unmarshalResult(resp, &surf); err != nil {
+		return nil, fmt.Errorf("cmux: decode surface: %w", err)
+	}
+	return &surf, nil
+}
+
+// ListSurfaces retrieves all surfaces from cmux.
+func (c *Client) ListSurfaces() ([]Surface, error) {
+	resp, err := c.Call("surface.list", map[string]any{})
+	if err != nil {
+		return nil, fmt.Errorf("cmux: surface.list: %w", err)
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("cmux: surface.list: %s", resp.Error)
+	}
+	var result struct {
+		Surfaces []Surface `json:"surfaces"`
+	}
+	if err := unmarshalResult(resp, &result); err != nil {
+		return nil, fmt.Errorf("cmux: decode surfaces: %w", err)
+	}
+	return result.Surfaces, nil
+}
+
+// FocusSurface focuses the surface with the given id.
+func (c *Client) FocusSurface(id string) error {
+	resp, err := c.Call("surface.focus", map[string]string{"surface_id": id})
+	if err != nil {
+		return fmt.Errorf("cmux: surface.focus: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: surface.focus: %s", resp.Error)
+	}
+	return nil
+}
+
+// SendText sends text input to the surface with the given id.
+func (c *Client) SendText(surfaceID, text string) error {
+	resp, err := c.Call("surface.send_text", map[string]string{
+		"surface_id": surfaceID,
+		"text":       text,
+	})
+	if err != nil {
+		return fmt.Errorf("cmux: surface.send_text: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: surface.send_text: %s", resp.Error)
+	}
+	return nil
+}
+
+// SendKey sends a key event to the surface with the given id.
+func (c *Client) SendKey(surfaceID, key string) error {
+	resp, err := c.Call("surface.send_key", map[string]string{
+		"surface_id": surfaceID,
+		"key":        key,
+	})
+	if err != nil {
+		return fmt.Errorf("cmux: surface.send_key: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: surface.send_key: %s", resp.Error)
+	}
+	return nil
+}

--- a/internal/cmux/surface.go
+++ b/internal/cmux/surface.go
@@ -1,7 +1,5 @@
 package cmux
 
-import "fmt"
-
 // Surface represents a cmux surface (pane, browser, etc.).
 type Surface struct {
 	ID   string `json:"id"`
@@ -10,76 +8,39 @@ type Surface struct {
 
 // Split creates a new surface by splitting in the given direction.
 func (c *Client) Split(direction string) (*Surface, error) {
-	resp, err := c.Call("surface.split", map[string]string{"direction": direction})
-	if err != nil {
-		return nil, fmt.Errorf("cmux: surface.split: %w", err)
-	}
-	if !resp.OK {
-		return nil, fmt.Errorf("cmux: surface.split: %s", resp.Error)
-	}
 	var surf Surface
-	if err := unmarshalResult(resp, &surf); err != nil {
-		return nil, fmt.Errorf("cmux: decode surface: %w", err)
+	if err := c.callResult("surface.split", map[string]string{"direction": direction}, &surf); err != nil {
+		return nil, err
 	}
 	return &surf, nil
 }
 
 // ListSurfaces retrieves all surfaces from cmux.
 func (c *Client) ListSurfaces() ([]Surface, error) {
-	resp, err := c.Call("surface.list", map[string]any{})
-	if err != nil {
-		return nil, fmt.Errorf("cmux: surface.list: %w", err)
-	}
-	if !resp.OK {
-		return nil, fmt.Errorf("cmux: surface.list: %s", resp.Error)
-	}
 	var result struct {
 		Surfaces []Surface `json:"surfaces"`
 	}
-	if err := unmarshalResult(resp, &result); err != nil {
-		return nil, fmt.Errorf("cmux: decode surfaces: %w", err)
+	if err := c.callResult("surface.list", map[string]any{}, &result); err != nil {
+		return nil, err
 	}
 	return result.Surfaces, nil
 }
 
 // FocusSurface focuses the surface with the given id.
 func (c *Client) FocusSurface(id string) error {
-	resp, err := c.Call("surface.focus", map[string]string{"surface_id": id})
-	if err != nil {
-		return fmt.Errorf("cmux: surface.focus: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: surface.focus: %s", resp.Error)
-	}
-	return nil
+	return c.callVoid("surface.focus", map[string]string{"surface_id": id})
 }
 
 // SendText sends text input to the surface with the given id.
 func (c *Client) SendText(surfaceID, text string) error {
-	resp, err := c.Call("surface.send_text", map[string]string{
-		"surface_id": surfaceID,
-		"text":       text,
+	return c.callVoid("surface.send_text", map[string]string{
+		"surface_id": surfaceID, "text": text,
 	})
-	if err != nil {
-		return fmt.Errorf("cmux: surface.send_text: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: surface.send_text: %s", resp.Error)
-	}
-	return nil
 }
 
 // SendKey sends a key event to the surface with the given id.
 func (c *Client) SendKey(surfaceID, key string) error {
-	resp, err := c.Call("surface.send_key", map[string]string{
-		"surface_id": surfaceID,
-		"key":        key,
+	return c.callVoid("surface.send_key", map[string]string{
+		"surface_id": surfaceID, "key": key,
 	})
-	if err != nil {
-		return fmt.Errorf("cmux: surface.send_key: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: surface.send_key: %s", resp.Error)
-	}
-	return nil
 }

--- a/internal/cmux/surface_test.go
+++ b/internal/cmux/surface_test.go
@@ -56,6 +56,28 @@ func TestListSurfaces(t *testing.T) {
 	assert.Equal(t, "browser", surfaces[1].Type)
 }
 
+func TestSplitError(t *testing.T) {
+	socketPath := newErrorServer(t, "surface.split")
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = c.Split("right")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "surface.split")
+}
+
+func TestListSurfacesError(t *testing.T) {
+	socketPath := newErrorServer(t, "surface.list")
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = c.ListSurfaces()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "surface.list")
+}
+
 func TestFocusSurface(t *testing.T) {
 	handlers := defaultHandlers()
 	var capturedID string

--- a/internal/cmux/surface_test.go
+++ b/internal/cmux/surface_test.go
@@ -1,0 +1,126 @@
+package cmux_test
+
+import (
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplit(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedDirection string
+	handlers["surface.split"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			Direction string `json:"direction"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedDirection = p.Direction
+		return map[string]string{"id": "surf-new", "type": "pane"}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	surf, err := c.Split("horizontal")
+	require.NoError(t, err)
+	require.NotNil(t, surf)
+	assert.Equal(t, "surf-new", surf.ID)
+	assert.Equal(t, "pane", surf.Type)
+	assert.Equal(t, "horizontal", capturedDirection)
+}
+
+func TestListSurfaces(t *testing.T) {
+	handlers := defaultHandlers()
+	handlers["surface.list"] = func(req jsonrpcRequest) interface{} {
+		return map[string]interface{}{
+			"surfaces": []map[string]string{
+				{"id": "surf-1", "type": "pane"},
+				{"id": "surf-2", "type": "browser"},
+			},
+		}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	surfaces, err := c.ListSurfaces()
+	require.NoError(t, err)
+	require.Len(t, surfaces, 2)
+	assert.Equal(t, "surf-1", surfaces[0].ID)
+	assert.Equal(t, "pane", surfaces[0].Type)
+	assert.Equal(t, "surf-2", surfaces[1].ID)
+	assert.Equal(t, "browser", surfaces[1].Type)
+}
+
+func TestFocusSurface(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedID string
+	handlers["surface.focus"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			SurfaceID string `json:"surface_id"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedID = p.SurfaceID
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.FocusSurface("surf-3")
+	require.NoError(t, err)
+	assert.Equal(t, "surf-3", capturedID)
+}
+
+func TestSendText(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedSurfaceID, capturedText string
+	handlers["surface.send_text"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			SurfaceID string `json:"surface_id"`
+			Text      string `json:"text"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedSurfaceID = p.SurfaceID
+		capturedText = p.Text
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.SendText("surf-3", "hello world")
+	require.NoError(t, err)
+	assert.Equal(t, "surf-3", capturedSurfaceID)
+	assert.Equal(t, "hello world", capturedText)
+}
+
+func TestSendKey(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedSurfaceID, capturedKey string
+	handlers["surface.send_key"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			SurfaceID string `json:"surface_id"`
+			Key       string `json:"key"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedSurfaceID = p.SurfaceID
+		capturedKey = p.Key
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.SendKey("surf-3", "ctrl+c")
+	require.NoError(t, err)
+	assert.Equal(t, "surf-3", capturedSurfaceID)
+	assert.Equal(t, "ctrl+c", capturedKey)
+}

--- a/internal/cmux/testhelpers_test.go
+++ b/internal/cmux/testhelpers_test.go
@@ -1,8 +1,59 @@
 package cmux_test
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 // unmarshalParams decodes a jsonrpcRequest's Params into dst.
 func unmarshalParams(req jsonrpcRequest, dst any) error {
 	return json.Unmarshal(req.Params, dst)
+}
+
+// newErrorServer creates a fake cmux server that accepts Dial (ping+identify)
+// but returns OK:false for errorMethod. All other methods return OK:true with
+// an empty result.
+func newErrorServer(t *testing.T, errorMethod string) string {
+	t.Helper()
+	socketPath := t.TempDir() + "/cmux_err.sock"
+	ln, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err2 := ln.Accept()
+			if err2 != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				dec := json.NewDecoder(c)
+				enc := json.NewEncoder(c)
+				for {
+					var req jsonrpcRequest
+					if err3 := dec.Decode(&req); err3 != nil {
+						return
+					}
+					switch {
+					case req.Method == "system.ping":
+						resultBytes, _ := json.Marshal(map[string]string{"pong": "ok"})
+						_ = enc.Encode(map[string]interface{}{"id": req.ID, "ok": true, "result": json.RawMessage(resultBytes)})
+					case req.Method == "system.identify":
+						resultBytes, _ := json.Marshal(map[string]string{"window_id": "w", "workspace_id": "ws", "pane_id": "p", "surface_id": "s"})
+						_ = enc.Encode(map[string]interface{}{"id": req.ID, "ok": true, "result": json.RawMessage(resultBytes)})
+					case req.Method == errorMethod:
+						_ = enc.Encode(map[string]interface{}{"id": req.ID, "ok": false, "error": errorMethod + " failed"})
+					default:
+						resultBytes, _ := json.Marshal(map[string]interface{}{})
+						_ = enc.Encode(map[string]interface{}{"id": req.ID, "ok": true, "result": json.RawMessage(resultBytes)})
+					}
+				}
+			}(conn)
+		}
+	}()
+	return socketPath
 }

--- a/internal/cmux/testhelpers_test.go
+++ b/internal/cmux/testhelpers_test.go
@@ -1,0 +1,8 @@
+package cmux_test
+
+import "encoding/json"
+
+// unmarshalParams decodes a jsonrpcRequest's Params into dst.
+func unmarshalParams(req jsonrpcRequest, dst any) error {
+	return json.Unmarshal(req.Params, dst)
+}

--- a/internal/cmux/workspace.go
+++ b/internal/cmux/workspace.go
@@ -1,0 +1,83 @@
+package cmux
+
+import "fmt"
+
+// Workspace represents a cmux workspace.
+type Workspace struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// ListWorkspaces retrieves all workspaces from cmux.
+func (c *Client) ListWorkspaces() ([]Workspace, error) {
+	resp, err := c.Call("workspace.list", map[string]any{})
+	if err != nil {
+		return nil, fmt.Errorf("cmux: workspace.list: %w", err)
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("cmux: workspace.list: %s", resp.Error)
+	}
+	var result struct {
+		Workspaces []Workspace `json:"workspaces"`
+	}
+	if err := unmarshalResult(resp, &result); err != nil {
+		return nil, fmt.Errorf("cmux: decode workspaces: %w", err)
+	}
+	return result.Workspaces, nil
+}
+
+// CreateWorkspace creates a new workspace in cmux.
+func (c *Client) CreateWorkspace() (*Workspace, error) {
+	resp, err := c.Call("workspace.create", map[string]any{})
+	if err != nil {
+		return nil, fmt.Errorf("cmux: workspace.create: %w", err)
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("cmux: workspace.create: %s", resp.Error)
+	}
+	var ws Workspace
+	if err := unmarshalResult(resp, &ws); err != nil {
+		return nil, fmt.Errorf("cmux: decode workspace: %w", err)
+	}
+	return &ws, nil
+}
+
+// SelectWorkspace switches cmux to the workspace with the given id.
+func (c *Client) SelectWorkspace(id string) error {
+	resp, err := c.Call("workspace.select", map[string]string{"workspace_id": id})
+	if err != nil {
+		return fmt.Errorf("cmux: workspace.select: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: workspace.select: %s", resp.Error)
+	}
+	return nil
+}
+
+// CurrentWorkspace retrieves the currently active workspace.
+func (c *Client) CurrentWorkspace() (*Workspace, error) {
+	resp, err := c.Call("workspace.current", map[string]any{})
+	if err != nil {
+		return nil, fmt.Errorf("cmux: workspace.current: %w", err)
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("cmux: workspace.current: %s", resp.Error)
+	}
+	var ws Workspace
+	if err := unmarshalResult(resp, &ws); err != nil {
+		return nil, fmt.Errorf("cmux: decode workspace: %w", err)
+	}
+	return &ws, nil
+}
+
+// CloseWorkspace closes the workspace with the given id.
+func (c *Client) CloseWorkspace(id string) error {
+	resp, err := c.Call("workspace.close", map[string]string{"workspace_id": id})
+	if err != nil {
+		return fmt.Errorf("cmux: workspace.close: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("cmux: workspace.close: %s", resp.Error)
+	}
+	return nil
+}

--- a/internal/cmux/workspace.go
+++ b/internal/cmux/workspace.go
@@ -1,7 +1,5 @@
 package cmux
 
-import "fmt"
-
 // Workspace represents a cmux workspace.
 type Workspace struct {
 	ID   string `json:"id"`
@@ -10,74 +8,39 @@ type Workspace struct {
 
 // ListWorkspaces retrieves all workspaces from cmux.
 func (c *Client) ListWorkspaces() ([]Workspace, error) {
-	resp, err := c.Call("workspace.list", map[string]any{})
-	if err != nil {
-		return nil, fmt.Errorf("cmux: workspace.list: %w", err)
-	}
-	if !resp.OK {
-		return nil, fmt.Errorf("cmux: workspace.list: %s", resp.Error)
-	}
 	var result struct {
 		Workspaces []Workspace `json:"workspaces"`
 	}
-	if err := unmarshalResult(resp, &result); err != nil {
-		return nil, fmt.Errorf("cmux: decode workspaces: %w", err)
+	if err := c.callResult("workspace.list", map[string]any{}, &result); err != nil {
+		return nil, err
 	}
 	return result.Workspaces, nil
 }
 
 // CreateWorkspace creates a new workspace in cmux.
 func (c *Client) CreateWorkspace() (*Workspace, error) {
-	resp, err := c.Call("workspace.create", map[string]any{})
-	if err != nil {
-		return nil, fmt.Errorf("cmux: workspace.create: %w", err)
-	}
-	if !resp.OK {
-		return nil, fmt.Errorf("cmux: workspace.create: %s", resp.Error)
-	}
 	var ws Workspace
-	if err := unmarshalResult(resp, &ws); err != nil {
-		return nil, fmt.Errorf("cmux: decode workspace: %w", err)
+	if err := c.callResult("workspace.create", map[string]any{}, &ws); err != nil {
+		return nil, err
 	}
 	return &ws, nil
 }
 
 // SelectWorkspace switches cmux to the workspace with the given id.
 func (c *Client) SelectWorkspace(id string) error {
-	resp, err := c.Call("workspace.select", map[string]string{"workspace_id": id})
-	if err != nil {
-		return fmt.Errorf("cmux: workspace.select: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: workspace.select: %s", resp.Error)
-	}
-	return nil
+	return c.callVoid("workspace.select", map[string]string{"workspace_id": id})
 }
 
 // CurrentWorkspace retrieves the currently active workspace.
 func (c *Client) CurrentWorkspace() (*Workspace, error) {
-	resp, err := c.Call("workspace.current", map[string]any{})
-	if err != nil {
-		return nil, fmt.Errorf("cmux: workspace.current: %w", err)
-	}
-	if !resp.OK {
-		return nil, fmt.Errorf("cmux: workspace.current: %s", resp.Error)
-	}
 	var ws Workspace
-	if err := unmarshalResult(resp, &ws); err != nil {
-		return nil, fmt.Errorf("cmux: decode workspace: %w", err)
+	if err := c.callResult("workspace.current", map[string]any{}, &ws); err != nil {
+		return nil, err
 	}
 	return &ws, nil
 }
 
 // CloseWorkspace closes the workspace with the given id.
 func (c *Client) CloseWorkspace(id string) error {
-	resp, err := c.Call("workspace.close", map[string]string{"workspace_id": id})
-	if err != nil {
-		return fmt.Errorf("cmux: workspace.close: %w", err)
-	}
-	if !resp.OK {
-		return fmt.Errorf("cmux: workspace.close: %s", resp.Error)
-	}
-	return nil
+	return c.callVoid("workspace.close", map[string]string{"workspace_id": id})
 }

--- a/internal/cmux/workspace_test.go
+++ b/internal/cmux/workspace_test.go
@@ -1,0 +1,109 @@
+package cmux_test
+
+import (
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListWorkspaces(t *testing.T) {
+	handlers := defaultHandlers()
+	handlers["workspace.list"] = func(req jsonrpcRequest) interface{} {
+		return map[string]interface{}{
+			"workspaces": []map[string]string{
+				{"id": "ws-1", "name": "alpha"},
+				{"id": "ws-2", "name": "beta"},
+			},
+		}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	workspaces, err := c.ListWorkspaces()
+	require.NoError(t, err)
+	require.Len(t, workspaces, 2)
+	assert.Equal(t, "ws-1", workspaces[0].ID)
+	assert.Equal(t, "alpha", workspaces[0].Name)
+	assert.Equal(t, "ws-2", workspaces[1].ID)
+	assert.Equal(t, "beta", workspaces[1].Name)
+}
+
+func TestCreateWorkspace(t *testing.T) {
+	handlers := defaultHandlers()
+	handlers["workspace.create"] = func(req jsonrpcRequest) interface{} {
+		return map[string]string{"id": "ws-new", "name": "new-workspace"}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	ws, err := c.CreateWorkspace()
+	require.NoError(t, err)
+	require.NotNil(t, ws)
+	assert.Equal(t, "ws-new", ws.ID)
+	assert.Equal(t, "new-workspace", ws.Name)
+}
+
+func TestSelectWorkspace(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedID string
+	handlers["workspace.select"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			WorkspaceID string `json:"workspace_id"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedID = p.WorkspaceID
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.SelectWorkspace("ws-42")
+	require.NoError(t, err)
+	assert.Equal(t, "ws-42", capturedID)
+}
+
+func TestCurrentWorkspace(t *testing.T) {
+	handlers := defaultHandlers()
+	handlers["workspace.current"] = func(req jsonrpcRequest) interface{} {
+		return map[string]string{"id": "ws-42", "name": "current"}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	ws, err := c.CurrentWorkspace()
+	require.NoError(t, err)
+	require.NotNil(t, ws)
+	assert.Equal(t, "ws-42", ws.ID)
+	assert.Equal(t, "current", ws.Name)
+}
+
+func TestCloseWorkspace(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedID string
+	handlers["workspace.close"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			WorkspaceID string `json:"workspace_id"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedID = p.WorkspaceID
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.CloseWorkspace("ws-42")
+	require.NoError(t, err)
+	assert.Equal(t, "ws-42", capturedID)
+}

--- a/internal/cmux/workspace_test.go
+++ b/internal/cmux/workspace_test.go
@@ -87,6 +87,39 @@ func TestCurrentWorkspace(t *testing.T) {
 	assert.Equal(t, "current", ws.Name)
 }
 
+func TestListWorkspacesError(t *testing.T) {
+	socketPath := newErrorServer(t, "workspace.list")
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = c.ListWorkspaces()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workspace.list")
+}
+
+func TestCreateWorkspaceError(t *testing.T) {
+	socketPath := newErrorServer(t, "workspace.create")
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = c.CreateWorkspace()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workspace.create")
+}
+
+func TestCurrentWorkspaceError(t *testing.T) {
+	socketPath := newErrorServer(t, "workspace.current")
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = c.CurrentWorkspace()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workspace.current")
+}
+
 func TestCloseWorkspace(t *testing.T) {
 	handlers := defaultHandlers()
 	var capturedID string

--- a/internal/terminal/caps.go
+++ b/internal/terminal/caps.go
@@ -154,7 +154,9 @@ func pingCmuxSocket(socketPath string) bool {
 		return false
 	}
 	defer conn.Close()
-	conn.SetDeadline(time.Now().Add(500 * time.Millisecond)) //nolint:errcheck
+	if err := conn.SetDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
+		return false
+	}
 	enc := json.NewEncoder(conn)
 	dec := json.NewDecoder(conn)
 	if err := enc.Encode(map[string]any{

--- a/internal/terminal/caps.go
+++ b/internal/terminal/caps.go
@@ -1,6 +1,11 @@
 package terminal
 
-import "os"
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"time"
+)
 
 // Caps represents what the host terminal supports.
 type Caps struct {
@@ -14,6 +19,7 @@ type Caps struct {
 	ClipboardAccess bool // OSC 52
 	FocusEvents     bool // Mode 1004
 	DarkBackground  bool // detected via OSC 11 query (defaults true)
+	CmuxSocket      bool // cmux Unix socket API available
 }
 
 var knownTerminals = map[string]Caps{
@@ -111,10 +117,12 @@ func DetectWithEnv(termProgram string, prober Prober) *Caps {
 				caps.DarkBackground = isDark
 			}
 		}
+		caps.CmuxSocket = detectCmuxSocket()
 		return caps
 	}
 
 	if prober == nil {
+		caps.CmuxSocket = detectCmuxSocket()
 		return caps
 	}
 
@@ -124,6 +132,41 @@ func DetectWithEnv(termProgram string, prober Prober) *Caps {
 	}
 	caps.SyncRendering = prober.ProbeSyncRendering()
 	caps.KittyKeyboard = prober.ProbeKittyKeyboard()
+	caps.CmuxSocket = detectCmuxSocket()
 
 	return caps
+}
+
+func detectCmuxSocket() bool {
+	if os.Getenv("CMUX_WORKSPACE_ID") == "" {
+		return false
+	}
+	socketPath := os.Getenv("CMUX_SOCKET_PATH")
+	if socketPath == "" {
+		socketPath = "/tmp/cmux.sock"
+	}
+	return pingCmuxSocket(socketPath)
+}
+
+func pingCmuxSocket(socketPath string) bool {
+	conn, err := net.DialTimeout("unix", socketPath, 500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(500 * time.Millisecond)) //nolint:errcheck
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+	if err := enc.Encode(map[string]any{
+		"id": "detect-1", "method": "system.ping", "params": struct{}{},
+	}); err != nil {
+		return false
+	}
+	var resp struct {
+		OK bool `json:"ok"`
+	}
+	if err := dec.Decode(&resp); err != nil {
+		return false
+	}
+	return resp.OK
 }

--- a/internal/terminal/caps_test.go
+++ b/internal/terminal/caps_test.go
@@ -1,9 +1,14 @@
 package terminal
 
 import (
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDetectWithEnv_Ghostty(t *testing.T) {
@@ -53,4 +58,50 @@ func TestDetectWithEnv_EmptyTermProgram(t *testing.T) {
 	caps := DetectWithEnv("", nil)
 	assert.False(t, caps.Hyperlinks)
 	assert.False(t, caps.KittyGraphics)
+}
+
+func TestDetectWithEnv_CmuxSocket_Detected(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "ws-123")
+	// Create fake cmux socket that responds to system.ping.
+	// Use os.MkdirTemp with a short prefix to stay within the Unix socket
+	// path limit of 104 characters on macOS.
+	dir, err := os.MkdirTemp("", "cmux")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	sock := filepath.Join(dir, "cmux.sock")
+	ln, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		dec := json.NewDecoder(conn)
+		enc := json.NewEncoder(conn)
+		for {
+			var req map[string]any
+			if err := dec.Decode(&req); err != nil {
+				return
+			}
+			enc.Encode(map[string]any{"id": req["id"], "ok": true, "result": map[string]bool{"pong": true}}) //nolint:errcheck
+		}
+	}()
+	t.Setenv("CMUX_SOCKET_PATH", sock)
+	caps := DetectWithEnv("ghostty", nil)
+	assert.True(t, caps.CmuxSocket)
+}
+
+func TestDetectWithEnv_CmuxSocket_NoEnvVar(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "")
+	caps := DetectWithEnv("ghostty", nil)
+	assert.False(t, caps.CmuxSocket)
+}
+
+func TestDetectWithEnv_CmuxSocket_BadSocket(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "ws-123")
+	t.Setenv("CMUX_SOCKET_PATH", "/nonexistent/cmux.sock")
+	caps := DetectWithEnv("ghostty", nil)
+	assert.False(t, caps.CmuxSocket)
 }

--- a/internal/tools/cmux_browser.go
+++ b/internal/tools/cmux_browser.go
@@ -1,0 +1,357 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+)
+
+// CmuxBrowserNavigateTool navigates a browser surface to a URL.
+// If no surface_id is provided it auto-creates a right split first.
+type CmuxBrowserNavigateTool struct {
+	client cmux.Caller
+}
+
+// NewCmuxBrowserNavigate creates a CmuxBrowserNavigateTool backed by client.
+func NewCmuxBrowserNavigate(client cmux.Caller) *CmuxBrowserNavigateTool {
+	return &CmuxBrowserNavigateTool{client: client}
+}
+
+func (t *CmuxBrowserNavigateTool) Name() string { return "cmux_browser_navigate" }
+
+func (t *CmuxBrowserNavigateTool) Description() string {
+	return "Navigate a browser surface to a URL. If no surface_id is given, " +
+		"auto-creates a right split, then navigates and waits for load."
+}
+
+func (t *CmuxBrowserNavigateTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"url": {
+				"type": "string",
+				"description": "The URL to navigate to"
+			},
+			"surface_id": {
+				"type": "string",
+				"description": "Target surface ID. If omitted, a new right split is created."
+			}
+		},
+		"required": ["url"]
+	}`)
+}
+
+type browserNavigateInput struct {
+	URL       string `json:"url"`
+	SurfaceID string `json:"surface_id"`
+}
+
+func (t *CmuxBrowserNavigateTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in browserNavigateInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+	if in.URL == "" {
+		return ToolResult{Content: "url is required", IsError: true}, nil
+	}
+
+	surfaceID := in.SurfaceID
+	if surfaceID == "" {
+		resp, err := t.client.Call("surface.split", map[string]string{"direction": "right"})
+		if err != nil {
+			return ToolResult{Content: fmt.Sprintf("surface.split failed: %s", err), IsError: true}, nil
+		}
+		if !resp.OK {
+			return ToolResult{Content: fmt.Sprintf("surface.split error: %s", resp.Error), IsError: true}, nil
+		}
+		var surf cmux.Surface
+		if err := json.Unmarshal(resp.Result, &surf); err != nil {
+			return ToolResult{Content: fmt.Sprintf("decode surface: %s", err), IsError: true}, nil
+		}
+		surfaceID = surf.ID
+	}
+
+	resp, err := t.client.Call("browser.navigate", map[string]string{
+		"surface_id": surfaceID,
+		"url":        in.URL,
+	})
+	if err != nil {
+		return ToolResult{Content: fmt.Sprintf("browser.navigate failed: %s", err), IsError: true}, nil
+	}
+	if !resp.OK {
+		return ToolResult{Content: fmt.Sprintf("browser.navigate error: %s", resp.Error), IsError: true}, nil
+	}
+
+	resp, err = t.client.Call("browser.wait", map[string]string{
+		"surface_id": surfaceID,
+		"load_state": "load",
+	})
+	if err != nil {
+		return ToolResult{Content: fmt.Sprintf("browser.wait failed: %s", err), IsError: true}, nil
+	}
+	if !resp.OK {
+		return ToolResult{Content: fmt.Sprintf("browser.wait error: %s", resp.Error), IsError: true}, nil
+	}
+
+	return ToolResult{Content: fmt.Sprintf("Navigated to %s in surface %s", in.URL, surfaceID)}, nil
+}
+
+// CmuxBrowserSnapshotTool captures the DOM snapshot of a browser surface.
+type CmuxBrowserSnapshotTool struct {
+	client cmux.Caller
+}
+
+// NewCmuxBrowserSnapshot creates a CmuxBrowserSnapshotTool backed by client.
+func NewCmuxBrowserSnapshot(client cmux.Caller) *CmuxBrowserSnapshotTool {
+	return &CmuxBrowserSnapshotTool{client: client}
+}
+
+func (t *CmuxBrowserSnapshotTool) Name() string { return "cmux_browser_snapshot" }
+
+func (t *CmuxBrowserSnapshotTool) Description() string {
+	return "Capture the DOM snapshot of a browser surface."
+}
+
+func (t *CmuxBrowserSnapshotTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"surface_id": {
+				"type": "string",
+				"description": "The surface ID to snapshot"
+			}
+		},
+		"required": ["surface_id"]
+	}`)
+}
+
+type browserSurfaceInput struct {
+	SurfaceID string `json:"surface_id"`
+}
+
+func (t *CmuxBrowserSnapshotTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in browserSurfaceInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+	if in.SurfaceID == "" {
+		return ToolResult{Content: "surface_id is required", IsError: true}, nil
+	}
+
+	resp, err := t.client.Call("browser.snapshot", map[string]string{"surface_id": in.SurfaceID})
+	if err != nil {
+		return ToolResult{Content: fmt.Sprintf("browser.snapshot failed: %s", err), IsError: true}, nil
+	}
+	if !resp.OK {
+		return ToolResult{Content: fmt.Sprintf("browser.snapshot error: %s", resp.Error), IsError: true}, nil
+	}
+
+	var result struct {
+		DOM string `json:"dom"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		return ToolResult{Content: fmt.Sprintf("decode snapshot: %s", err), IsError: true}, nil
+	}
+
+	return ToolResult{Content: result.DOM}, nil
+}
+
+// CmuxBrowserClickTool clicks an element in a browser surface.
+type CmuxBrowserClickTool struct {
+	client cmux.Caller
+}
+
+// NewCmuxBrowserClick creates a CmuxBrowserClickTool backed by client.
+func NewCmuxBrowserClick(client cmux.Caller) *CmuxBrowserClickTool {
+	return &CmuxBrowserClickTool{client: client}
+}
+
+func (t *CmuxBrowserClickTool) Name() string { return "cmux_browser_click" }
+
+func (t *CmuxBrowserClickTool) Description() string {
+	return "Click an element (identified by ref) in a browser surface."
+}
+
+func (t *CmuxBrowserClickTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"surface_id": {
+				"type": "string",
+				"description": "The surface ID"
+			},
+			"ref": {
+				"type": "string",
+				"description": "Element reference to click"
+			}
+		},
+		"required": ["surface_id", "ref"]
+	}`)
+}
+
+type browserClickInput struct {
+	SurfaceID string `json:"surface_id"`
+	Ref       string `json:"ref"`
+}
+
+func (t *CmuxBrowserClickTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in browserClickInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+	if in.SurfaceID == "" {
+		return ToolResult{Content: "surface_id is required", IsError: true}, nil
+	}
+	if in.Ref == "" {
+		return ToolResult{Content: "ref is required", IsError: true}, nil
+	}
+
+	resp, err := t.client.Call("browser.click", map[string]string{
+		"surface_id": in.SurfaceID,
+		"ref":        in.Ref,
+	})
+	if err != nil {
+		return ToolResult{Content: fmt.Sprintf("browser.click failed: %s", err), IsError: true}, nil
+	}
+	if !resp.OK {
+		return ToolResult{Content: fmt.Sprintf("browser.click error: %s", resp.Error), IsError: true}, nil
+	}
+
+	return ToolResult{Content: fmt.Sprintf("Clicked %s in surface %s", in.Ref, in.SurfaceID)}, nil
+}
+
+// CmuxBrowserTypeTool types text into an element in a browser surface.
+type CmuxBrowserTypeTool struct {
+	client cmux.Caller
+}
+
+// NewCmuxBrowserType creates a CmuxBrowserTypeTool backed by client.
+func NewCmuxBrowserType(client cmux.Caller) *CmuxBrowserTypeTool {
+	return &CmuxBrowserTypeTool{client: client}
+}
+
+func (t *CmuxBrowserTypeTool) Name() string { return "cmux_browser_type" }
+
+func (t *CmuxBrowserTypeTool) Description() string {
+	return "Type text into an element (identified by ref) in a browser surface."
+}
+
+func (t *CmuxBrowserTypeTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"surface_id": {
+				"type": "string",
+				"description": "The surface ID"
+			},
+			"ref": {
+				"type": "string",
+				"description": "Element reference to type into"
+			},
+			"text": {
+				"type": "string",
+				"description": "Text to type"
+			}
+		},
+		"required": ["surface_id", "ref", "text"]
+	}`)
+}
+
+type browserTypeInput struct {
+	SurfaceID string `json:"surface_id"`
+	Ref       string `json:"ref"`
+	Text      string `json:"text"`
+}
+
+func (t *CmuxBrowserTypeTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in browserTypeInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+	if in.SurfaceID == "" {
+		return ToolResult{Content: "surface_id is required", IsError: true}, nil
+	}
+	if in.Ref == "" {
+		return ToolResult{Content: "ref is required", IsError: true}, nil
+	}
+
+	resp, err := t.client.Call("browser.type", map[string]string{
+		"surface_id": in.SurfaceID,
+		"ref":        in.Ref,
+		"text":       in.Text,
+	})
+	if err != nil {
+		return ToolResult{Content: fmt.Sprintf("browser.type failed: %s", err), IsError: true}, nil
+	}
+	if !resp.OK {
+		return ToolResult{Content: fmt.Sprintf("browser.type error: %s", resp.Error), IsError: true}, nil
+	}
+
+	return ToolResult{Content: fmt.Sprintf("Typed %q into %s in surface %s", in.Text, in.Ref, in.SurfaceID)}, nil
+}
+
+// CmuxBrowserWaitTool waits for a browser surface to reach a load state.
+type CmuxBrowserWaitTool struct {
+	client cmux.Caller
+}
+
+// NewCmuxBrowserWait creates a CmuxBrowserWaitTool backed by client.
+func NewCmuxBrowserWait(client cmux.Caller) *CmuxBrowserWaitTool {
+	return &CmuxBrowserWaitTool{client: client}
+}
+
+func (t *CmuxBrowserWaitTool) Name() string { return "cmux_browser_wait" }
+
+func (t *CmuxBrowserWaitTool) Description() string {
+	return "Wait for a browser surface to reach the given load state."
+}
+
+func (t *CmuxBrowserWaitTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"surface_id": {
+				"type": "string",
+				"description": "The surface ID"
+			},
+			"load_state": {
+				"type": "string",
+				"description": "Load state to wait for (e.g. load, domcontentloaded, networkidle)"
+			}
+		},
+		"required": ["surface_id", "load_state"]
+	}`)
+}
+
+type browserWaitInput struct {
+	SurfaceID string `json:"surface_id"`
+	LoadState string `json:"load_state"`
+}
+
+func (t *CmuxBrowserWaitTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in browserWaitInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+	if in.SurfaceID == "" {
+		return ToolResult{Content: "surface_id is required", IsError: true}, nil
+	}
+	if in.LoadState == "" {
+		return ToolResult{Content: "load_state is required", IsError: true}, nil
+	}
+
+	resp, err := t.client.Call("browser.wait", map[string]string{
+		"surface_id": in.SurfaceID,
+		"load_state": in.LoadState,
+	})
+	if err != nil {
+		return ToolResult{Content: fmt.Sprintf("browser.wait failed: %s", err), IsError: true}, nil
+	}
+	if !resp.OK {
+		return ToolResult{Content: fmt.Sprintf("browser.wait error: %s", resp.Error), IsError: true}, nil
+	}
+
+	return ToolResult{Content: fmt.Sprintf("Surface %s reached load state %q", in.SurfaceID, in.LoadState)}, nil
+}

--- a/internal/tools/cmux_browser_test.go
+++ b/internal/tools/cmux_browser_test.go
@@ -1,0 +1,116 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+	"github.com/julianshen/rubichan/internal/cmux/cmuxtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmuxBrowserNavigateTool_Name(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	tool := NewCmuxBrowserNavigate(mc)
+	assert.Equal(t, "cmux_browser_navigate", tool.Name())
+}
+
+func TestCmuxBrowserNavigateTool_Execute(t *testing.T) {
+	// no surface_id → auto-split
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.split", cmux.Surface{ID: "surf-1", Type: "browser"})
+	mc.SetResult("browser.navigate", map[string]any{})
+	mc.SetResult("browser.wait", map[string]any{})
+
+	tool := NewCmuxBrowserNavigate(mc)
+	input, _ := json.Marshal(map[string]string{"url": "https://example.com"})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.False(t, result.IsError, result.Content)
+	assert.Contains(t, result.Content, "https://example.com")
+	assert.Contains(t, result.Content, "surf-1")
+
+	calls := mc.Calls()
+	require.Len(t, calls, 3)
+	assert.Equal(t, "surface.split", calls[0].Method)
+	assert.Equal(t, "browser.navigate", calls[1].Method)
+	assert.Equal(t, "browser.wait", calls[2].Method)
+}
+
+func TestCmuxBrowserNavigateTool_WithSurfaceID(t *testing.T) {
+	// surface_id provided → no split call
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("browser.navigate", map[string]any{})
+	mc.SetResult("browser.wait", map[string]any{})
+
+	tool := NewCmuxBrowserNavigate(mc)
+	input, _ := json.Marshal(map[string]string{"url": "https://example.com", "surface_id": "existing-surf"})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.False(t, result.IsError, result.Content)
+	assert.Contains(t, result.Content, "existing-surf")
+
+	calls := mc.Calls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, "browser.navigate", calls[0].Method)
+	assert.Equal(t, "browser.wait", calls[1].Method)
+}
+
+func TestCmuxBrowserSnapshotTool_Execute(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("browser.snapshot", map[string]string{"dom": "<html>hello</html>"})
+
+	tool := NewCmuxBrowserSnapshot(mc)
+	input, _ := json.Marshal(map[string]string{"surface_id": "surf-2"})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.False(t, result.IsError, result.Content)
+	assert.Equal(t, "<html>hello</html>", result.Content)
+}
+
+func TestCmuxBrowserClickTool_Execute(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("browser.click", map[string]any{})
+
+	tool := NewCmuxBrowserClick(mc)
+	input, _ := json.Marshal(map[string]string{"surface_id": "surf-3", "ref": "button#submit"})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.False(t, result.IsError, result.Content)
+	assert.Contains(t, result.Content, "button#submit")
+	assert.Contains(t, result.Content, "surf-3")
+}
+
+func TestCmuxBrowserTypeTool_Execute(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("browser.type", map[string]any{})
+
+	tool := NewCmuxBrowserType(mc)
+	input, _ := json.Marshal(map[string]string{"surface_id": "surf-4", "ref": "input#search", "text": "hello world"})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.False(t, result.IsError, result.Content)
+	assert.Contains(t, result.Content, "hello world")
+	assert.Contains(t, result.Content, "surf-4")
+}
+
+func TestCmuxBrowserWaitTool_Execute(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("browser.wait", map[string]any{})
+
+	tool := NewCmuxBrowserWait(mc)
+	input, _ := json.Marshal(map[string]string{"surface_id": "surf-5", "load_state": "networkidle"})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.False(t, result.IsError, result.Content)
+	assert.Contains(t, result.Content, "surf-5")
+	assert.Contains(t, result.Content, "networkidle")
+}

--- a/internal/tools/cmux_orchestrate.go
+++ b/internal/tools/cmux_orchestrate.go
@@ -91,20 +91,17 @@ func (t *CmuxOrchestrateTool) Execute(ctx context.Context, input json.RawMessage
 	orch := cmux.NewOrchestrator(t.client)
 	orch.SetPollRate(2 * time.Second)
 
-	// Dispatch all tasks.
 	for _, task := range in.Tasks {
 		if _, err := orch.Dispatch(task.Direction, task.Command); err != nil {
 			return ToolResult{Content: fmt.Sprintf("dispatch failed: %s", err), IsError: true}, nil
 		}
 	}
 
-	// Wait for all tasks to complete.
 	results, err := orch.Wait(timeout)
 	if err != nil {
 		return ToolResult{Content: fmt.Sprintf("orchestration failed: %s", err), IsError: true}, nil
 	}
 
-	// Build summary.
 	var sb strings.Builder
 	for _, r := range results {
 		sb.WriteString(fmt.Sprintf("surface %s (%s): %s\n", r.SurfaceID, r.Command, r.Status))

--- a/internal/tools/cmux_orchestrate.go
+++ b/internal/tools/cmux_orchestrate.go
@@ -97,7 +97,7 @@ func (t *CmuxOrchestrateTool) Execute(ctx context.Context, input json.RawMessage
 		}
 	}
 
-	results, err := orch.Wait(timeout)
+	results, err := orch.Wait(ctx, timeout)
 	if err != nil {
 		return ToolResult{Content: fmt.Sprintf("orchestration failed: %s", err), IsError: true}, nil
 	}

--- a/internal/tools/cmux_orchestrate.go
+++ b/internal/tools/cmux_orchestrate.go
@@ -1,0 +1,212 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+)
+
+// CmuxOrchestrateTool runs multiple commands in parallel pane splits and
+// polls the sidebar for completion signals.
+type CmuxOrchestrateTool struct {
+	client cmux.Caller
+}
+
+// NewCmuxOrchestrate creates a CmuxOrchestrateTool backed by client.
+func NewCmuxOrchestrate(client cmux.Caller) *CmuxOrchestrateTool {
+	return &CmuxOrchestrateTool{client: client}
+}
+
+func (t *CmuxOrchestrateTool) Name() string { return "cmux_orchestrate" }
+
+func (t *CmuxOrchestrateTool) Description() string {
+	return "Run multiple commands across split panes in parallel. " +
+		"Each task gets its own pane. Polls sidebar logs for [DONE]/[ERROR] completion markers."
+}
+
+func (t *CmuxOrchestrateTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"tasks": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"direction": {
+							"type": "string",
+							"enum": ["left", "right", "up", "down"],
+							"description": "Split direction for this task's pane"
+						},
+						"command": {
+							"type": "string",
+							"description": "Shell command to run in the pane"
+						}
+					},
+					"required": ["direction", "command"]
+				},
+				"description": "Tasks to run in parallel"
+			},
+			"timeout": {
+				"type": "string",
+				"description": "Overall timeout, e.g. '5m', '30s'. Defaults to '5m'."
+			}
+		},
+		"required": ["tasks"]
+	}`)
+}
+
+type orchestrateTask struct {
+	Direction string `json:"direction"`
+	Command   string `json:"command"`
+}
+
+type orchestrateInput struct {
+	Tasks   []orchestrateTask `json:"tasks"`
+	Timeout string            `json:"timeout"`
+}
+
+// taskState tracks one running task.
+type taskState struct {
+	surfaceID string
+	command   string
+	done      bool
+	status    string // "done", "error", "timeout"
+}
+
+func (t *CmuxOrchestrateTool) Execute(ctx context.Context, input json.RawMessage) (ToolResult, error) {
+	var in orchestrateInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+	if len(in.Tasks) == 0 {
+		return ToolResult{Content: "tasks must not be empty", IsError: true}, nil
+	}
+
+	timeout := 5 * time.Minute
+	if in.Timeout != "" {
+		d, err := time.ParseDuration(in.Timeout)
+		if err != nil {
+			return ToolResult{Content: fmt.Sprintf("invalid timeout %q: %s", in.Timeout, err), IsError: true}, nil
+		}
+		timeout = d
+	}
+
+	// Launch each task: split pane, send command + enter.
+	states := make([]*taskState, 0, len(in.Tasks))
+	for _, task := range in.Tasks {
+		resp, err := t.client.Call("surface.split", map[string]string{"direction": task.Direction})
+		if err != nil {
+			return ToolResult{Content: fmt.Sprintf("surface.split failed: %s", err), IsError: true}, nil
+		}
+		if !resp.OK {
+			return ToolResult{Content: fmt.Sprintf("surface.split error: %s", resp.Error), IsError: true}, nil
+		}
+		var surf cmux.Surface
+		if err := json.Unmarshal(resp.Result, &surf); err != nil {
+			return ToolResult{Content: fmt.Sprintf("decode surface: %s", err), IsError: true}, nil
+		}
+
+		// Send command text.
+		if resp, err := t.client.Call("surface.send_text", map[string]string{
+			"surface_id": surf.ID,
+			"text":       task.Command,
+		}); err != nil || !resp.OK {
+			msg := fmt.Sprintf("send_text failed for surface %s", surf.ID)
+			if err != nil {
+				msg = fmt.Sprintf("%s: %s", msg, err)
+			} else {
+				msg = fmt.Sprintf("%s: %s", msg, resp.Error)
+			}
+			return ToolResult{Content: msg, IsError: true}, nil
+		}
+
+		// Send Enter.
+		if resp, err := t.client.Call("surface.send_key", map[string]string{
+			"surface_id": surf.ID,
+			"key":        "Enter",
+		}); err != nil || !resp.OK {
+			msg := fmt.Sprintf("send_key failed for surface %s", surf.ID)
+			if err != nil {
+				msg = fmt.Sprintf("%s: %s", msg, err)
+			} else {
+				msg = fmt.Sprintf("%s: %s", msg, resp.Error)
+			}
+			return ToolResult{Content: msg, IsError: true}, nil
+		}
+
+		states = append(states, &taskState{surfaceID: surf.ID, command: task.Command})
+	}
+
+	// Poll sidebar-state every 2 s until all done or timeout.
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		allDone := true
+		for _, s := range states {
+			if !s.done {
+				allDone = false
+				break
+			}
+		}
+		if allDone {
+			break
+		}
+		if time.Now().After(deadline) {
+			for _, s := range states {
+				if !s.done {
+					s.status = "timeout"
+					s.done = true
+				}
+			}
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return ToolResult{Content: "context cancelled", IsError: true}, nil
+		case <-ticker.C:
+			resp, err := t.client.Call("sidebar-state", map[string]any{})
+			if err != nil {
+				continue
+			}
+			if !resp.OK {
+				continue
+			}
+			var state cmux.SidebarState
+			if err := json.Unmarshal(resp.Result, &state); err != nil {
+				continue
+			}
+			for _, entry := range state.Logs {
+				for _, s := range states {
+					if s.done {
+						continue
+					}
+					if !strings.Contains(entry.Message, s.surfaceID) {
+						continue
+					}
+					if strings.Contains(entry.Message, "[DONE]") {
+						s.done = true
+						s.status = "done"
+					} else if strings.Contains(entry.Message, "[ERROR]") {
+						s.done = true
+						s.status = "error"
+					}
+				}
+			}
+		}
+	}
+
+	// Build summary.
+	var sb strings.Builder
+	for _, s := range states {
+		sb.WriteString(fmt.Sprintf("surface %s (%s): %s\n", s.surfaceID, s.command, s.status))
+	}
+	return ToolResult{Content: strings.TrimRight(sb.String(), "\n")}, nil
+}

--- a/internal/tools/cmux_orchestrate.go
+++ b/internal/tools/cmux_orchestrate.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CmuxOrchestrateTool runs multiple commands in parallel pane splits and
-// polls the sidebar for completion signals.
+// polls the sidebar for completion signals. Delegates to cmux.Orchestrator.
 type CmuxOrchestrateTool struct {
 	client cmux.Caller
 }
@@ -70,14 +70,6 @@ type orchestrateInput struct {
 	Timeout string            `json:"timeout"`
 }
 
-// taskState tracks one running task.
-type taskState struct {
-	surfaceID string
-	command   string
-	done      bool
-	status    string // "done", "error", "timeout"
-}
-
 func (t *CmuxOrchestrateTool) Execute(ctx context.Context, input json.RawMessage) (ToolResult, error) {
 	var in orchestrateInput
 	if err := json.Unmarshal(input, &in); err != nil {
@@ -96,117 +88,26 @@ func (t *CmuxOrchestrateTool) Execute(ctx context.Context, input json.RawMessage
 		timeout = d
 	}
 
-	// Launch each task: split pane, send command + enter.
-	states := make([]*taskState, 0, len(in.Tasks))
+	orch := cmux.NewOrchestrator(t.client)
+	orch.SetPollRate(2 * time.Second)
+
+	// Dispatch all tasks.
 	for _, task := range in.Tasks {
-		resp, err := t.client.Call("surface.split", map[string]string{"direction": task.Direction})
-		if err != nil {
-			return ToolResult{Content: fmt.Sprintf("surface.split failed: %s", err), IsError: true}, nil
+		if _, err := orch.Dispatch(task.Direction, task.Command); err != nil {
+			return ToolResult{Content: fmt.Sprintf("dispatch failed: %s", err), IsError: true}, nil
 		}
-		if !resp.OK {
-			return ToolResult{Content: fmt.Sprintf("surface.split error: %s", resp.Error), IsError: true}, nil
-		}
-		var surf cmux.Surface
-		if err := json.Unmarshal(resp.Result, &surf); err != nil {
-			return ToolResult{Content: fmt.Sprintf("decode surface: %s", err), IsError: true}, nil
-		}
-
-		// Send command text.
-		if resp, err := t.client.Call("surface.send_text", map[string]string{
-			"surface_id": surf.ID,
-			"text":       task.Command,
-		}); err != nil || !resp.OK {
-			msg := fmt.Sprintf("send_text failed for surface %s", surf.ID)
-			if err != nil {
-				msg = fmt.Sprintf("%s: %s", msg, err)
-			} else {
-				msg = fmt.Sprintf("%s: %s", msg, resp.Error)
-			}
-			return ToolResult{Content: msg, IsError: true}, nil
-		}
-
-		// Send Enter.
-		if resp, err := t.client.Call("surface.send_key", map[string]string{
-			"surface_id": surf.ID,
-			"key":        "Enter",
-		}); err != nil || !resp.OK {
-			msg := fmt.Sprintf("send_key failed for surface %s", surf.ID)
-			if err != nil {
-				msg = fmt.Sprintf("%s: %s", msg, err)
-			} else {
-				msg = fmt.Sprintf("%s: %s", msg, resp.Error)
-			}
-			return ToolResult{Content: msg, IsError: true}, nil
-		}
-
-		states = append(states, &taskState{surfaceID: surf.ID, command: task.Command})
 	}
 
-	// Poll sidebar-state every 2 s until all done or timeout.
-	deadline := time.Now().Add(timeout)
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		allDone := true
-		for _, s := range states {
-			if !s.done {
-				allDone = false
-				break
-			}
-		}
-		if allDone {
-			break
-		}
-		if time.Now().After(deadline) {
-			for _, s := range states {
-				if !s.done {
-					s.status = "timeout"
-					s.done = true
-				}
-			}
-			break
-		}
-
-		select {
-		case <-ctx.Done():
-			return ToolResult{Content: "context cancelled", IsError: true}, nil
-		case <-ticker.C:
-			resp, err := t.client.Call("sidebar-state", map[string]any{})
-			if err != nil {
-				continue
-			}
-			if !resp.OK {
-				continue
-			}
-			var state cmux.SidebarState
-			if err := json.Unmarshal(resp.Result, &state); err != nil {
-				continue
-			}
-			for _, entry := range state.Logs {
-				for _, s := range states {
-					if s.done {
-						continue
-					}
-					if !strings.Contains(entry.Message, s.surfaceID) {
-						continue
-					}
-					if strings.Contains(entry.Message, "[DONE]") {
-						s.done = true
-						s.status = "done"
-					} else if strings.Contains(entry.Message, "[ERROR]") {
-						s.done = true
-						s.status = "error"
-					}
-				}
-			}
-		}
+	// Wait for all tasks to complete.
+	results, err := orch.Wait(timeout)
+	if err != nil {
+		return ToolResult{Content: fmt.Sprintf("orchestration failed: %s", err), IsError: true}, nil
 	}
 
 	// Build summary.
 	var sb strings.Builder
-	for _, s := range states {
-		sb.WriteString(fmt.Sprintf("surface %s (%s): %s\n", s.surfaceID, s.command, s.status))
+	for _, r := range results {
+		sb.WriteString(fmt.Sprintf("surface %s (%s): %s\n", r.SurfaceID, r.Command, r.Status))
 	}
 	return ToolResult{Content: strings.TrimRight(sb.String(), "\n")}, nil
 }

--- a/internal/tools/cmux_orchestrate_test.go
+++ b/internal/tools/cmux_orchestrate_test.go
@@ -20,12 +20,11 @@ func TestCmuxOrchestrateTool_Name(t *testing.T) {
 func TestCmuxOrchestrateTool_Execute_SingleTask(t *testing.T) {
 	mc := cmuxtest.NewMockClient()
 	mc.SetResult("surface.split", cmux.Surface{ID: "orch-surf-1", Type: "terminal"})
-	mc.SetResult("surface.send_text", map[string]any{})
-	mc.SetResult("surface.send_key", map[string]any{})
-	// Return a [DONE] log on first poll.
+	mc.SetResult("surface.send_text", true)
+	mc.SetResult("surface.send_key", true)
 	mc.SetResult("sidebar-state", cmux.SidebarState{
 		Logs: []cmux.LogEntry{
-			{Message: "[DONE] orch-surf-1 finished", Level: "info"},
+			{Message: "[DONE] finished", Level: "info", Source: "orch-surf-1"},
 		},
 	})
 
@@ -72,11 +71,11 @@ func TestCmuxOrchestrateTool_Execute_InvalidTimeout(t *testing.T) {
 func TestCmuxOrchestrateTool_Execute_ErrorLog(t *testing.T) {
 	mc := cmuxtest.NewMockClient()
 	mc.SetResult("surface.split", cmux.Surface{ID: "orch-surf-2", Type: "terminal"})
-	mc.SetResult("surface.send_text", map[string]any{})
-	mc.SetResult("surface.send_key", map[string]any{})
+	mc.SetResult("surface.send_text", true)
+	mc.SetResult("surface.send_key", true)
 	mc.SetResult("sidebar-state", cmux.SidebarState{
 		Logs: []cmux.LogEntry{
-			{Message: "[ERROR] orch-surf-2 crashed", Level: "error"},
+			{Message: "[ERROR] crashed", Level: "error", Source: "orch-surf-2"},
 		},
 	})
 

--- a/internal/tools/cmux_orchestrate_test.go
+++ b/internal/tools/cmux_orchestrate_test.go
@@ -1,0 +1,93 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+	"github.com/julianshen/rubichan/internal/cmux/cmuxtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmuxOrchestrateTool_Name(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	tool := NewCmuxOrchestrate(mc)
+	assert.Equal(t, "cmux_orchestrate", tool.Name())
+}
+
+func TestCmuxOrchestrateTool_Execute_SingleTask(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.split", cmux.Surface{ID: "orch-surf-1", Type: "terminal"})
+	mc.SetResult("surface.send_text", map[string]any{})
+	mc.SetResult("surface.send_key", map[string]any{})
+	// Return a [DONE] log on first poll.
+	mc.SetResult("sidebar-state", cmux.SidebarState{
+		Logs: []cmux.LogEntry{
+			{Message: "[DONE] orch-surf-1 finished", Level: "info"},
+		},
+	})
+
+	tool := NewCmuxOrchestrate(mc)
+	input, _ := json.Marshal(orchestrateInput{
+		Tasks: []orchestrateTask{
+			{Direction: "right", Command: "echo hello"},
+		},
+		Timeout: "10s",
+	})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.False(t, result.IsError, result.Content)
+	assert.Contains(t, result.Content, "orch-surf-1")
+	assert.Contains(t, result.Content, "done")
+}
+
+func TestCmuxOrchestrateTool_Execute_EmptyTasks(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	tool := NewCmuxOrchestrate(mc)
+	input, _ := json.Marshal(orchestrateInput{Tasks: []orchestrateTask{}})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "tasks must not be empty")
+}
+
+func TestCmuxOrchestrateTool_Execute_InvalidTimeout(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	tool := NewCmuxOrchestrate(mc)
+	input, _ := json.Marshal(orchestrateInput{
+		Tasks:   []orchestrateTask{{Direction: "right", Command: "echo hi"}},
+		Timeout: "notaduration",
+	})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "invalid timeout")
+}
+
+func TestCmuxOrchestrateTool_Execute_ErrorLog(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.split", cmux.Surface{ID: "orch-surf-2", Type: "terminal"})
+	mc.SetResult("surface.send_text", map[string]any{})
+	mc.SetResult("surface.send_key", map[string]any{})
+	mc.SetResult("sidebar-state", cmux.SidebarState{
+		Logs: []cmux.LogEntry{
+			{Message: "[ERROR] orch-surf-2 crashed", Level: "error"},
+		},
+	})
+
+	tool := NewCmuxOrchestrate(mc)
+	input, _ := json.Marshal(orchestrateInput{
+		Tasks:   []orchestrateTask{{Direction: "down", Command: "bad-cmd"}},
+		Timeout: "10s",
+	})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content, "error")
+}

--- a/internal/tools/cmux_surface.go
+++ b/internal/tools/cmux_surface.go
@@ -1,0 +1,153 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+)
+
+// CmuxSplitTool creates a new surface by splitting in the given direction.
+type CmuxSplitTool struct {
+	client cmux.Caller
+}
+
+// NewCmuxSplit creates a CmuxSplitTool backed by client.
+func NewCmuxSplit(client cmux.Caller) *CmuxSplitTool {
+	return &CmuxSplitTool{client: client}
+}
+
+func (t *CmuxSplitTool) Name() string { return "cmux_split" }
+
+func (t *CmuxSplitTool) Description() string {
+	return "Create a new surface by splitting the current pane in the given direction."
+}
+
+func (t *CmuxSplitTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"direction": {
+				"type": "string",
+				"enum": ["left", "right", "up", "down"],
+				"description": "Direction to split"
+			}
+		},
+		"required": ["direction"]
+	}`)
+}
+
+type splitInput struct {
+	Direction string `json:"direction"`
+}
+
+func (t *CmuxSplitTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in splitInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+	if in.Direction == "" {
+		return ToolResult{Content: "direction is required", IsError: true}, nil
+	}
+
+	resp, err := t.client.Call("surface.split", map[string]string{"direction": in.Direction})
+	if err != nil {
+		return ToolResult{Content: fmt.Sprintf("surface.split failed: %s", err), IsError: true}, nil
+	}
+	if !resp.OK {
+		return ToolResult{Content: fmt.Sprintf("surface.split error: %s", resp.Error), IsError: true}, nil
+	}
+
+	var surf cmux.Surface
+	if err := json.Unmarshal(resp.Result, &surf); err != nil {
+		return ToolResult{Content: fmt.Sprintf("decode surface: %s", err), IsError: true}, nil
+	}
+
+	return ToolResult{Content: fmt.Sprintf("Created %s split — surface_id: %s", in.Direction, surf.ID)}, nil
+}
+
+// CmuxSendTool sends text or a key event to a surface.
+type CmuxSendTool struct {
+	client cmux.Caller
+}
+
+// NewCmuxSend creates a CmuxSendTool backed by client.
+func NewCmuxSend(client cmux.Caller) *CmuxSendTool {
+	return &CmuxSendTool{client: client}
+}
+
+func (t *CmuxSendTool) Name() string { return "cmux_send" }
+
+func (t *CmuxSendTool) Description() string {
+	return "Send text or a key event to a surface. Provide either 'text' or 'key', not both."
+}
+
+func (t *CmuxSendTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"surface_id": {
+				"type": "string",
+				"description": "Target surface ID"
+			},
+			"text": {
+				"type": "string",
+				"description": "Text to send (mutually exclusive with key)"
+			},
+			"key": {
+				"type": "string",
+				"description": "Key event to send, e.g. 'Enter' (mutually exclusive with text)"
+			}
+		},
+		"required": ["surface_id"]
+	}`)
+}
+
+type sendInput struct {
+	SurfaceID string `json:"surface_id"`
+	Text      string `json:"text"`
+	Key       string `json:"key"`
+}
+
+func (t *CmuxSendTool) Execute(_ context.Context, input json.RawMessage) (ToolResult, error) {
+	var in sendInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return ToolResult{Content: fmt.Sprintf("invalid input: %s", err), IsError: true}, nil
+	}
+	if in.SurfaceID == "" {
+		return ToolResult{Content: "surface_id is required", IsError: true}, nil
+	}
+	if in.Text == "" && in.Key == "" {
+		return ToolResult{Content: "either text or key must be provided", IsError: true}, nil
+	}
+	if in.Text != "" && in.Key != "" {
+		return ToolResult{Content: "text and key are mutually exclusive", IsError: true}, nil
+	}
+
+	if in.Text != "" {
+		resp, err := t.client.Call("surface.send_text", map[string]string{
+			"surface_id": in.SurfaceID,
+			"text":       in.Text,
+		})
+		if err != nil {
+			return ToolResult{Content: fmt.Sprintf("surface.send_text failed: %s", err), IsError: true}, nil
+		}
+		if !resp.OK {
+			return ToolResult{Content: fmt.Sprintf("surface.send_text error: %s", resp.Error), IsError: true}, nil
+		}
+		return ToolResult{Content: fmt.Sprintf("Sent text to surface %s", in.SurfaceID)}, nil
+	}
+
+	resp, err := t.client.Call("surface.send_key", map[string]string{
+		"surface_id": in.SurfaceID,
+		"key":        in.Key,
+	})
+	if err != nil {
+		return ToolResult{Content: fmt.Sprintf("surface.send_key failed: %s", err), IsError: true}, nil
+	}
+	if !resp.OK {
+		return ToolResult{Content: fmt.Sprintf("surface.send_key error: %s", resp.Error), IsError: true}, nil
+	}
+	return ToolResult{Content: fmt.Sprintf("Sent key %q to surface %s", in.Key, in.SurfaceID)}, nil
+}

--- a/internal/tools/cmux_surface_test.go
+++ b/internal/tools/cmux_surface_test.go
@@ -1,0 +1,87 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/cmux"
+	"github.com/julianshen/rubichan/internal/cmux/cmuxtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmuxSplitTool_Execute(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.split", cmux.Surface{ID: "new-surf", Type: "terminal"})
+
+	tool := NewCmuxSplit(mc)
+	input, _ := json.Marshal(map[string]string{"direction": "right"})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.False(t, result.IsError, result.Content)
+	assert.Contains(t, result.Content, "right")
+	assert.Contains(t, result.Content, "new-surf")
+
+	calls := mc.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "surface.split", calls[0].Method)
+}
+
+func TestCmuxSendTool_Text(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.send_text", map[string]any{})
+
+	tool := NewCmuxSend(mc)
+	input, _ := json.Marshal(map[string]string{"surface_id": "surf-1", "text": "hello"})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.False(t, result.IsError, result.Content)
+	assert.Contains(t, result.Content, "surf-1")
+
+	calls := mc.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "surface.send_text", calls[0].Method)
+}
+
+func TestCmuxSendTool_Key(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("surface.send_key", map[string]any{})
+
+	tool := NewCmuxSend(mc)
+	input, _ := json.Marshal(map[string]string{"surface_id": "surf-2", "key": "Enter"})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.False(t, result.IsError, result.Content)
+	assert.Contains(t, result.Content, "Enter")
+	assert.Contains(t, result.Content, "surf-2")
+
+	calls := mc.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "surface.send_key", calls[0].Method)
+}
+
+func TestCmuxSendTool_NeitherTextNorKey(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	tool := NewCmuxSend(mc)
+	input, _ := json.Marshal(map[string]string{"surface_id": "surf-3"})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "either text or key")
+}
+
+func TestCmuxSendTool_BothTextAndKey(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	tool := NewCmuxSend(mc)
+	input, _ := json.Marshal(map[string]string{"surface_id": "surf-4", "text": "hi", "key": "Enter"})
+	result, err := tool.Execute(context.Background(), input)
+
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "mutually exclusive")
+}

--- a/internal/tui/bootstrapprogress.go
+++ b/internal/tui/bootstrapprogress.go
@@ -55,7 +55,7 @@ func (b *BootstrapProgressOverlay) Update(msg tea.Msg) (Overlay, tea.Cmd) {
 			b.messages = append(b.messages, fmt.Sprintf("❌ Error: %s", msg.Error))
 			b.done = true
 			if b.cmuxClient != nil {
-				b.cmuxClient.Call("clear-progress", map[string]any{})
+				cmux.CallerClearProgress(b.cmuxClient)
 			} else if b.caps != nil && b.caps.ProgressBar {
 				terminal.ClearProgress(os.Stderr)
 			}
@@ -63,7 +63,7 @@ func (b *BootstrapProgressOverlay) Update(msg tea.Msg) (Overlay, tea.Cmd) {
 			b.messages = append(b.messages, "✅ Bootstrap complete!")
 			b.done = true
 			if b.cmuxClient != nil {
-				b.cmuxClient.Call("clear-progress", map[string]any{})
+				cmux.CallerClearProgress(b.cmuxClient)
 			} else if b.caps != nil && b.caps.ProgressBar {
 				terminal.ClearProgress(os.Stderr)
 			}
@@ -78,10 +78,7 @@ func (b *BootstrapProgressOverlay) Update(msg tea.Msg) (Overlay, tea.Cmd) {
 				percent = 95
 			}
 			if b.cmuxClient != nil {
-				b.cmuxClient.Call("set-progress", map[string]any{
-					"value": float64(percent) / 100.0,
-					"label": msg.Message,
-				})
+				cmux.CallerSetProgress(b.cmuxClient, float64(percent)/100.0, msg.Message)
 			} else if b.caps != nil && b.caps.ProgressBar {
 				terminal.SetProgress(os.Stderr, terminal.ProgressNormal, percent)
 			}

--- a/internal/tui/bootstrapprogress.go
+++ b/internal/tui/bootstrapprogress.go
@@ -55,7 +55,7 @@ func (b *BootstrapProgressOverlay) Update(msg tea.Msg) (Overlay, tea.Cmd) {
 			b.messages = append(b.messages, fmt.Sprintf("❌ Error: %s", msg.Error))
 			b.done = true
 			if b.cmuxClient != nil {
-				b.cmuxClient.Call("clear-progress", nil)
+				b.cmuxClient.Call("clear-progress", map[string]any{})
 			} else if b.caps != nil && b.caps.ProgressBar {
 				terminal.ClearProgress(os.Stderr)
 			}
@@ -63,7 +63,7 @@ func (b *BootstrapProgressOverlay) Update(msg tea.Msg) (Overlay, tea.Cmd) {
 			b.messages = append(b.messages, "✅ Bootstrap complete!")
 			b.done = true
 			if b.cmuxClient != nil {
-				b.cmuxClient.Call("clear-progress", nil)
+				b.cmuxClient.Call("clear-progress", map[string]any{})
 			} else if b.caps != nil && b.caps.ProgressBar {
 				terminal.ClearProgress(os.Stderr)
 			}

--- a/internal/tui/bootstrapprogress.go
+++ b/internal/tui/bootstrapprogress.go
@@ -43,9 +43,9 @@ func NewBootstrapProgressOverlay(width, height int, caps *terminal.Caps, cmuxCli
 }
 
 // Update handles progress messages during bootstrap.
-// Progress bar escape sequences (OSC 9;4) are written directly to stderr because
-// they target the terminal's titlebar/tab, which exists outside Bubble Tea's
-// alternate screen and does not interfere with TUI rendering.
+// When running inside cmux, progress is sent via the socket API. Otherwise,
+// OSC 9;4 escape sequences are written directly to stderr — these target the
+// terminal titlebar/tab outside Bubble Tea's alternate screen.
 func (b *BootstrapProgressOverlay) Update(msg tea.Msg) (Overlay, tea.Cmd) {
 	switch msg := msg.(type) {
 	case BootstrapProgressMsg:

--- a/internal/tui/bootstrapprogress.go
+++ b/internal/tui/bootstrapprogress.go
@@ -21,10 +21,10 @@ type BootstrapProgressMsg struct {
 
 // BootstrapProgressOverlay displays progress during knowledge graph bootstrap.
 type BootstrapProgressOverlay struct {
-	messages []string
-	phase    string
-	done     bool
-	error    string
+	messages   []string
+	phase      string
+	done       bool
+	error      string
 	width      int
 	height     int
 	caps       *terminal.Caps

--- a/internal/tui/bootstrapprogress.go
+++ b/internal/tui/bootstrapprogress.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/julianshen/rubichan/internal/cmux"
 	"github.com/julianshen/rubichan/internal/terminal"
 )
 
@@ -24,18 +25,20 @@ type BootstrapProgressOverlay struct {
 	phase    string
 	done     bool
 	error    string
-	width    int
-	height   int
-	caps     *terminal.Caps
+	width      int
+	height     int
+	caps       *terminal.Caps
+	cmuxClient cmux.Caller
 }
 
 // NewBootstrapProgressOverlay creates a new progress overlay.
-func NewBootstrapProgressOverlay(width, height int, caps *terminal.Caps) *BootstrapProgressOverlay {
+func NewBootstrapProgressOverlay(width, height int, caps *terminal.Caps, cmuxClient cmux.Caller) *BootstrapProgressOverlay {
 	return &BootstrapProgressOverlay{
-		messages: []string{"🚀 Knowledge Graph Bootstrap Started"},
-		width:    width,
-		height:   height,
-		caps:     caps,
+		messages:   []string{"🚀 Knowledge Graph Bootstrap Started"},
+		width:      width,
+		height:     height,
+		caps:       caps,
+		cmuxClient: cmuxClient,
 	}
 }
 
@@ -51,13 +54,17 @@ func (b *BootstrapProgressOverlay) Update(msg tea.Msg) (Overlay, tea.Cmd) {
 			b.error = msg.Error
 			b.messages = append(b.messages, fmt.Sprintf("❌ Error: %s", msg.Error))
 			b.done = true
-			if b.caps != nil && b.caps.ProgressBar {
+			if b.cmuxClient != nil {
+				b.cmuxClient.Call("clear-progress", nil)
+			} else if b.caps != nil && b.caps.ProgressBar {
 				terminal.ClearProgress(os.Stderr)
 			}
 		} else if msg.Phase == "complete" {
 			b.messages = append(b.messages, "✅ Bootstrap complete!")
 			b.done = true
-			if b.caps != nil && b.caps.ProgressBar {
+			if b.cmuxClient != nil {
+				b.cmuxClient.Call("clear-progress", nil)
+			} else if b.caps != nil && b.caps.ProgressBar {
 				terminal.ClearProgress(os.Stderr)
 			}
 		} else {
@@ -66,11 +73,16 @@ func (b *BootstrapProgressOverlay) Update(msg tea.Msg) (Overlay, tea.Cmd) {
 			} else {
 				b.messages = append(b.messages, fmt.Sprintf("  %s...", msg.Message))
 			}
-			if b.caps != nil && b.caps.ProgressBar {
-				percent := len(b.messages) * 15
-				if percent > 95 {
-					percent = 95
-				}
+			percent := len(b.messages) * 15
+			if percent > 95 {
+				percent = 95
+			}
+			if b.cmuxClient != nil {
+				b.cmuxClient.Call("set-progress", map[string]any{
+					"value": float64(percent) / 100.0,
+					"label": msg.Message,
+				})
+			} else if b.caps != nil && b.caps.ProgressBar {
 				terminal.SetProgress(os.Stderr, terminal.ProgressNormal, percent)
 			}
 		}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/julianshen/rubichan/internal/agent"
 	"github.com/julianshen/rubichan/internal/checkpoint"
+	"github.com/julianshen/rubichan/internal/cmux"
 	"github.com/julianshen/rubichan/internal/commands"
 	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/knowledgegraph"
@@ -143,6 +144,7 @@ type Model struct {
 	debug             bool
 	lastPrompt        string
 	termCaps          *terminal.Caps
+	cmuxClient        cmux.Caller    // nil when not running in cmux
 	sessionState      *session.State
 	eventSink         session.EventSink
 	toolApprovalCount map[string]int // per-turn count of times each tool was approved
@@ -409,8 +411,21 @@ func (m *Model) TermCaps() *terminal.Caps {
 	return m.termCaps
 }
 
+// SetCmuxClient sets the cmux client for rich sidebar/notification dispatch.
+// Pass nil when not running inside cmux.
+func (m *Model) SetCmuxClient(client cmux.Caller) {
+	m.cmuxClient = client
+}
+
 // notifyIfSupported sends a desktop notification if the terminal supports it.
 func (m *Model) notifyIfSupported(message string) {
+	if m.cmuxClient != nil {
+		m.cmuxClient.Call("notification.create", map[string]string{
+			"title": "Rubichan",
+			"body":  message,
+		})
+		return
+	}
 	if m.termCaps != nil && m.termCaps.Notifications {
 		terminal.Notify(os.Stderr, message)
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -37,7 +37,7 @@ const (
 	TurnStatusError     = "error"
 
 	// Archival configuration constants
-	archiveCheckInterval = 10  // archive every 10 turns
+	archiveCheckInterval  = 10 // archive every 10 turns
 	minTurnsBeforeArchive = 50 // don't archive until we have this many
 )
 
@@ -144,10 +144,10 @@ type Model struct {
 	debug             bool
 	lastPrompt        string
 	termCaps          *terminal.Caps
-	cmuxClient        cmux.Caller    // nil when not running in cmux
+	cmuxClient        cmux.Caller // nil when not running in cmux
 	sessionState      *session.State
 	eventSink         session.EventSink
-	toolApprovalCount map[string]int // per-turn count of times each tool was approved
+	toolApprovalCount map[string]int     // per-turn count of times each tool was approved
 	bootstrapCancel   context.CancelFunc // cancels bootstrap process if set
 }
 
@@ -418,10 +418,12 @@ func (m *Model) SetCmuxClient(client cmux.Caller) {
 }
 
 // notifyIfSupported sends a desktop notification if the terminal supports it.
+// Tries cmux first; falls back to OSC terminal notifications on failure.
 func (m *Model) notifyIfSupported(message string) {
 	if m.cmuxClient != nil {
-		cmux.CallerNotify(m.cmuxClient, "Rubichan", "", message)
-		return
+		if cmux.CallerNotify(m.cmuxClient, "Rubichan", "", message) {
+			return
+		}
 	}
 	if m.termCaps != nil && m.termCaps.Notifications {
 		terminal.Notify(os.Stderr, message)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -420,10 +420,7 @@ func (m *Model) SetCmuxClient(client cmux.Caller) {
 // notifyIfSupported sends a desktop notification if the terminal supports it.
 func (m *Model) notifyIfSupported(message string) {
 	if m.cmuxClient != nil {
-		m.cmuxClient.Call("notification.create", map[string]string{
-			"title": "Rubichan",
-			"body":  message,
-		})
+		cmux.CallerNotify(m.cmuxClient, "Rubichan", "", message)
 		return
 	}
 	if m.termCaps != nil && m.termCaps.Notifications {

--- a/internal/tui/overlay.go
+++ b/internal/tui/overlay.go
@@ -81,7 +81,7 @@ func (m *Model) processOverlayResult(result any) tea.Cmd {
 		// Unlike other overlays, bootstrap runs as an async operation because discovery
 		// can take seconds. The progress overlay provides feedback via BootstrapProgressMsg.
 		// The context can be cancelled via m.bootstrapCancel (e.g., user presses Ctrl+C).
-		m.activeOverlay = NewBootstrapProgressOverlay(m.width, m.height, m.termCaps)
+		m.activeOverlay = NewBootstrapProgressOverlay(m.width, m.height, m.termCaps, m.cmuxClient)
 		m.state = StateBootstrapProgressOverlay
 		ctx, cancel := context.WithCancel(context.Background())
 		m.bootstrapCancel = cancel


### PR DESCRIPTION
## Summary

- Add `internal/cmux/` package with JSON-RPC Unix socket client for cmux terminal integration
- 7 feature modules: sidebar metadata, notifications, workspace, surface, browser automation, orchestrator
- `Caller` interface + `MockClient` for full testability
- 8 agent tools: 5 browser (navigate/snapshot/click/type/wait), split, send, orchestrate
- `CmuxSocket` detection in terminal Caps via env var + socket ping
- TUI wiring: `SetCmuxClient`, cmux-preferred notifications and progress bars
- Mode entrypoint wiring: interactive (tool registration), headless (notifications), wiki (progress + notifications)
- Opt-in integration tests gated behind `cmux_integration` build tag

When running inside cmux, Rubichan automatically upgrades from OSC escape sequences to cmux's richer API:
- Progress bars → sidebar progress with labels
- Notifications → native macOS notifications with title/subtitle/body
- Browser automation and multi-pane orchestration become available as agent tools

## Test plan

- [x] All unit tests pass (`go test ./internal/cmux/... ./internal/tools/ ./internal/tui/`)
- [x] Binary builds cleanly (`go build ./cmd/rubichan/`)
- [x] Integration tests skip correctly outside cmux
- [ ] Manual: Run inside cmux to verify socket detection and sidebar updates
- [ ] Manual: Verify browser tools work with cmux browser surfaces


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional cmux Unix-socket control plane with progress, notifications, sidebar status/logs, surfaces (split/focus/send), browser automation, orchestration, and workspace controls.
* **Documentation**
  * Draft design spec describing cmux integration and usage patterns.
* **Tests**
  * Extensive unit/integration tests and mocks covering cmux client, sidebar, surface, browser, orchestrator, notifications, and workspace APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->