### PR TITLE
Set cmux sidebar color to rubichan pink on init

### DIFF
--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1382,6 +1382,9 @@ func dialCmux(caps *terminal.Caps) (cmux.Caller, func()) {
 		log.Printf("warning: cmux socket detected but dial failed: %v — cmux features disabled", err)
 		return nil, func() {}
 	}
+	// Set sidebar accent color to rubichan's pink theme.
+	cmux.CallerSetSidebarColor(cc, "#FF6B9D")
+
 	return cc, func() { cc.Close() }
 }
 

--- a/internal/cmux/caller.go
+++ b/internal/cmux/caller.go
@@ -20,6 +20,11 @@ func CallerNotify(c Caller, title, subtitle, body string) bool {
 	return err == nil && resp.OK
 }
 
+// CallerSetSidebarColor sets the sidebar accent color via any Caller. Best-effort.
+func CallerSetSidebarColor(c Caller, color string) {
+	c.Call("set-sidebar-color", map[string]string{"color": color}) //nolint:errcheck
+}
+
 // CallerSetProgress sets the sidebar progress via any Caller. Best-effort.
 func CallerSetProgress(c Caller, fraction float64, label string) {
 	c.Call("set-progress", map[string]any{"value": fraction, "label": label}) //nolint:errcheck

--- a/internal/cmux/caller_test.go
+++ b/internal/cmux/caller_test.go
@@ -34,6 +34,20 @@ func TestCallerNotifyFailure(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestCallerSetSidebarColor(t *testing.T) {
+	mc := cmuxtest.NewMockClient()
+	mc.SetResult("set-sidebar-color", true)
+
+	cmux.CallerSetSidebarColor(mc, "#FF6B9D")
+
+	calls := mc.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "set-sidebar-color", calls[0].Method)
+	params, ok := calls[0].Params.(map[string]string)
+	require.True(t, ok)
+	assert.Equal(t, "#FF6B9D", params["color"])
+}
+
 func TestCallerSetProgress(t *testing.T) {
 	mc := cmuxtest.NewMockClient()
 	mc.SetResult("set-progress", true)

--- a/internal/cmux/sidebar.go
+++ b/internal/cmux/sidebar.go
@@ -31,6 +31,12 @@ type LogEntry struct {
 	Source  string `json:"source"`
 }
 
+// SetSidebarColor sets the accent color of the cmux sidebar panel.
+// The color should be a hex color string (e.g. "#FF6B9D").
+func (c *Client) SetSidebarColor(color string) error {
+	return c.callVoid("set-sidebar-color", map[string]string{"color": color})
+}
+
 // SetStatus sets a named status entry in the sidebar.
 func (c *Client) SetStatus(key, value, icon, color string) error {
 	return c.callVoid("set-status", map[string]string{

--- a/internal/cmux/sidebar_test.go
+++ b/internal/cmux/sidebar_test.go
@@ -8,6 +8,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSetSidebarColor(t *testing.T) {
+	handlers := defaultHandlers()
+	var capturedColor string
+	handlers["set-sidebar-color"] = func(req jsonrpcRequest) interface{} {
+		var p struct {
+			Color string `json:"color"`
+		}
+		_ = unmarshalParams(req, &p)
+		capturedColor = p.Color
+		return map[string]string{}
+	}
+	socketPath := newTestServer(t, handlers)
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.SetSidebarColor("#FF6B9D")
+	require.NoError(t, err)
+	assert.Equal(t, "#FF6B9D", capturedColor)
+}
+
+func TestSetSidebarColorError(t *testing.T) {
+	socketPath := newErrorServer(t, "set-sidebar-color")
+	c, err := cmux.Dial(socketPath)
+	require.NoError(t, err)
+	defer c.Close()
+
+	err = c.SetSidebarColor("#FF6B9D")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "set-sidebar-color")
+}
+
 func TestSetStatus(t *testing.T) {
 	handlers := defaultHandlers()
 	var capturedKey, capturedValue, capturedIcon, capturedColor string


### PR DESCRIPTION
## Summary
- Add `SetSidebarColor` method on `Client` and `CallerSetSidebarColor` best-effort helper to the cmux package
- Call `CallerSetSidebarColor(cc, "#FF6B9D")` inside `dialCmux` so the sidebar accent matches rubichan's warm pink across all three execution modes (interactive, headless, wiki)
- Add unit tests for both the `Client` method and the `Caller` helper

## Test plan
- [x] `TestSetSidebarColor` — verifies color is sent via JSON-RPC
- [x] `TestSetSidebarColorError` — verifies error propagation
- [x] `TestCallerSetSidebarColor` — verifies best-effort helper sends correct method/params
- [x] Full `go test ./internal/cmux/...` passes
- [x] `go build ./cmd/rubichan/` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)