### PR TITLE
Add Z.ai provider to /config overlay

### DIFF
--- a/internal/tui/configform.go
+++ b/internal/tui/configform.go
@@ -33,6 +33,7 @@ func NewConfigForm(cfg *config.Config, savePath string) *ConfigForm {
 				huh.NewOption("Anthropic", "anthropic"),
 				huh.NewOption("OpenAI Compatible", "openai"),
 				huh.NewOption("Ollama", "ollama"),
+				huh.NewOption("Z.ai (Zhipu)", "zai"),
 			).
 			Value(&cfg.Provider.Default),
 		huh.NewInput().

--- a/internal/tui/configform_test.go
+++ b/internal/tui/configform_test.go
@@ -45,3 +45,18 @@ func TestConfigFormSave(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ollama", loaded.Provider.Default)
 }
+
+func TestConfigFormSaveZai(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "zai"
+
+	form := NewConfigForm(cfg, path)
+	err := form.Save()
+	require.NoError(t, err)
+
+	loaded, err := config.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "zai", loaded.Provider.Default)
+}

--- a/internal/tui/configform_test.go
+++ b/internal/tui/configform_test.go
@@ -32,31 +32,19 @@ func TestConfigFormIsCompletedAborted(t *testing.T) {
 }
 
 func TestConfigFormSave(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.toml")
-	cfg := config.DefaultConfig()
-	cfg.Provider.Default = "ollama"
+	for _, provider := range []string{"ollama", "zai"} {
+		t.Run(provider, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.toml")
+			cfg := config.DefaultConfig()
+			cfg.Provider.Default = provider
 
-	form := NewConfigForm(cfg, path)
-	err := form.Save()
-	require.NoError(t, err)
+			form := NewConfigForm(cfg, path)
+			require.NoError(t, form.Save())
 
-	loaded, err := config.Load(path)
-	require.NoError(t, err)
-	assert.Equal(t, "ollama", loaded.Provider.Default)
-}
-
-func TestConfigFormSaveZai(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.toml")
-	cfg := config.DefaultConfig()
-	cfg.Provider.Default = "zai"
-
-	form := NewConfigForm(cfg, path)
-	err := form.Save()
-	require.NoError(t, err)
-
-	loaded, err := config.Load(path)
-	require.NoError(t, err)
-	assert.Equal(t, "zai", loaded.Provider.Default)
+			loaded, err := config.Load(path)
+			require.NoError(t, err)
+			assert.Equal(t, provider, loaded.Provider.Default)
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Add "Z.ai (Zhipu)" as a selectable provider in the `/config` overlay dropdown
- Add test verifying zai config round-trips through save/load

## Test plan
- [x] Existing `TestConfigForm*` tests pass
- [x] New `TestConfigFormSaveZai` verifies zai selection persists to disk
- [ ] Manual: run `/config`, select Z.ai, confirm it saves `default = "zai"` in config.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)