### PR TITLE
Fix zai provider not registered at runtime

### DIFF
--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -80,6 +80,7 @@ import (
 	_ "github.com/julianshen/rubichan/internal/provider/anthropic"
 	"github.com/julianshen/rubichan/internal/provider/ollama"
 	_ "github.com/julianshen/rubichan/internal/provider/openai"
+	_ "github.com/julianshen/rubichan/internal/provider/zai"
 )
 
 var (


### PR DESCRIPTION
## Summary
- Add missing blank import `_ "internal/provider/zai"` in `cmd/rubichan/main.go`
- Without it, the zai package's `init()` never runs, so `RegisterProvider("zai", ...)` is never called

## Test plan
- [x] `go build ./cmd/rubichan/` compiles
- [ ] Manual: set provider to zai, restart — no longer crashes with "zai provider not registered"

🤖 Generated with [Claude Code](https://claude.com/claude-code)