### PR TITLE
Fix Z.ai provider: use coding endpoint and wire --api-base flag

### DIFF
--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1317,6 +1317,15 @@ func loadConfig() (*config.Config, error) {
 // BaseURL is overwritten; otherwise a new entry is appended.
 func applyAPIBaseFlag(cfg *config.Config) {
 	name := cfg.Provider.Default
+	// Z.ai has its own config struct — apply directly.
+	if name == "zai" {
+		cfg.Provider.Zai.BaseURL = apiBaseFlag
+		if apiKeyFlag != "" {
+			cfg.Provider.Zai.APIKeySource = "config"
+			cfg.Provider.Zai.APIKey = apiKeyFlag
+		}
+		return
+	}
 	// For built-in providers that don't use the openai_compatible list,
 	// synthesise a provider name so the entry can be looked up later.
 	if name == "anthropic" || name == "ollama" || name == "" {

--- a/internal/provider/apierror.go
+++ b/internal/provider/apierror.go
@@ -130,9 +130,11 @@ var contentFilterPatterns = []string{
 // quotaExceededPatterns detect quota exhaustion that some providers surface as 429.
 var quotaExceededPatterns = []string{
 	"insufficient_quota",
+	"insufficient balance",
 	"quota exceeded",
 	"billing hard limit",
 	"check your plan and billing details",
+	"no resource package",
 }
 
 // classifyByMessage inspects the error message text to refine classification

--- a/internal/provider/apierror_test.go
+++ b/internal/provider/apierror_test.go
@@ -208,6 +208,14 @@ func TestClassifyAPIError_QuotaExceeded_As429(t *testing.T) {
 	assert.False(t, pe.IsRetryable(), "quota exhaustion should not be retryable")
 }
 
+func TestClassifyAPIError_QuotaExceeded_ZaiInsufficientBalance(t *testing.T) {
+	// Z.ai surfaces quota exhaustion as 429 with "Insufficient balance" message.
+	pe := ClassifyAPIError(http.StatusTooManyRequests, []byte(`{"error":{"message":"Insufficient balance or no resource package. Please recharge."}}`), nil, "zai")
+	require.NotNil(t, pe)
+	assert.Equal(t, ErrQuotaExceeded, pe.Kind)
+	assert.False(t, pe.IsRetryable(), "quota exhaustion should not be retryable")
+}
+
 func TestClassifyAPIError_InvalidRequest(t *testing.T) {
 	body := []byte(`{"error":{"message":"invalid parameter: temperature must be between 0 and 2"}}`)
 	pe := ClassifyAPIError(http.StatusBadRequest, body, nil, "openai")

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -120,7 +120,7 @@ func newZaiProvider(cfg *config.Config) (LLMProvider, error) {
 
 	baseURL := cfg.Provider.Zai.BaseURL
 	if baseURL == "" {
-		baseURL = "https://api.z.ai/api/paas/v4"
+		baseURL = "https://api.z.ai/api/coding/paas/v4"
 	}
 
 	model := cfg.Provider.Zai.Model


### PR DESCRIPTION
## Summary
- Switch default Z.ai base URL from `/api/paas/v4` to `/api/coding/paas/v4` — the coding endpoint is correct for AI coding agent API keys (general endpoint returns "insufficient balance" for coding-tier keys)
- Fix `--api-base` flag being silently ignored when `--provider zai` (it only updated OpenAI-compatible config entries, not `cfg.Provider.Zai.BaseURL`)
- Add Z.ai-specific quota error patterns ("insufficient balance", "no resource package") to `apierror.go` so they classify as `ErrQuotaExceeded` instead of generic rate limits

## Test plan
- [x] `go test ./internal/provider/...` — all pass
- [x] `go test ./cmd/rubichan/...` — all pass
- [x] Manual: `rubichan --provider zai --model glm-5 --headless --prompt "..."` succeeds with coding endpoint
- [x] Manual: `rubichan --provider zai --api-base <url>` correctly overrides base URL
- [x] New test: `TestClassifyAPIError_QuotaExceeded_ZaiInsufficientBalance` verifies error classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added special handling for Zai provider API configuration through command-line flags.

* **Bug Fixes**
  * Improved error detection to recognize quota-exceeded scenarios, including insufficient balance and resource package messages.

* **Updates**
  * Updated default API endpoint for Zai provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->