### PR TITLE
Wire Z.ai into bootstrap, credentials, and CLI flags

### DIFF
--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1361,6 +1361,10 @@ func applyAPIKeyFlag(cfg *config.Config) {
 	case "ollama":
 		// Ollama doesn't use API keys; ignore silently.
 		return
+	case "zai":
+		cfg.Provider.Zai.APIKeySource = "config"
+		cfg.Provider.Zai.APIKey = apiKeyFlag
+		return
 	}
 	for i, oc := range cfg.Provider.OpenAI {
 		if oc.Name == name {

--- a/internal/config/apikey.go
+++ b/internal/config/apikey.go
@@ -77,6 +77,13 @@ func HasUsableCredentialsForProvider(cfg *Config, providerName string) bool {
 			"ANTHROPIC_API_KEY",
 		)
 		return err == nil
+	case "zai":
+		_, err := ResolveAPIKey(
+			cfg.Provider.Zai.APIKeySource,
+			cfg.Provider.Zai.APIKey,
+			"Z_AI_API_KEY",
+		)
+		return err == nil
 	default:
 		for _, oc := range cfg.Provider.OpenAI {
 			if oc.Name != providerName {

--- a/internal/config/apikey_test.go
+++ b/internal/config/apikey_test.go
@@ -86,3 +86,23 @@ func TestHasUsableCredentialsForProviderAnthropicConfig(t *testing.T) {
 
 	assert.True(t, HasUsableCredentialsForProvider(cfg, "anthropic"))
 }
+
+func TestHasUsableCredentialsForProviderZaiConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.Provider.Zai.APIKeySource = "config"
+	cfg.Provider.Zai.APIKey = "zai-test-key"
+
+	assert.True(t, HasUsableCredentialsForProvider(cfg, "zai"))
+}
+
+func TestHasUsableCredentialsForProviderZaiEnv(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Provider.Zai.APIKeySource = "env"
+
+	assert.False(t, HasUsableCredentialsForProvider(cfg, "zai"))
+
+	t.Setenv("Z_AI_API_KEY", "zai-env-key")
+	assert.True(t, HasUsableCredentialsForProvider(cfg, "zai"))
+}

--- a/internal/tui/bootstrap.go
+++ b/internal/tui/bootstrap.go
@@ -42,6 +42,7 @@ func NewBootstrapForm(savePath string) *BootstrapForm {
 				huh.NewOption("Anthropic (Claude)", "anthropic"),
 				huh.NewOption("OpenAI Compatible", "openai"),
 				huh.NewOption("Ollama (Local)", "ollama"),
+				huh.NewOption("Z.ai (Zhipu)", "zai"),
 			).
 			Value(&cfg.Provider.Default),
 	).Title("Welcome to Rubichan")
@@ -69,6 +70,14 @@ func NewBootstrapForm(savePath string) *BootstrapForm {
 	).Title("OpenAI Compatible Provider").
 		WithHideFunc(func() bool { return cfg.Provider.Default != "openai" })
 
+	zaiKeyGroup := huh.NewGroup(
+		huh.NewInput().
+			Title("Z.ai API Key").
+			Value(&cfg.Provider.Zai.APIKey).
+			EchoMode(huh.EchoModePassword),
+	).Title("Authentication").
+		WithHideFunc(func() bool { return cfg.Provider.Default != "zai" })
+
 	modelGroup := huh.NewGroup(
 		huh.NewInput().
 			Title("Model").
@@ -77,7 +86,7 @@ func NewBootstrapForm(savePath string) *BootstrapForm {
 	).Title("Model").
 		WithHideFunc(func() bool { return cfg.Provider.Default == "ollama" })
 
-	bf.form = huh.NewForm(providerGroup, anthropicKeyGroup, openaiGroup, modelGroup)
+	bf.form = huh.NewForm(providerGroup, anthropicKeyGroup, openaiGroup, zaiKeyGroup, modelGroup)
 	return bf
 }
 
@@ -95,6 +104,9 @@ func (b *BootstrapForm) Config() *config.Config { return b.cfg }
 func (b *BootstrapForm) Save() error {
 	if b.cfg.Provider.Default == "anthropic" && b.cfg.Provider.Anthropic.APIKey != "" {
 		b.cfg.Provider.Anthropic.APIKeySource = "config"
+	}
+	if b.cfg.Provider.Default == "zai" && b.cfg.Provider.Zai.APIKey != "" {
+		b.cfg.Provider.Zai.APIKeySource = "config"
 	}
 	if b.cfg.Provider.Default == "openai" && b.openaiKey != "" {
 		baseURL := b.openaiBaseURL

--- a/internal/tui/bootstrap_test.go
+++ b/internal/tui/bootstrap_test.go
@@ -154,6 +154,37 @@ func TestBootstrapFormSaveOpenAIKey(t *testing.T) {
 	assert.Empty(t, loaded.Provider.Anthropic.APIKey)
 }
 
+func TestBootstrapFormSaveZai(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	form := NewBootstrapForm(path)
+	form.Config().Provider.Default = "zai"
+	form.Config().Provider.Zai.APIKey = "zai-test-key"
+
+	err := form.Save()
+	require.NoError(t, err)
+
+	loaded, err := config.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "zai", loaded.Provider.Default)
+	assert.Equal(t, "zai-test-key", loaded.Provider.Zai.APIKey)
+	assert.Equal(t, "config", loaded.Provider.Zai.APIKeySource)
+}
+
+func TestNeedsBootstrapWithZaiKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "zai"
+	cfg.Provider.Zai.APIKeySource = "config"
+	cfg.Provider.Zai.APIKey = "zai-test"
+	require.NoError(t, config.Save(path, cfg))
+
+	assert.False(t, NeedsBootstrap(path))
+}
+
 func TestBootstrapFormSaveOllamaNoKey(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")


### PR DESCRIPTION
## Summary
- Add "zai" case to `HasUsableCredentialsForProvider` so bootstrap isn't triggered on every restart
- Add Z.ai option + API key input to bootstrap wizard for first-run setup
- Add "zai" case to `applyAPIKeyFlag` so `--api-key` flag works with Z.ai provider

Fixes: selecting Z.ai in /config caused model not to persist and bootstrap to re-trigger on restart.

## Test plan
- [x] `TestHasUsableCredentialsForProviderZaiConfig` — config-based key resolves
- [x] `TestHasUsableCredentialsForProviderZaiEnv` — env-based key resolves
- [x] `TestBootstrapFormSaveZai` — bootstrap saves zai key with correct source
- [x] `TestNeedsBootstrapWithZaiKey` — bootstrap not triggered when zai key exists
- [x] All existing tests pass
- [x] `go build ./cmd/rubichan/` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Z.ai (Zhipu) provider support. Users can now select Z.ai as their default provider and configure API key credentials through the interactive bootstrap wizard or command-line interface, with flexible storage options via environment variables or configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->