### PR TITLE
Wire checkpoint system for undo/rewind support

### DIFF
--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sourcegraph/conc"
 
 	"github.com/julianshen/rubichan/internal/agent"
+	"github.com/julianshen/rubichan/internal/checkpoint"
 	"github.com/julianshen/rubichan/internal/cmux"
 	"github.com/julianshen/rubichan/internal/commands"
 	"github.com/julianshen/rubichan/internal/config"
@@ -1697,11 +1698,20 @@ func runInteractive() error {
 		}
 	}
 
+	// Create checkpoint manager for undo/rewind support.
+	cpSessionID := uuid.New().String()
+	cpMgr, err := checkpoint.New(cwd, cpSessionID, 0)
+	if err != nil {
+		return fmt.Errorf("create checkpoint manager: %w", err)
+	}
+	defer cpMgr.Cleanup()
+
 	// Create TUI model first (with nil agent) so we can extract the
 	// interactive approval function before constructing the agent.
 	model := tui.NewModel(nil, "rubichan", cfg.Provider.Model, cfg.Agent.MaxTurns, cfgPath, cfg, cmdRegistry)
 	model.SetTermCaps(caps)
 	model.SetCmuxClient(cmuxClient)
+	model.SetCheckpointManager(cpMgr)
 	model.SetDebug(debugMode)
 	if rt != nil {
 		model.SetSkillSummaryProvider(rt)
@@ -1768,10 +1778,11 @@ func runInteractive() error {
 		}
 	}
 
-	// Register remaining commands that were previously only in the defaultReg
-	// fallback inside NewModel.
+	// Register remaining commands that need post-model dependencies.
 	for _, cmd := range []commands.SlashCommand{
 		commands.NewUndoOverlayCommand(),
+		commands.NewUndoCommand(cpMgr),
+		commands.NewRewindCommand(cpMgr),
 		commands.NewContextCommand(func() agentsdk.ContextBudget {
 			if model.GetAgent() != nil {
 				return model.GetAgent().ContextBudget()
@@ -1873,6 +1884,7 @@ func runInteractive() error {
 
 	// Enable ACP server for interactive mode
 	opts = append(opts, agent.WithACP())
+	opts = append(opts, agent.WithCheckpointManager(cpMgr))
 
 	// Create agent with the approval function.
 	a := agent.New(p, registry, approvalFunc, cfg, opts...)

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1779,9 +1779,11 @@ func runInteractive() error {
 	}
 
 	// Register remaining commands that need post-model dependencies.
+	// NewUndoOverlayCommand handles /undo via the TUI overlay (shows checkpoint
+	// list). NewUndoCommand is not registered here to avoid a name collision —
+	// the overlay supersedes the direct command in interactive mode.
 	for _, cmd := range []commands.SlashCommand{
 		commands.NewUndoOverlayCommand(),
-		commands.NewUndoCommand(cpMgr),
 		commands.NewRewindCommand(cpMgr),
 		commands.NewContextCommand(func() agentsdk.ContextBudget {
 			if model.GetAgent() != nil {

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1704,14 +1704,18 @@ func runInteractive() error {
 	if err != nil {
 		return fmt.Errorf("create checkpoint manager: %w", err)
 	}
-	defer cpMgr.Cleanup()
+	defer func() {
+		if err := cpMgr.Cleanup(); err != nil {
+			log.Printf("checkpoint cleanup: %v", err)
+		}
+	}()
 
 	// Create TUI model first (with nil agent) so we can extract the
 	// interactive approval function before constructing the agent.
 	model := tui.NewModel(nil, "rubichan", cfg.Provider.Model, cfg.Agent.MaxTurns, cfgPath, cfg, cmdRegistry)
 	model.SetTermCaps(caps)
 	model.SetCmuxClient(cmuxClient)
-	model.SetCheckpointManager(cpMgr)
+	model.SetCheckpointManager(cpMgr) // TUI-only: enables /undo overlay; plainHost uses /rewind directly
 	model.SetDebug(debugMode)
 	if rt != nil {
 		model.SetSkillSummaryProvider(rt)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -411,6 +411,11 @@ func (m *Model) TermCaps() *terminal.Caps {
 	return m.termCaps
 }
 
+// SetCheckpointManager sets the checkpoint manager for undo/rewind support.
+func (m *Model) SetCheckpointManager(mgr *checkpoint.Manager) {
+	m.checkpointMgr = mgr
+}
+
 // SetCmuxClient sets the cmux client for rich sidebar/notification dispatch.
 // Pass nil when not running inside cmux.
 func (m *Model) SetCmuxClient(client cmux.Caller) {


### PR DESCRIPTION
## Summary
- The checkpoint manager, `/undo`, `/rewind` commands, and `WithCheckpointManager` agent option all existed but were never connected in `main.go`
- Creates `checkpoint.Manager` with session-scoped spill directory, passes it to the agent (enables file-modification tracking via toolexec middleware), sets it on the TUI model (enables `/undo` overlay to show checkpoint list), and registers `/undo` + `/rewind` slash commands
- Also adds `SetCheckpointManager` setter on the TUI model

## Test plan
- [x] `go build ./cmd/rubichan/` compiles
- [x] `go test ./cmd/rubichan/ ./internal/tui/ ./internal/checkpoint/` passes
- [ ] Manual: run rubichan, edit a file via agent, type `/undo` — should show the overlay with checkpoint entries and revert the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive sessions now include a checkpoint manager used by the UI and agent, enabling undo and rewind actions within the session.

* **Bug Fixes**
  * Startup now aborts cleanly on checkpoint initialization errors and guarantees checkpoint cleanup.
  * Slash-command registration updated to ensure undo/rewind commands are available after the UI is initialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->