### PR TITLE
Agent loop hardening: typed exit reasons, orphan safety net, compaction breaker, result caps, streaming tool exec

### DIFF
--- a/docs/superpowers/plans/2026-04-13-agent-loop-hardening.md
+++ b/docs/superpowers/plans/2026-04-13-agent-loop-hardening.md
@@ -1,0 +1,1635 @@
+# Agent Loop Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close five production-readiness gaps in Rubichan's agent loop identified by comparing against Claude Code's `query.ts` (see `docs/superpowers/plans/reference_query_ts.md`): typed exit reasons, orphaned tool_result safety net, compaction circuit breaker, per-tool result size budget, and streaming tool execution for concurrency-safe read-only tools.
+
+**Architecture:** Five independent but ordered subsystems. Task 1 (typed exit reasons) is a foundation that later tasks assert on in tests. Task 2 (orphan safety net) and Task 3 (circuit breaker) are small, high-ROI correctness fixes. Task 4 (per-tool result cap) adds a new `MaxResultBytes` capability to the `Tool` interface via an optional extension interface (preserves backward compatibility). Task 5 (streaming tool exec) is the largest change — it adds a `ConcurrencySafe` marker and dispatches safe tools the moment their `input_json_delta` finalizes, while unsafe tools remain queued until stream end.
+
+**Tech Stack:** Go 1.22+, `sourcegraph/conc/pool` for bounded parallelism, existing `provider.StreamEvent` channel model, `modernc.org/sqlite` for persistence (unchanged by this plan).
+
+**Non-Goals:** Model fallback, withholding pattern, Haiku background summarization, token budgets, abort-type distinction. Those are separate plans.
+
+**Invariants preserved:**
+- `TurnEvent{Type: "done"}` is always the last event emitted on the channel (existing contract at `agent.go:882-884`).
+- Every `AddAssistant` with a `tool_use` block is followed by matching `AddToolResult` calls before the next iteration or loop exit.
+- Concurrent `Turn()` calls remain serialized via `a.turnMu`.
+
+---
+
+## File Structure
+
+**New files:**
+- `pkg/agentsdk/exit_reason.go` — `TurnExitReason` enum (Task 1)
+- `internal/agent/orphan.go` — `synthesizeMissingToolResults` helper (Task 2)
+- `internal/agent/orphan_test.go` — unit tests (Task 2)
+- `internal/agent/compaction_breaker_test.go` — circuit breaker tests (Task 3)
+- `pkg/agentsdk/tool_caps.go` — `ResultCappedTool` and `ConcurrencySafeTool` optional interfaces (Tasks 4 & 5)
+- `internal/agent/result_cap.go` — enforcement helper (Task 4)
+- `internal/agent/result_cap_test.go` — tests (Task 4)
+- `internal/agent/stream_tool_exec.go` — streaming dispatcher (Task 5)
+- `internal/agent/stream_tool_exec_test.go` — tests (Task 5)
+
+**Modified files:**
+- `pkg/agentsdk/events.go` — add `ExitReason` field to `TurnEvent` (Task 1)
+- `internal/agent/agent.go` — `runLoop` emits exit reasons, calls orphan sweeper, uses circuit breaker, dispatches streaming tools (Tasks 1, 2, 3, 5)
+- `internal/agent/context.go` — `ContextManager` tracks consecutive compaction failures (Task 3)
+
+---
+
+## Task 1: Typed Exit Reasons
+
+**Why first:** Tasks 2–5 all need to assert in tests that the loop exited for the *correct* reason. Today tests can only assert "did an error event arrive." Ch.5 names this as one of the three reasons async generators beat event emitters; the Go analogue is a final `done` event carrying a typed reason.
+
+**Files:**
+- Create: `pkg/agentsdk/exit_reason.go`
+- Modify: `pkg/agentsdk/events.go` (add field to `TurnEvent`)
+- Modify: `internal/agent/agent.go` (thread reason through every `makeDoneEvent` call site)
+- Modify: `internal/agent/agent_test.go` (add one assertion on reason to an existing test)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/agent/agent_test.go` at the end of the file:
+
+```go
+func TestTurnEmitsExitReasonCompleted(t *testing.T) {
+	t.Parallel()
+	ag, _ := newTestAgentWithStaticReply(t, "done.")
+	ch, err := ag.Turn(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+	var last TurnEvent
+	for ev := range ch {
+		last = ev
+	}
+	if last.Type != "done" {
+		t.Fatalf("want last event type=done, got %q", last.Type)
+	}
+	if last.ExitReason != agentsdk.ExitCompleted {
+		t.Fatalf("want ExitCompleted, got %v", last.ExitReason)
+	}
+}
+```
+
+If `newTestAgentWithStaticReply` does not exist, search `agent_test.go` for the equivalent fixture (look for `newTestAgent` + a fake provider returning a single text block) and use it — do not invent a new fixture.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+go test ./internal/agent/ -run TestTurnEmitsExitReasonCompleted
+```
+Expected: compile error — `agentsdk.ExitCompleted` undefined, `ExitReason` field missing.
+
+- [ ] **Step 3: Create the exit reason enum**
+
+Create `pkg/agentsdk/exit_reason.go`:
+
+```go
+package agentsdk
+
+// TurnExitReason enumerates why a turn stopped. Every "done" TurnEvent
+// carries exactly one of these. New reasons must be added here and nowhere
+// else; callers switch on this value.
+type TurnExitReason int
+
+const (
+	// ExitUnknown is the zero value. Emitting a done event with this reason
+	// is a bug — it means a code path forgot to set a reason.
+	ExitUnknown TurnExitReason = iota
+
+	// ExitCompleted: the model returned no tool calls and no error.
+	ExitCompleted
+
+	// ExitMaxTurns: the loop hit its maxTurns ceiling.
+	ExitMaxTurns
+
+	// ExitCancelled: ctx.Err() was observed (user abort, timeout, etc.).
+	ExitCancelled
+
+	// ExitProviderError: the provider returned an unrecoverable error.
+	ExitProviderError
+
+	// ExitRateLimited: the rate limiter returned an error from Wait().
+	ExitRateLimited
+
+	// ExitSkillActivationFailed: skill runtime could not evaluate triggers.
+	ExitSkillActivationFailed
+
+	// ExitTaskComplete: model invoked the task_complete tool.
+	ExitTaskComplete
+
+	// ExitNoProgress: maxRepeatedPendingToolRounds reached.
+	ExitNoProgress
+
+	// ExitEmptyResponse: model returned no text and no tool calls.
+	ExitEmptyResponse
+
+	// ExitCompactionFailed: compaction circuit breaker tripped (Task 3).
+	ExitCompactionFailed
+
+	// ExitProtocolViolation: orphaned tool_use blocks detected and not
+	// recoverable (reserved for Task 2).
+	ExitProtocolViolation
+
+	// ExitPanic: a panic was recovered in Turn's deferred handler.
+	ExitPanic
+)
+
+// String returns a stable lowercase identifier usable in logs and tests.
+func (r TurnExitReason) String() string {
+	switch r {
+	case ExitCompleted:
+		return "completed"
+	case ExitMaxTurns:
+		return "max_turns"
+	case ExitCancelled:
+		return "cancelled"
+	case ExitProviderError:
+		return "provider_error"
+	case ExitRateLimited:
+		return "rate_limited"
+	case ExitSkillActivationFailed:
+		return "skill_activation_failed"
+	case ExitTaskComplete:
+		return "task_complete"
+	case ExitNoProgress:
+		return "no_progress"
+	case ExitEmptyResponse:
+		return "empty_response"
+	case ExitCompactionFailed:
+		return "compaction_failed"
+	case ExitProtocolViolation:
+		return "protocol_violation"
+	case ExitPanic:
+		return "panic"
+	default:
+		return "unknown"
+	}
+}
+```
+
+- [ ] **Step 4: Add ExitReason field to TurnEvent**
+
+Edit `pkg/agentsdk/events.go`. Find the `TurnEvent` struct definition (starts at line 5). Add a new field immediately after `ContextBudget`:
+
+```go
+	ContextBudget  *ContextBudget     // populated for done events: per-component context usage breakdown
+	ExitReason     TurnExitReason     // populated for done events: why the turn stopped
+```
+
+- [ ] **Step 5: Thread ExitReason through makeDoneEvent**
+
+Edit `internal/agent/agent.go:1140`. Change the signature and body:
+
+```go
+func (a *Agent) makeDoneEvent(inputTokens, outputTokens int, reason agentsdk.TurnExitReason) TurnEvent {
+	budget := a.context.Budget()
+	event := TurnEvent{
+		Type:          "done",
+		InputTokens:   inputTokens,
+		OutputTokens:  outputTokens,
+		ContextBudget: &budget,
+		ExitReason:    reason,
+	}
+	if a.diffTracker != nil {
+		event.DiffSummary = a.diffTracker.Summarize()
+	}
+	return event
+}
+```
+
+- [ ] **Step 6: Update every makeDoneEvent call site**
+
+Run `grep -n makeDoneEvent internal/agent/agent.go` — there are calls around lines 884, 1163, 1173, 1233, 1241, 1362, 1411, 1424, 1434, 1442, 1453, plus any missed. For each, supply the right reason. Exact mapping:
+
+| File:line context | Reason |
+|---|---|
+| Panic recover (`agent.go:884`) | `agentsdk.ExitPanic` |
+| Skill activation error (`:1163`) | `agentsdk.ExitSkillActivationFailed` |
+| `ctx.Err()` at loop top (`:1173`) | `agentsdk.ExitCancelled` |
+| Rate limiter Wait error (`:1233`) | `agentsdk.ExitRateLimited` |
+| Provider Stream error (`:1241`) | `agentsdk.ExitProviderError` |
+| Stream errored mid-way (`:1362`) | `agentsdk.ExitProviderError` |
+| No pending tools — happy path (`:1411`) | `agentsdk.ExitCompleted` |
+| No-progress guard (`:1424`) | `agentsdk.ExitNoProgress` |
+| `task_complete` tool (`:1434`) | `agentsdk.ExitTaskComplete` |
+| Tool exec cancelled (`:1442`) | `agentsdk.ExitCancelled` |
+| Max turns exceeded (`:1453`) | `agentsdk.ExitMaxTurns` |
+
+For the `len(blocks) == 0 && len(pendingTools) == 0` case at agent.go:1397, that path currently appends a placeholder and falls through to the no-pending-tools exit at :1411. Add a sibling error-event emission but still exit via `ExitEmptyResponse` *instead of* `ExitCompleted`. Specifically, before the `if len(pendingTools) == 0` block at :1410, add:
+
+```go
+		emptyResponseExit := false
+		if len(blocks) == 1 && blocks[0].Type == "text" && blocks[0].Text == "[empty response from model]" {
+			emptyResponseExit = true
+		}
+```
+
+And change the no-pending-tools exit to:
+
+```go
+		if len(pendingTools) == 0 {
+			reason := agentsdk.ExitCompleted
+			if emptyResponseExit {
+				reason = agentsdk.ExitEmptyResponse
+			}
+			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, reason)
+			return
+		}
+```
+
+- [ ] **Step 7: Run the test**
+
+```
+go test ./internal/agent/ -run TestTurnEmitsExitReasonCompleted -v
+```
+Expected: PASS.
+
+- [ ] **Step 8: Run full agent test suite**
+
+```
+go test ./internal/agent/...
+```
+Expected: all PASS. If any test fails because it switched on a `done` event without setting `ExitReason`, those failures are real — fix the call site, not the test.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pkg/agentsdk/exit_reason.go pkg/agentsdk/events.go internal/agent/agent.go internal/agent/agent_test.go
+git commit -m "[BEHAVIORAL] Add TurnExitReason enum to done events
+
+Every turn now ends with a typed reason (completed, max_turns, cancelled,
+provider_error, etc.) instead of an untyped done event. Tests can now
+assert on the correct exit path instead of 'no error event arrived'.
+
+Refs: docs/superpowers/plans/2026-04-13-agent-loop-hardening.md Task 1"
+```
+
+---
+
+## Task 2: Orphaned Tool Result Safety Net
+
+**Why:** If `provider.Stream` errors partway through emitting a `tool_use` block — or if the context is cancelled between stream end and `executeTools` — the next API request contains an assistant message with a `tool_use` block that has no matching `tool_result`. Anthropic returns 400 ("messages.N.content.M: tool_use ids were found without tool_result blocks"). Ch.5 calls this the protocol safety net; Claude Code fires it in three places (model crash, fallback, abort). Rubichan fires it zero places.
+
+**Files:**
+- Create: `internal/agent/orphan.go`
+- Create: `internal/agent/orphan_test.go`
+- Modify: `internal/agent/agent.go` (call sweeper before every early return after a stream failure)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/agent/orphan_test.go`:
+
+```go
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/provider"
+)
+
+func TestSynthesizeMissingToolResultsFillsOrphans(t *testing.T) {
+	t.Parallel()
+	conv := NewConversation("sys")
+	conv.AddUser("hi")
+	conv.AddAssistant([]provider.ContentBlock{
+		{Type: "text", Text: "using tools"},
+		{Type: "tool_use", ID: "call_1", Name: "read_file", Input: json.RawMessage(`{"path":"a"}`)},
+		{Type: "tool_use", ID: "call_2", Name: "read_file", Input: json.RawMessage(`{"path":"b"}`)},
+	})
+
+	n := synthesizeMissingToolResults(conv, "stream aborted")
+	if n != 2 {
+		t.Fatalf("want 2 orphans sealed, got %d", n)
+	}
+
+	msgs := conv.Messages()
+	got := map[string]bool{}
+	for _, m := range msgs {
+		for _, b := range m.Content {
+			if b.Type == "tool_result" {
+				got[b.ToolUseID] = true
+			}
+		}
+	}
+	if !got["call_1"] || !got["call_2"] {
+		t.Fatalf("missing tool_result for orphans: %v", got)
+	}
+}
+
+func TestSynthesizeMissingToolResultsSkipsIfAlreadyAnswered(t *testing.T) {
+	t.Parallel()
+	conv := NewConversation("sys")
+	conv.AddUser("hi")
+	conv.AddAssistant([]provider.ContentBlock{
+		{Type: "tool_use", ID: "call_1", Name: "read_file", Input: json.RawMessage(`{}`)},
+	})
+	conv.AddToolResult("call_1", "ok", false)
+
+	n := synthesizeMissingToolResults(conv, "reason")
+	if n != 0 {
+		t.Fatalf("want 0 orphans, got %d", n)
+	}
+}
+
+func TestSynthesizeMissingToolResultsNoAssistantTail(t *testing.T) {
+	t.Parallel()
+	conv := NewConversation("sys")
+	conv.AddUser("hi")
+
+	n := synthesizeMissingToolResults(conv, "reason")
+	if n != 0 {
+		t.Fatalf("want 0 when last message is user, got %d", n)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```
+go test ./internal/agent/ -run TestSynthesizeMissingToolResults -v
+```
+Expected: compile error — `synthesizeMissingToolResults` undefined.
+
+- [ ] **Step 3: Implement the sweeper**
+
+Create `internal/agent/orphan.go`:
+
+```go
+package agent
+
+import "fmt"
+
+// synthesizeMissingToolResults walks the conversation and, for every
+// tool_use block in the most recent assistant message that does not have
+// a matching tool_result in a subsequent message, appends an error
+// tool_result. Returns the number of orphans sealed.
+//
+// This exists because the Anthropic/OpenAI wire protocol requires every
+// tool_use block to be followed by a tool_result. If the stream dies
+// between tool_use emission and tool execution, the next API call fails
+// with a 400 protocol error. Sealing orphans with a synthetic error
+// result keeps the conversation valid for a retry or for resume from
+// a persisted snapshot.
+//
+// Called from every agent-loop exit path that follows a stream which may
+// have emitted tool_use blocks: provider stream error, context cancel
+// mid-stream, rate-limiter error, and the deferred panic handler.
+func synthesizeMissingToolResults(conv *Conversation, reason string) int {
+	msgs := conv.Messages()
+	if len(msgs) == 0 {
+		return 0
+	}
+
+	// Find the last assistant message.
+	assistantIdx := -1
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == "assistant" {
+			assistantIdx = i
+			break
+		}
+	}
+	if assistantIdx == -1 {
+		return 0
+	}
+
+	// Collect tool_use IDs in that assistant message.
+	var pendingIDs []string
+	for _, block := range msgs[assistantIdx].Content {
+		if block.Type == "tool_use" && block.ID != "" {
+			pendingIDs = append(pendingIDs, block.ID)
+		}
+	}
+	if len(pendingIDs) == 0 {
+		return 0
+	}
+
+	// Collect tool_result IDs that appear after the assistant message.
+	answered := map[string]bool{}
+	for i := assistantIdx + 1; i < len(msgs); i++ {
+		for _, block := range msgs[i].Content {
+			if block.Type == "tool_result" && block.ToolUseID != "" {
+				answered[block.ToolUseID] = true
+			}
+		}
+	}
+
+	sealed := 0
+	for _, id := range pendingIDs {
+		if answered[id] {
+			continue
+		}
+		conv.AddToolResult(id,
+			fmt.Sprintf("tool execution did not complete: %s", reason),
+			true,
+		)
+		sealed++
+	}
+	return sealed
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+```
+go test ./internal/agent/ -run TestSynthesizeMissingToolResults -v
+```
+Expected: all three PASS.
+
+- [ ] **Step 5: Wire the sweeper into runLoop exit paths**
+
+Edit `internal/agent/agent.go`. Every early return in `runLoop` that happens *after* `stream, err := a.provider.Stream(ctx, req)` at line 1238 must call the sweeper before returning. Locations:
+
+1. Stream error at `:1361` (`if streamErr { ... return }`) — before the `ch <-` line, insert:
+   ```go
+   synthesizeMissingToolResults(a.conversation, "stream error")
+   ```
+2. Tool exec cancelled at `:1440` — before the `ch <-`, insert:
+   ```go
+   synthesizeMissingToolResults(a.conversation, "cancelled during tool execution")
+   ```
+3. Deferred panic handler at `agent.go:869-887` in `Turn()` — after the `a.logger.Error` line, insert:
+   ```go
+   synthesizeMissingToolResults(a.conversation, "agent panic")
+   ```
+4. `ctx.Err()` check at `:1171` — this runs *before* the stream, so the previous turn's tool_use blocks (if any) are already matched. Do **not** call the sweeper here; if you do, it will no-op, but a misleading "orphan sealed" log could appear.
+
+Do not wire the sweeper into the `max_turns` exit or the happy-path `ExitCompleted` exit — those paths reach the end of an iteration naturally and all tool_use blocks already have results.
+
+- [ ] **Step 6: Write the integration test**
+
+Add to `internal/agent/orphan_test.go`:
+
+```go
+func TestRunLoopStreamErrorLeavesNoOrphans(t *testing.T) {
+	t.Parallel()
+	// Fake provider that emits a tool_use then an error event.
+	fp := &fakeProviderToolThenError{
+		toolID:   "call_1",
+		toolName: "read_file",
+		input:    `{"path":"x"}`,
+		errMsg:   "simulated stream failure",
+	}
+	ag := newTestAgentWithProvider(t, fp)
+	ch, err := ag.Turn(context.Background(), "read x")
+	if err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+	for range ch {
+	}
+
+	// The conversation must not end with an unmatched tool_use.
+	msgs := ag.conversation.Messages()
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role != "assistant" {
+			continue
+		}
+		for _, b := range msgs[i].Content {
+			if b.Type != "tool_use" {
+				continue
+			}
+			// Found a tool_use; a tool_result for it must appear after.
+			found := false
+			for j := i + 1; j < len(msgs); j++ {
+				for _, rb := range msgs[j].Content {
+					if rb.Type == "tool_result" && rb.ToolUseID == b.ID {
+						found = true
+					}
+				}
+			}
+			if !found {
+				t.Fatalf("orphan tool_use %s survived runLoop exit", b.ID)
+			}
+		}
+		break
+	}
+}
+```
+
+Reuse whatever fake provider pattern `agent_test.go` already establishes. If there's no existing "emit tool_use then error" helper, add one minimal shim at the bottom of `orphan_test.go`, not a new file. If the helper already exists, use it.
+
+- [ ] **Step 7: Run the integration test**
+
+```
+go test ./internal/agent/ -run TestRunLoopStreamErrorLeavesNoOrphans -v
+```
+Expected: PASS.
+
+- [ ] **Step 8: Run full package tests**
+
+```
+go test ./internal/agent/... ./pkg/agentsdk/...
+```
+Expected: all PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/agent/orphan.go internal/agent/orphan_test.go internal/agent/agent.go
+git commit -m "[BEHAVIORAL] Seal orphaned tool_use blocks on abnormal loop exit
+
+When Stream errors, context is cancelled mid-tool-exec, or the agent
+panics, the last assistant message may contain tool_use blocks with no
+matching tool_result. The wire protocol rejects this on the next API
+call with a 400. synthesizeMissingToolResults appends error tool_results
+for every orphan so the conversation stays valid and resumable.
+
+Refs: docs/superpowers/plans/2026-04-13-agent-loop-hardening.md Task 2"
+```
+
+---
+
+## Task 3: Compaction Circuit Breaker
+
+**Why:** Ch.5 documents the production horror: "sessions stuck over the context limit burning 250K API calls per day in an infinite compact-fail-retry loop." Rubichan's `ContextManager.Compact` at `context.go:87` silently swallows strategy errors and moves on; if the summarizer consistently errors and no other strategy shrinks the conversation, the loop will re-attempt compaction every turn forever — and `IsBlocked` at hard block will loop into `ForceCompact` which also silently fails.
+
+Add a consecutive-failure counter to `ContextManager`. When it hits 3, surface `ErrCompactionExhausted`. The agent loop catches this and exits with `ExitCompactionFailed`.
+
+**Files:**
+- Modify: `internal/agent/context.go` (add counter + error)
+- Create: `internal/agent/compaction_breaker_test.go`
+- Modify: `internal/agent/agent.go` (catch error at two Compact call sites, exit with typed reason)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/agent/compaction_breaker_test.go`:
+
+```go
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// alwaysFailingStrategy returns a non-nil error from every Compact call.
+type alwaysFailingStrategy struct{ name string }
+
+func (s *alwaysFailingStrategy) Name() string { return s.name }
+func (s *alwaysFailingStrategy) Compact(_ context.Context, msgs []provider.Message, _ int) ([]provider.Message, error) {
+	return msgs, errors.New("boom")
+}
+
+func TestCompactionCircuitBreakerTripsAfterThreeFailures(t *testing.T) {
+	t.Parallel()
+	cm := NewContextManager(100, 10) // tiny budget to force compaction
+	cm.SetStrategies([]agentsdk.CompactionStrategy{&alwaysFailingStrategy{name: "fail"}})
+
+	conv := NewConversation("system")
+	for i := 0; i < 50; i++ {
+		conv.AddUser("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	}
+
+	for i := 0; i < 2; i++ {
+		err := cm.Compact(context.Background(), conv)
+		if err != nil {
+			t.Fatalf("attempt %d: want nil, got %v", i+1, err)
+		}
+	}
+	if err := cm.Compact(context.Background(), conv); !errors.Is(err, ErrCompactionExhausted) {
+		t.Fatalf("want ErrCompactionExhausted on third failure, got %v", err)
+	}
+}
+
+func TestCompactionCircuitBreakerResetsOnSuccess(t *testing.T) {
+	t.Parallel()
+	cm := NewContextManager(100, 10)
+	succeedNext := false
+	strat := &fakeStrategyWithToggle{succeed: &succeedNext}
+	cm.SetStrategies([]agentsdk.CompactionStrategy{strat})
+
+	conv := NewConversation("system")
+	for i := 0; i < 50; i++ {
+		conv.AddUser("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	}
+
+	_ = cm.Compact(context.Background(), conv)
+	_ = cm.Compact(context.Background(), conv)
+	succeedNext = true
+	if err := cm.Compact(context.Background(), conv); err != nil {
+		t.Fatalf("success should reset counter, got %v", err)
+	}
+	succeedNext = false
+	for i := 0; i < 20; i++ {
+		conv.AddUser("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	}
+	// After reset, three new failures needed to trip.
+	_ = cm.Compact(context.Background(), conv)
+	_ = cm.Compact(context.Background(), conv)
+	if err := cm.Compact(context.Background(), conv); !errors.Is(err, ErrCompactionExhausted) {
+		t.Fatalf("want trip after 3 new failures, got %v", err)
+	}
+}
+
+type fakeStrategyWithToggle struct{ succeed *bool }
+
+func (s *fakeStrategyWithToggle) Name() string { return "toggle" }
+func (s *fakeStrategyWithToggle) Compact(_ context.Context, msgs []provider.Message, _ int) ([]provider.Message, error) {
+	if *s.succeed {
+		// Drop half to register as a shrink.
+		if len(msgs) > 2 {
+			return msgs[len(msgs)/2:], nil
+		}
+		return msgs, nil
+	}
+	return msgs, errors.New("boom")
+}
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```
+go test ./internal/agent/ -run TestCompactionCircuitBreaker -v
+```
+Expected: compile error — `ErrCompactionExhausted` undefined, `Compact` currently has no error return.
+
+- [ ] **Step 3: Modify ContextManager**
+
+Edit `internal/agent/context.go`. Add after the existing imports:
+
+```go
+import "errors"
+```
+
+(Merge into the existing import block.)
+
+At the top of the file, after the `import` block, add:
+
+```go
+// ErrCompactionExhausted is returned from Compact/ForceCompact when the
+// strategy chain has failed MaxConsecutiveCompactionFailures times in a
+// row without reducing token count. The loop must terminate rather than
+// retry — infinite compact-fail-retry will burn API budget with no
+// progress. Observed in Claude Code as "250K API calls/day" incidents.
+var ErrCompactionExhausted = errors.New("compaction failed repeatedly; circuit breaker tripped")
+
+// MaxConsecutiveCompactionFailures is the threshold for the circuit
+// breaker. Matches Claude Code's MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES=3.
+const MaxConsecutiveCompactionFailures = 3
+```
+
+Modify the `ContextManager` struct at line 17 to add the counter:
+
+```go
+type ContextManager struct {
+	budget               ContextBudget
+	compactTrigger       float64
+	hardBlock            float64
+	strategies           []CompactionStrategy
+	consecutiveFailures  int
+}
+```
+
+Change `Compact`'s signature (line 87) from returning nothing to returning an error. Rewrite the body:
+
+```go
+func (cm *ContextManager) Compact(ctx context.Context, conv *Conversation) error {
+	if !cm.ShouldCompact(conv) {
+		return nil
+	}
+	systemTokens := len(conv.SystemPrompt())/4 + 10
+	messageBudget := cm.budget.EffectiveWindow() - systemTokens
+	if messageBudget < 0 {
+		messageBudget = 0
+	}
+
+	signals := ComputeConversationSignals(conv.messages)
+	for _, s := range cm.strategies {
+		if sa, ok := s.(SignalAware); ok {
+			sa.SetSignals(signals)
+		}
+	}
+
+	beforeTokens := estimateMessageTokens(conv.messages)
+	anyStrategySucceeded := false
+
+	for i, s := range cm.strategies {
+		if i > 0 && !cm.ExceedsBudget(conv) {
+			break
+		}
+		result, err := s.Compact(ctx, conv.messages, messageBudget)
+		if err != nil {
+			continue
+		}
+		conv.messages = result
+		anyStrategySucceeded = true
+	}
+
+	afterTokens := estimateMessageTokens(conv.messages)
+	shrank := afterTokens < beforeTokens
+
+	if anyStrategySucceeded && shrank {
+		cm.consecutiveFailures = 0
+		return nil
+	}
+
+	cm.consecutiveFailures++
+	if cm.consecutiveFailures >= MaxConsecutiveCompactionFailures {
+		return ErrCompactionExhausted
+	}
+	return nil
+}
+```
+
+The key semantic change: a "success" now requires both (a) at least one strategy returning without error and (b) the token count actually dropping. Silent-no-op strategies no longer reset the breaker.
+
+- [ ] **Step 4: Run the tests**
+
+```
+go test ./internal/agent/ -run TestCompactionCircuitBreaker -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Fix downstream callers of Compact**
+
+`Compact` now returns an error. Find callers:
+
+```
+grep -n "\.context\.Compact(\|cm\.Compact(\|\.Compact(ctx, " internal/agent/ -r
+```
+
+Three in-package call sites to handle:
+
+1. `agent.go:857` (in `Turn`):
+   ```go
+   if err := a.context.Compact(ctx, a.conversation); err != nil && errors.Is(err, ErrCompactionExhausted) {
+       a.turnMu.Unlock()
+       return nil, fmt.Errorf("compaction exhausted before turn start: %w", err)
+   }
+   ```
+   (Return error synchronously — the channel has not been created yet.)
+
+2. `context.go:222` (deprecated `Truncate`): ignore the error — this is a shim.
+   ```go
+   func (cm *ContextManager) Truncate(conv *Conversation) {
+       _ = cm.Compact(context.Background(), conv)
+   }
+   ```
+
+3. Any test files that call `cm.Compact(...)` — just add `_ =` or `if err := ...`.
+
+- [ ] **Step 6: Wire the breaker into runLoop**
+
+Edit `internal/agent/agent.go` around line 1213 where `IsBlocked` triggers `ForceCompact`. `ForceCompact` does not itself participate in the breaker (it returns a result struct, not an error), so instead add a proactive check at the top of each loop iteration right after `ctx.Err() != nil`:
+
+```go
+		if ctx.Err() != nil {
+			ch <- TurnEvent{Type: "error", Error: ctx.Err()}
+			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCancelled)
+			return
+		}
+
+		if err := a.context.Compact(ctx, a.conversation); err != nil {
+			if errors.Is(err, ErrCompactionExhausted) {
+				ch <- TurnEvent{Type: "error", Error: err}
+				ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCompactionFailed)
+				return
+			}
+			// Non-breaker errors should not happen today; log and continue.
+			a.logger.Warn("compaction returned unexpected error: %v", err)
+		}
+```
+
+Add `"errors"` to the imports if not already present.
+
+- [ ] **Step 7: Write a runLoop integration test**
+
+Add to `compaction_breaker_test.go`:
+
+```go
+func TestRunLoopExitsWithCompactionFailed(t *testing.T) {
+	t.Parallel()
+	ag := newTestAgentWithStaticReply(t, "ignored")
+	// Replace context manager with one that always fails.
+	ag.context = NewContextManager(50, 5)
+	ag.context.SetStrategies([]agentsdk.CompactionStrategy{&alwaysFailingStrategy{name: "fail"}})
+	// Bloat the conversation so ShouldCompact is true.
+	for i := 0; i < 100; i++ {
+		ag.conversation.AddUser("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	}
+	// Trip the breaker by pre-failing twice.
+	_ = ag.context.Compact(context.Background(), ag.conversation)
+	_ = ag.context.Compact(context.Background(), ag.conversation)
+
+	ch, err := ag.Turn(context.Background(), "hello")
+	if err != nil {
+		// Turn may return error synchronously — that's valid.
+		if !errors.Is(err, ErrCompactionExhausted) {
+			t.Fatalf("sync error: want ErrCompactionExhausted, got %v", err)
+		}
+		return
+	}
+	var last TurnEvent
+	for ev := range ch {
+		last = ev
+	}
+	if last.ExitReason != agentsdk.ExitCompactionFailed {
+		t.Fatalf("want ExitCompactionFailed, got %v", last.ExitReason)
+	}
+}
+```
+
+- [ ] **Step 8: Run tests**
+
+```
+go test ./internal/agent/...
+```
+Expected: PASS. If pre-existing tests fail because `Compact` now returns an error they ignored, add `_ =` to their call sites — those are structural fixes, not behavioral.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/agent/context.go internal/agent/compaction_breaker_test.go internal/agent/agent.go
+git commit -m "[BEHAVIORAL] Add circuit breaker on repeated compaction failure
+
+ContextManager.Compact now returns ErrCompactionExhausted after three
+consecutive failures (strategy error or no token reduction). The agent
+loop catches this and exits with ExitCompactionFailed instead of
+re-attempting compaction every turn forever. Prevents the 'stuck over
+context limit burning hundreds of thousands of API calls' failure mode.
+
+Refs: docs/superpowers/plans/2026-04-13-agent-loop-hardening.md Task 3"
+```
+
+---
+
+## Task 4: Per-Tool Result Size Budget
+
+**Why:** Ch.5's Layer 0 (`applyToolResultBudget`) enforces per-message size limits on tool results before any compression runs. Rubichan's `shell` tool can currently emit 5 MB of output into a single tool_result; that one result dominates the context window and makes every compaction pass choose between truncating it or leaving everything else. Enforcing a per-tool cap at emission time means the garbage never enters the conversation.
+
+Design: optional extension interface. Tools that care implement `ResultCappedTool`. Tools that don't are exempt (matches Ch.5's "tools without a finite `maxResultSizeChars` are exempted"). Capping is done at `executeSingleTool` boundary, before the result flows to the conversation.
+
+**Files:**
+- Create: `pkg/agentsdk/tool_caps.go`
+- Create: `internal/agent/result_cap.go`
+- Create: `internal/agent/result_cap_test.go`
+- Modify: `internal/agent/agent.go` (apply cap in `executeSingleTool`)
+- Modify: one concrete tool (`internal/tools/shell/...`) to demonstrate the opt-in
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/agent/result_cap_test.go`:
+
+```go
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+type fakeCappedTool struct {
+	name string
+	cap  int
+}
+
+func (t *fakeCappedTool) Name() string                  { return t.name }
+func (t *fakeCappedTool) MaxResultBytes() int           { return t.cap }
+
+func TestApplyResultCapBelowCap(t *testing.T) {
+	t.Parallel()
+	res := agentsdk.ToolResult{Content: "hello"}
+	capped := applyResultCap(&fakeCappedTool{name: "x", cap: 100}, res)
+	if capped.Content != "hello" {
+		t.Fatalf("unexpected content: %q", capped.Content)
+	}
+}
+
+func TestApplyResultCapAboveCapTruncatesAndMarks(t *testing.T) {
+	t.Parallel()
+	big := strings.Repeat("a", 10000)
+	res := agentsdk.ToolResult{Content: big}
+	capped := applyResultCap(&fakeCappedTool{name: "x", cap: 100}, res)
+	if len(capped.Content) > 200 {
+		t.Fatalf("content not truncated, got %d bytes", len(capped.Content))
+	}
+	if !strings.Contains(capped.Content, "truncated") {
+		t.Fatalf("truncation marker missing from: %q", capped.Content)
+	}
+	if !strings.HasPrefix(capped.Content, strings.Repeat("a", 50)) {
+		t.Fatalf("prefix not preserved")
+	}
+}
+
+func TestApplyResultCapNilInterfaceIsNoOp(t *testing.T) {
+	t.Parallel()
+	big := strings.Repeat("a", 10000)
+	res := agentsdk.ToolResult{Content: big}
+	capped := applyResultCap(nil, res)
+	if capped.Content != big {
+		t.Fatalf("nil tool should be no-op")
+	}
+}
+
+func TestApplyResultCapUncappedToolIsNoOp(t *testing.T) {
+	t.Parallel()
+	big := strings.Repeat("a", 10000)
+	res := agentsdk.ToolResult{Content: big}
+	// Tool does not implement ResultCapped — it's a plain Tool.
+	capped := applyResultCap(plainTool{}, res)
+	if capped.Content != big {
+		t.Fatalf("plain tool should be exempt")
+	}
+}
+
+type plainTool struct{}
+
+func (plainTool) Name() string { return "plain" }
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```
+go test ./internal/agent/ -run TestApplyResultCap -v
+```
+Expected: compile error — `applyResultCap` and `ResultCapped` interface undefined.
+
+- [ ] **Step 3: Define the interface**
+
+Create `pkg/agentsdk/tool_caps.go`:
+
+```go
+package agentsdk
+
+// ResultCapped is an optional extension interface for tools that want
+// the agent to truncate their output before it enters the conversation.
+//
+// Tools that implement this interface report a byte cap; if a result's
+// Content exceeds the cap, the agent replaces it with a head+tail slice
+// plus a truncation marker. Tools that don't implement this interface
+// are exempt — their output flows through unchanged.
+//
+// Recommended caps:
+//   - shell:       64 KB (head + tail of interleaved stdout/stderr)
+//   - read_file:   256 KB (large files already have pagination)
+//   - grep/search: 64 KB
+//   - http_fetch:  128 KB
+//
+// Claude Code calls this "Layer 0" of context management in query.ts.
+// Enforcing size at emission prevents a single tool_result from
+// dominating the context window and forcing every subsequent compaction
+// pass to trade granular history for one bloated result.
+type ResultCapped interface {
+	// MaxResultBytes returns the maximum byte length of ToolResult.Content.
+	// Return a non-positive value to opt out (treated as exempt).
+	MaxResultBytes() int
+}
+```
+
+- [ ] **Step 4: Implement applyResultCap**
+
+Create `internal/agent/result_cap.go`:
+
+```go
+package agent
+
+import (
+	"fmt"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// applyResultCap truncates a tool result if the tool implements the
+// ResultCapped interface and the content exceeds its declared cap.
+// Exempt tools (no interface, or cap <= 0) pass through unchanged.
+//
+// The truncation strategy preserves both the head (50%) and tail (50%)
+// of the content minus space for a truncation marker. This beats head-only
+// truncation because tool output often has essential information at both
+// ends — shell commands put errors at the tail, file reads put context at
+// the head.
+func applyResultCap(tool any, res agentsdk.ToolResult) agentsdk.ToolResult {
+	capped, ok := tool.(agentsdk.ResultCapped)
+	if !ok {
+		return res
+	}
+	max := capped.MaxResultBytes()
+	if max <= 0 {
+		return res
+	}
+	if len(res.Content) <= max {
+		return res
+	}
+
+	marker := fmt.Sprintf("\n\n[... truncated: %d bytes exceeded %d byte cap ...]\n\n",
+		len(res.Content), max)
+	slice := max - len(marker)
+	if slice < 200 {
+		// Cap is too small to keep head+tail; just keep head.
+		res.Content = res.Content[:max-len(marker)] + marker
+		return res
+	}
+	head := slice / 2
+	tail := slice - head
+	res.Content = res.Content[:head] + marker + res.Content[len(res.Content)-tail:]
+	return res
+}
+```
+
+- [ ] **Step 5: Run the unit tests**
+
+```
+go test ./internal/agent/ -run TestApplyResultCap -v
+```
+Expected: PASS.
+
+- [ ] **Step 6: Wire cap into executeSingleTool**
+
+Find `executeSingleTool` in `internal/agent/agent.go` (grep for `func (a \*Agent) executeSingleTool`). Locate the point where a `ToolResult` has been returned from the tool and before the result is converted to a `toolExecResult`. Insert:
+
+```go
+	// Enforce per-tool result cap (agentsdk.ResultCapped). Exempt tools
+	// flow through unchanged.
+	if tool != nil {
+		result = applyResultCap(tool, result)
+	}
+```
+
+The exact line depends on the existing body — `tool` is the variable holding the resolved tool instance from the registry, `result` is the `agentsdk.ToolResult`. Add the snippet immediately after the `Execute` call returns and before any conversion to event or result struct.
+
+- [ ] **Step 7: Opt in one real tool as a demonstration**
+
+Find the shell tool. Look for `internal/tools/shell/` and locate the struct that implements `Execute(ctx, input) (ToolResult, error)`. Add:
+
+```go
+// MaxResultBytes implements agentsdk.ResultCapped. Shell output is
+// frequently large; 64 KB keeps head+tail context while preventing a
+// single command from dominating the context window.
+func (*Tool) MaxResultBytes() int { return 64 * 1024 }
+```
+
+(Replace `Tool` with the actual struct name — likely `shellTool` or `ShellTool`.)
+
+- [ ] **Step 8: Add an integration test**
+
+Add to `result_cap_test.go`:
+
+```go
+func TestShellToolReportsCap(t *testing.T) {
+	t.Parallel()
+	// Create the shell tool via its constructor; any non-nil cap > 0 is fine.
+	st := newShellToolForTest(t)
+	capped, ok := interface{}(st).(agentsdk.ResultCapped)
+	if !ok {
+		t.Fatal("shell tool should implement agentsdk.ResultCapped")
+	}
+	if capped.MaxResultBytes() <= 0 {
+		t.Fatal("shell tool cap should be > 0")
+	}
+}
+```
+
+If `newShellToolForTest` doesn't exist, inline the constructor — don't add a new test helper file just for this. If the shell tool's package name differs from what the import path suggests, adjust the import.
+
+- [ ] **Step 9: Run full tests**
+
+```
+go test ./internal/agent/... ./pkg/agentsdk/... ./internal/tools/shell/...
+```
+Expected: all PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add pkg/agentsdk/tool_caps.go internal/agent/result_cap.go internal/agent/result_cap_test.go internal/agent/agent.go internal/tools/shell/
+git commit -m "[BEHAVIORAL] Add per-tool result size cap via ResultCapped interface
+
+Tools that implement agentsdk.ResultCapped report a MaxResultBytes value;
+the agent truncates oversize results at emission with a head+tail slice
+and a marker. Exempt tools (no interface) pass through unchanged. Shell
+tool opts in at 64 KB — previously a chatty command could dump megabytes
+into a single tool_result and dominate the context window, forcing every
+subsequent compaction to trade granular history for one bloated result.
+
+Refs: docs/superpowers/plans/2026-04-13-agent-loop-hardening.md Task 4"
+```
+
+---
+
+## Task 5: Streaming Tool Execution for Concurrency-Safe Tools
+
+**Why:** Today `runLoop` accumulates the entire assistant response (text + tool_use deltas) into `toolInputBuf` and only dispatches tools after `stream` returns EOF at agent.go:1335. Claude Code's `StreamingToolExecutor` dispatches concurrency-safe tools the moment their `tool_use` block finalizes — so by the time the model finishes its trailing text, the `Read` result is already in memory.
+
+For a typical "read file, reason, edit" turn, this is a 1–3 second latency win because the model's post-tool text streams in parallel with disk I/O.
+
+Design:
+- New optional marker interface `agentsdk.ConcurrencySafeTool` with method `IsConcurrencySafe() bool`. Read-only tools (`read_file`, `grep`, `glob`, `list_dir`, `code_search`, `http_fetch` GET) implement it; write tools (`write_file`, `patch_file`, `shell`, `edit`) do not.
+- New `streamingToolExecutor` type owns an in-flight map keyed by tool_use_id, a results channel, and a `sync.WaitGroup`.
+- When `runLoop` finalizes a tool_use block during streaming (existing `finalizeTool` closure at agent.go:1254), it calls `execStream.Dispatch(tool)` if the tool is concurrency-safe, auto-approved, and parallelizable. Non-safe tools are queued via the existing path.
+- When the stream ends, `execStream.Drain()` waits for outstanding futures and merges their results into `results []toolExecResult` *in original tool-call order*.
+- Tools not streamed are executed by the existing `executeTools` code path. Results are merged by position.
+- **Abort semantics**: if `ctx` is cancelled mid-stream, `Drain` waits for in-flight futures but does not dispatch anything new. Any tool that hasn't started gets a synthesized cancellation tool_result via the orphan sweeper from Task 2.
+
+This task depends on Tasks 1 (exit reasons for test assertions) and 2 (orphan sweeper for safe cancellation).
+
+**Files:**
+- Modify: `pkg/agentsdk/tool_caps.go` (add `ConcurrencySafeTool` interface, same file as Task 4)
+- Create: `internal/agent/stream_tool_exec.go`
+- Create: `internal/agent/stream_tool_exec_test.go`
+- Modify: `internal/agent/agent.go` (wire executor into `runLoop`)
+- Modify: one or two read-only tools to opt in (`read_file`, `grep`)
+
+- [ ] **Step 1: Add the ConcurrencySafeTool interface**
+
+Append to `pkg/agentsdk/tool_caps.go`:
+
+```go
+// ConcurrencySafeTool is an optional extension interface. Tools that
+// implement it declare themselves safe to execute as soon as their
+// tool_use block finalizes during streaming — the agent dispatches them
+// without waiting for the full model response.
+//
+// A tool is concurrency-safe if and only if:
+//   1. It has no observable side effects on the filesystem, network,
+//      or process state (pure reads).
+//   2. Its result depends only on the input and on external state that
+//      won't be mutated by another concurrently-dispatched tool.
+//   3. Re-ordering it with respect to sibling tool calls in the same
+//      response is a no-op as far as the user is concerned.
+//
+// Tools that return false (or don't implement the interface) are queued
+// and executed after the stream completes, in declaration order, via
+// the normal executeTools pipeline.
+//
+// Examples of safe tools: read_file, grep, glob, list_dir, code_search,
+// http_get.
+//
+// Examples of unsafe tools: write_file, patch_file, shell, edit, git,
+// database writes, anything with network side effects.
+type ConcurrencySafeTool interface {
+	IsConcurrencySafe() bool
+}
+```
+
+- [ ] **Step 2: Write the executor test first**
+
+Create `internal/agent/stream_tool_exec_test.go`:
+
+```go
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+type fakeConcurrencySafeTool struct {
+	name       string
+	execDelay  time.Duration
+	called     atomic.Int32
+	returnText string
+}
+
+func (t *fakeConcurrencySafeTool) Name() string                 { return t.name }
+func (t *fakeConcurrencySafeTool) Description() string          { return "" }
+func (t *fakeConcurrencySafeTool) InputSchema() json.RawMessage { return nil }
+func (t *fakeConcurrencySafeTool) IsConcurrencySafe() bool      { return true }
+func (t *fakeConcurrencySafeTool) Execute(ctx context.Context, _ json.RawMessage) (agentsdk.ToolResult, error) {
+	t.called.Add(1)
+	select {
+	case <-time.After(t.execDelay):
+	case <-ctx.Done():
+		return agentsdk.ToolResult{}, ctx.Err()
+	}
+	return agentsdk.ToolResult{Content: t.returnText}, nil
+}
+
+func TestStreamingExecutorDispatchesSafeToolsImmediately(t *testing.T) {
+	t.Parallel()
+	// Two slow concurrency-safe tools. If executed sequentially after
+	// stream-end, the turn would take ~200ms. If dispatched during
+	// streaming, they run in parallel with wall time ~100ms.
+	tool := &fakeConcurrencySafeTool{
+		name:       "read_file",
+		execDelay:  100 * time.Millisecond,
+		returnText: "ok",
+	}
+	ex := newStreamingToolExecutor(2)
+	ctx := context.Background()
+
+	start := time.Now()
+	ex.Dispatch(ctx, tool, provider.ToolUseBlock{ID: "a", Name: "read_file", Input: json.RawMessage(`{}`)})
+	ex.Dispatch(ctx, tool, provider.ToolUseBlock{ID: "b", Name: "read_file", Input: json.RawMessage(`{}`)})
+	results := ex.Drain()
+	elapsed := time.Since(start)
+
+	if len(results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(results))
+	}
+	if elapsed > 180*time.Millisecond {
+		t.Fatalf("tools ran sequentially (%v) — expected parallel dispatch", elapsed)
+	}
+	if tool.called.Load() != 2 {
+		t.Fatalf("want 2 invocations, got %d", tool.called.Load())
+	}
+}
+
+func TestStreamingExecutorPreservesResultOrder(t *testing.T) {
+	t.Parallel()
+	fast := &fakeConcurrencySafeTool{name: "fast", execDelay: 10 * time.Millisecond, returnText: "fast"}
+	slow := &fakeConcurrencySafeTool{name: "slow", execDelay: 80 * time.Millisecond, returnText: "slow"}
+	ex := newStreamingToolExecutor(2)
+	ctx := context.Background()
+
+	ex.Dispatch(ctx, slow, provider.ToolUseBlock{ID: "first", Name: "slow"})
+	ex.Dispatch(ctx, fast, provider.ToolUseBlock{ID: "second", Name: "fast"})
+	results := ex.Drain()
+
+	if len(results) != 2 || results[0].toolUseID != "first" || results[1].toolUseID != "second" {
+		t.Fatalf("order not preserved: %+v", results)
+	}
+	if results[0].content != "slow" || results[1].content != "fast" {
+		t.Fatalf("content mismatch: %+v", results)
+	}
+}
+
+func TestStreamingExecutorCancelBlocksNewDispatch(t *testing.T) {
+	t.Parallel()
+	tool := &fakeConcurrencySafeTool{name: "read_file", execDelay: 50 * time.Millisecond, returnText: "ok"}
+	ex := newStreamingToolExecutor(2)
+	ctx, cancel := context.WithCancel(context.Background())
+	ex.Dispatch(ctx, tool, provider.ToolUseBlock{ID: "a"})
+	cancel()
+	// Dispatching after cancel should be a no-op (tool still gets a result,
+	// but it's an error result synthesized by the executor).
+	ex.Dispatch(ctx, tool, provider.ToolUseBlock{ID: "b"})
+	results := ex.Drain()
+	if len(results) != 2 {
+		t.Fatalf("want 2 results (one ok, one cancelled), got %d", len(results))
+	}
+	// The 'b' dispatch after cancel must be marked as an error.
+	var bResult *toolExecResult
+	for i := range results {
+		if results[i].toolUseID == "b" {
+			bResult = &results[i]
+		}
+	}
+	if bResult == nil || !bResult.isError {
+		t.Fatalf("dispatch-after-cancel should produce an error result, got %+v", bResult)
+	}
+}
+```
+
+- [ ] **Step 3: Run to confirm failure**
+
+```
+go test ./internal/agent/ -run TestStreamingExecutor -v
+```
+Expected: `newStreamingToolExecutor` undefined.
+
+- [ ] **Step 4: Implement the executor**
+
+Create `internal/agent/stream_tool_exec.go`:
+
+```go
+package agent
+
+import (
+	"context"
+	"sync"
+
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// streamingToolExecutor dispatches concurrency-safe tools as soon as
+// their tool_use block finalizes during a streaming model response.
+// Results are collected and returned in dispatch order from Drain().
+//
+// Ordering note: tools are dispatched in stream order (the order the
+// model emits tool_use blocks). Drain() returns them in that same
+// dispatch order, regardless of execution wall time. This matches the
+// protocol requirement that tool_result messages follow their matching
+// tool_use in conversation order.
+//
+// Parallelism is bounded by maxParallel; excess dispatches block in the
+// goroutine pool. Callers typically set this to maxParallelTools (8).
+type streamingToolExecutor struct {
+	sem     chan struct{}
+	mu      sync.Mutex
+	futures []*toolFuture
+	wg      sync.WaitGroup
+}
+
+type toolFuture struct {
+	toolUseID string
+	toolName  string
+	done      chan struct{}
+	result    toolExecResult
+}
+
+func newStreamingToolExecutor(maxParallel int) *streamingToolExecutor {
+	if maxParallel < 1 {
+		maxParallel = 1
+	}
+	return &streamingToolExecutor{
+		sem: make(chan struct{}, maxParallel),
+	}
+}
+
+// Dispatch starts execution of a concurrency-safe tool in the background.
+// If ctx is already cancelled, the future is completed immediately with
+// an error result — the tool is not executed. The caller must still call
+// Drain to retrieve the result slot in order.
+func (e *streamingToolExecutor) Dispatch(ctx context.Context, tool agentsdk.Tool, tc provider.ToolUseBlock) {
+	f := &toolFuture{
+		toolUseID: tc.ID,
+		toolName:  tc.Name,
+		done:      make(chan struct{}),
+	}
+	e.mu.Lock()
+	e.futures = append(e.futures, f)
+	e.mu.Unlock()
+
+	if ctx.Err() != nil {
+		f.result = toolErrorResult(tc, "context cancelled before tool dispatch")
+		close(f.done)
+		return
+	}
+
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+		// Bound parallelism.
+		select {
+		case e.sem <- struct{}{}:
+		case <-ctx.Done():
+			f.result = toolErrorResult(tc, "context cancelled while waiting for executor slot")
+			close(f.done)
+			return
+		}
+		defer func() { <-e.sem }()
+
+		res, err := tool.Execute(ctx, tc.Input)
+		if err != nil {
+			f.result = toolErrorResult(tc, err.Error())
+			close(f.done)
+			return
+		}
+		res = applyResultCap(tool, res)
+		f.result = toolExecResult{
+			toolUseID: tc.ID,
+			content:   res.Content,
+			isError:   res.IsError,
+			event:     makeToolResultEvent(tc.ID, tc.Name, res.Content, res.Display(), res.IsError),
+		}
+		close(f.done)
+	}()
+}
+
+// Drain waits for every dispatched future to complete and returns
+// their results in dispatch order. Safe to call once; subsequent calls
+// return an empty slice.
+func (e *streamingToolExecutor) Drain() []toolExecResult {
+	e.wg.Wait()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]toolExecResult, 0, len(e.futures))
+	for _, f := range e.futures {
+		<-f.done
+		out = append(out, f.result)
+	}
+	e.futures = nil
+	return out
+}
+
+// isStreamingEligible returns true if a tool can be dispatched during
+// streaming. Requires the ConcurrencySafeTool marker AND auto-approval.
+func isStreamingEligible(tool agentsdk.Tool, result ApprovalResult) bool {
+	cs, ok := tool.(agentsdk.ConcurrencySafeTool)
+	if !ok || !cs.IsConcurrencySafe() {
+		return false
+	}
+	return result == agentsdk.AutoApproved || result == agentsdk.TrustRuleApproved
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+```
+go test ./internal/agent/ -run TestStreamingExecutor -v
+```
+Expected: PASS.
+
+- [ ] **Step 6: Wire the executor into runLoop**
+
+Edit `internal/agent/agent.go`. The goal is to dispatch eligible tools from `finalizeTool` and merge the results in `executeTools`.
+
+First, inside `runLoop` just before the accumulator `var blocks []provider.ContentBlock` at line 1246, add:
+
+```go
+		execStream := newStreamingToolExecutor(maxParallelTools)
+		streamingDispatched := map[string]bool{}
+```
+
+Modify the `finalizeTool` closure at line 1254. After `pendingTools = append(pendingTools, *currentTool)` and before the `blocks = append(...)` line, insert:
+
+```go
+			// Dispatch concurrency-safe, auto-approved tools immediately
+			// so they run while the model continues streaming post-tool
+			// text. The result is collected at stream end.
+			if a.approvalChecker != nil {
+				approval := a.approvalChecker.CheckApproval(currentTool.Name, currentTool.Input)
+				tool, ok := a.tools.Get(currentTool.Name)
+				if ok && isStreamingEligible(tool, approval) {
+					execStream.Dispatch(ctx, tool, *currentTool)
+					streamingDispatched[currentTool.ID] = true
+				}
+			}
+```
+
+(`a.tools.Get` — confirm the exact method name on the registry via `grep -n "func.*Registry.*Get" internal/tools/`. If the method is called something else like `Lookup` or `Tool`, adjust accordingly.)
+
+Then, modify `executeTools` at line 1566 to accept a pre-populated results map from streamed dispatches. The simplest change is a new parameter:
+
+```go
+func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTools []provider.ToolUseBlock, streamedResults map[string]toolExecResult) bool {
+```
+
+At the start of `executeTools`, after the planning step, skip tools already in `streamedResults`:
+
+```go
+	// Merge in results that were dispatched during streaming. These tools
+	// skip approval/parallelization planning — they already ran.
+	results := make([]toolExecResult, len(pendingTools))
+	planned := make([]plannedToolCall, 0, len(pendingTools))
+	for i, tc := range pendingTools {
+		if r, ok := streamedResults[tc.ID]; ok {
+			results[i] = r
+			// Still emit a tool_call event so the UI sees it.
+			ch <- TurnEvent{
+				Type: "tool_call",
+				ToolCall: &ToolCallEvent{ID: tc.ID, Name: tc.Name, Input: tc.Input},
+			}
+			continue
+		}
+		planned = append(planned, plannedToolCall{
+			index:          i,
+			tc:             tc,
+			approvalResult: a.approvalResultForTool(tc),
+		})
+	}
+```
+
+Then replace the existing partition loop to iterate over `planned` instead of `plannedTools` (rename variable). The existing auto-approved / denied / needs-approval partitioning and parallel execution stays as-is. At the end, the existing "emit results in original order" loop still works because we pre-filled `results[i]` for streamed tools.
+
+At the `executeTools` call sites at agent.go:1433 and :1440, pass the drained map:
+
+```go
+		streamedResults := map[string]toolExecResult{}
+		for _, r := range execStream.Drain() {
+			streamedResults[r.toolUseID] = r
+		}
+
+		// Check if the model signaled task completion...
+		for _, tc := range pendingTools {
+			if tc.Name == tools.TaskCompleteName {
+				a.executeTools(ctx, ch, pendingTools, streamedResults)
+				ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitTaskComplete)
+				return
+			}
+		}
+
+		if cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults); cancelled {
+			synthesizeMissingToolResults(a.conversation, "cancelled during tool execution")
+			ch <- TurnEvent{Type: "error", Error: ctx.Err()}
+			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCancelled)
+			return
+		}
+```
+
+Also: the helper `executePlannedToolsSequential` at :1711 is called only when `approvalChecker == nil`. Pass `nil` as the streamed map and accept it as a parameter:
+
+```go
+	return a.executePlannedToolsSequential(ctx, ch, a.planToolCalls(pendingTools), streamedResults)
+```
+
+Add an early merge at the top of `executePlannedToolsSequential` matching what `executeTools` does.
+
+- [ ] **Step 7: Opt in read_file and grep**
+
+Find the read_file tool (`grep -rn "func.*Name.*\"read_file\"" internal/tools/`) and add:
+
+```go
+// IsConcurrencySafe declares this tool as eligible for streaming dispatch.
+// read_file is a pure read with no side effects.
+func (*ReadFileTool) IsConcurrencySafe() bool { return true }
+```
+
+Do the same for `grep`, `glob`, `list_dir`, and `code_search` if they exist. Each gets one method, ~3 lines. Replace `ReadFileTool` with the actual struct name.
+
+- [ ] **Step 8: Write a runLoop integration test**
+
+Add to `stream_tool_exec_test.go`:
+
+```go
+func TestRunLoopStreamsReadFileDuringModelResponse(t *testing.T) {
+	t.Parallel()
+	// Fake provider that streams: text_delta, tool_use (read_file), 200ms of text_delta.
+	// Real read_file would normally take near-zero time; we use a fake that sleeps 100ms
+	// during Execute to observe overlap.
+	readTool := &fakeConcurrencySafeTool{name: "read_file", execDelay: 100 * time.Millisecond, returnText: "file contents"}
+	fp := newStreamingFakeProvider(readTool, 200*time.Millisecond)
+	ag := newTestAgentWithProviderAndTool(t, fp, readTool)
+
+	start := time.Now()
+	ch, err := ag.Turn(context.Background(), "read it")
+	if err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+	for range ch {
+	}
+	elapsed := time.Since(start)
+
+	// Without streaming: 200ms stream + 100ms tool = 300ms minimum.
+	// With streaming: max(200ms, 100ms) = 200ms. Allow 50ms slack.
+	if elapsed > 260*time.Millisecond {
+		t.Fatalf("streaming dispatch not effective — elapsed %v", elapsed)
+	}
+}
+```
+
+If `newStreamingFakeProvider` does not exist, implement it inline as a minimal `provider.Provider` whose `Stream` method emits text_delta events, then a tool_use event, then more text_delta events with `time.Sleep` between them, then a stop event.
+
+- [ ] **Step 9: Run tests**
+
+```
+go test ./internal/agent/... -race
+```
+Expected: all PASS, no data races.
+
+- [ ] **Step 10: Run the broader suite**
+
+```
+go test ./... -race
+```
+Expected: all PASS. Any failure in a mode's ACP tests is a wiring issue — the `executeTools` signature changed and every caller needs updating. Fix with `_, _ = ...` only if the caller was previously ignoring the return value (existing pattern).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add pkg/agentsdk/tool_caps.go internal/agent/stream_tool_exec.go internal/agent/stream_tool_exec_test.go internal/agent/agent.go internal/tools/
+git commit -m "[BEHAVIORAL] Dispatch concurrency-safe tools during streaming
+
+Tools implementing agentsdk.ConcurrencySafeTool are dispatched the moment
+their tool_use block finalizes during a streaming response, running in
+parallel with the remaining post-tool text. read_file, grep, glob,
+list_dir, and code_search opt in. Write/shell tools remain queued until
+stream end. For turns that read a file before reasoning, the file is
+already in memory by the time the model finishes its preamble — typical
+latency win 1–3 seconds on large-context turns.
+
+Refs: docs/superpowers/plans/2026-04-13-agent-loop-hardening.md Task 5"
+```
+
+---
+
+## Verification
+
+After all five tasks, run:
+
+```
+go test ./... -race
+golangci-lint run ./...
+gofmt -l .
+```
+
+Expected: all PASS, no output from `gofmt -l`, no lint errors.
+
+Check coverage on touched files:
+
+```
+go test ./internal/agent/ ./pkg/agentsdk/ -cover
+```
+
+Expected: coverage >= 90% per the project standard.
+
+## Rollout Notes
+
+**Backward compatibility:** All five tasks are additive. `TurnExitReason` adds an enum field (zero value = `ExitUnknown`, which is a bug signal). The orphan sweeper only appends messages — it never modifies or drops. The circuit breaker only trips on repeated failures; healthy sessions are unaffected. `ResultCapped` and `ConcurrencySafeTool` are opt-in extension interfaces; tools that don't implement them are exempt.
+
+**Observability:** After Task 1, consumers should log `event.ExitReason.String()` on every `done` event. That alone will reveal how often the production loop hits `ExitNoProgress`, `ExitEmptyResponse`, or (newly) `ExitCompactionFailed` — useful signal that the old untyped done event was hiding.
+
+**What's deliberately not in this plan:**
+- Model fallback and thinking-signature stripping (requires multi-provider coordination)
+- Withholding pattern for recoverable errors (requires a buffered error queue inside the loop)
+- Haiku background tool-use summarization (requires a dedicated summarizer provider config)
+- Token budget with diminishing-returns detection (requires a new `TokenBudget` config type)
+- Abort type distinction (hard abort vs submit-interrupt) — requires TUI-side changes too
+
+Each of these is a separate plan. Tasks 1–3 are prerequisites for any of them.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -881,7 +881,7 @@ func (a *Agent) Turn(ctx context.Context, userMessage string) (<-chan TurnEvent,
 				}
 				// Maintain contract: every turn ends with a "done" event.
 				select {
-				case ch <- TurnEvent{Type: "done"}:
+				case ch <- TurnEvent{Type: "done", ExitReason: agentsdk.ExitPanic}:
 				default:
 				}
 			}
@@ -1137,13 +1137,14 @@ func (a *Agent) buildSystemPromptWithFragments(ctx context.Context, lastUserMess
 
 // makeDoneEvent constructs a "done" TurnEvent, attaching the cumulative diff
 // summary from the DiffTracker if one is attached, and the context budget.
-func (a *Agent) makeDoneEvent(inputTokens, outputTokens int) TurnEvent {
+func (a *Agent) makeDoneEvent(inputTokens, outputTokens int, reason agentsdk.TurnExitReason) TurnEvent {
 	budget := a.context.Budget()
 	event := TurnEvent{
 		Type:          "done",
 		InputTokens:   inputTokens,
 		OutputTokens:  outputTokens,
 		ContextBudget: &budget,
+		ExitReason:    reason,
 	}
 	if a.diffTracker != nil {
 		event.DiffSummary = a.diffTracker.Summarize()
@@ -1160,7 +1161,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		triggerCtx := a.buildSkillTriggerContext(lastUserMessage)
 		if err := a.skillRuntime.EvaluateAndActivate(triggerCtx); err != nil {
 			ch <- TurnEvent{Type: "error", Error: fmt.Errorf("activate skills for turn: %w", err)}
-			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens)
+			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitSkillActivationFailed)
 			return
 		}
 	}
@@ -1170,7 +1171,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 
 		if ctx.Err() != nil {
 			ch <- TurnEvent{Type: "error", Error: ctx.Err()}
-			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens)
+			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCancelled)
 			return
 		}
 
@@ -1230,7 +1231,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			}
 			if err := a.rateLimiter.Wait(ctx); err != nil {
 				ch <- TurnEvent{Type: "error", Error: fmt.Errorf("rate limiter: %w", err)}
-				ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens)
+				ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitRateLimited)
 				return
 			}
 		}
@@ -1238,7 +1239,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		stream, err := a.provider.Stream(ctx, req)
 		if err != nil {
 			ch <- TurnEvent{Type: "error", Error: fmt.Errorf("provider stream: %w", err)}
-			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens)
+			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError)
 			return
 		}
 
@@ -1359,7 +1360,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 
 		// On stream error, discard partial blocks to prevent conversation corruption
 		if streamErr {
-			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens)
+			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError)
 			return
 		}
 
@@ -1400,6 +1401,11 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			ch <- TurnEvent{Type: "error", Error: fmt.Errorf("empty response from model")}
 		}
 
+		emptyResponseExit := false
+		if len(blocks) == 1 && blocks[0].Type == "text" && blocks[0].Text == "[empty response from model]" {
+			emptyResponseExit = true
+		}
+
 		// Add assistant message with accumulated blocks
 		if len(blocks) > 0 {
 			a.conversation.AddAssistant(blocks)
@@ -1408,7 +1414,11 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 
 		// If no pending tool calls, we're done
 		if len(pendingTools) == 0 {
-			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens)
+			reason := agentsdk.ExitCompleted
+			if emptyResponseExit {
+				reason = agentsdk.ExitEmptyResponse
+			}
+			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, reason)
 			return
 		}
 
@@ -1421,7 +1431,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		}
 		if repeatedPendingToolRounds >= maxRepeatedPendingToolRounds {
 			ch <- TurnEvent{Type: "error", Error: fmt.Errorf("detected no progress after %d repeated tool-only rounds", repeatedPendingToolRounds)}
-			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens)
+			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitNoProgress)
 			return
 		}
 
@@ -1431,7 +1441,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		for _, tc := range pendingTools {
 			if tc.Name == tools.TaskCompleteName {
 				a.executeTools(ctx, ch, pendingTools)
-				ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens)
+				ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitTaskComplete)
 				return
 			}
 		}
@@ -1439,7 +1449,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// Execute tool calls — parallelize auto-approved tools when possible.
 		if cancelled := a.executeTools(ctx, ch, pendingTools); cancelled {
 			ch <- TurnEvent{Type: "error", Error: ctx.Err()}
-			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens)
+			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCancelled)
 			return
 		}
 
@@ -1451,7 +1461,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 
 	// Reached max turns.
 	ch <- TurnEvent{Type: "error", Error: fmt.Errorf("max turns (%d) exceeded", a.maxTurns)}
-	ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens)
+	ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitMaxTurns)
 }
 
 const maxRepeatedPendingToolRounds = 3

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -877,7 +877,7 @@ func (a *Agent) Turn(ctx context.Context, userMessage string) (<-chan TurnEvent,
 			if r := recover(); r != nil {
 				stack := debug.Stack()
 				a.logger.Error("agent panic recovered: %v\n%s", r, stack)
-				synthesizeMissingToolResults(a.conversation, "agent panic")
+				synthesizeMissingToolResults(a.conversation, orphanReasonPanic)
 				// Non-blocking send to avoid deadlocking turnMu if channel
 				// buffer is full (e.g., reader stopped consuming events).
 				select {
@@ -1292,14 +1292,17 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 
 				// Streaming dispatch: if the tool is concurrency-safe
 				// and auto-approved, start executing it now so it runs
-				// in parallel with the remaining model stream.
-				if a.approvalChecker != nil {
-					if tool, ok := a.tools.Get(currentTool.Name); ok {
-						approval := a.approvalChecker.CheckApproval(currentTool.Name, currentTool.Input)
-						if isStreamingEligible(tool, approval) {
+				// in parallel with the remaining model stream. The
+				// marker check comes first so non-eligible tools skip
+				// the approval scan entirely — approval can be expensive
+				// when a security scanner is wired in.
+				if tool, ok := a.tools.Get(currentTool.Name); ok {
+					if cs, csok := tool.(agentsdk.ConcurrencySafeTool); csok && cs.IsConcurrencySafe() {
+						approval := a.approvalResultForTool(*currentTool)
+						if approval == AutoApproved || approval == TrustRuleApproved {
 							// Dispatch in background; executeTools
-							// will emit the tool_call event when it
-							// sees the cached result.
+							// emits the tool_call event when it sees
+							// the cached result.
 							execStream.Dispatch(ctx, *currentTool)
 						}
 					}
@@ -1407,7 +1410,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			_ = execStream.Drain()
 			// Defensive: currently a no-op because AddAssistant has not been called
 			// yet on this path, but protects against future reorderings.
-			synthesizeMissingToolResults(a.conversation, "stream error")
+			synthesizeMissingToolResults(a.conversation, orphanReasonStreamError)
 			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError)
 			return
 		}
@@ -1442,12 +1445,14 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// If the LLM returned no content at all (no text, no tool calls),
 		// emit an error and add a placeholder assistant message to keep the
 		// conversation valid (every user message must be followed by an
-		// assistant message).
-		emptyResponseExit := false
+		// assistant message). The placeholder downgrades the exit reason
+		// from ExitCompleted to ExitEmptyResponse so observability can
+		// distinguish "model said nothing" from "model finished normally".
+		exitReason := agentsdk.ExitCompleted
 		if len(blocks) == 0 && len(pendingTools) == 0 {
-			blocks = append(blocks, provider.ContentBlock{Type: "text", Text: "[empty response from model]"})
+			blocks = append(blocks, provider.ContentBlock{Type: "text", Text: emptyModelResponseText})
 			ch <- TurnEvent{Type: "error", Error: fmt.Errorf("empty response from model")}
-			emptyResponseExit = true
+			exitReason = agentsdk.ExitEmptyResponse
 		}
 
 		// Add assistant message with accumulated blocks
@@ -1461,11 +1466,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// empty in this branch, but Drain is cheap and safe).
 		if len(pendingTools) == 0 {
 			_ = execStream.Drain()
-			reason := agentsdk.ExitCompleted
-			if emptyResponseExit {
-				reason = agentsdk.ExitEmptyResponse
-			}
-			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, reason)
+			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, exitReason)
 			return
 		}
 
@@ -1505,7 +1506,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 
 		// Execute tool calls — parallelize auto-approved tools when possible.
 		if cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults); cancelled {
-			synthesizeMissingToolResults(a.conversation, "cancelled during tool execution")
+			synthesizeMissingToolResults(a.conversation, orphanReasonToolCancel)
 			ch <- TurnEvent{Type: "error", Error: ctx.Err()}
 			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCancelled)
 			return
@@ -1665,21 +1666,10 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 		})
 	}
 
-	// If every tool was already streamed, skip partition/execute and
-	// jump straight to result emission.
-	if len(plannedTools) == 0 {
-		for i := range pendingTools {
-			r := results[i]
-			a.conversation.AddToolResult(r.toolUseID, r.content, r.isError)
-			a.persistToolResult(r.toolUseID, r.content, r.isError)
-			ch <- r.event
-			a.recordToolProgress(pendingTools[i], r)
-		}
-		a.saveSnapshotIfNeeded()
-		return false
-	}
-
 	// Partition into auto-approved and needs-approval using input-sensitive check.
+	// When every pending tool was already streamed, plannedTools is empty and
+	// the partition/execute stages below are all no-ops — control falls through
+	// to the final emission loop without a dedicated fast path.
 	var autoApproved, autoDenied, needsApproval []plannedToolCall
 	for _, planned := range plannedTools {
 		switch planned.approvalResult {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1361,6 +1361,8 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 
 		// On stream error, discard partial blocks to prevent conversation corruption
 		if streamErr {
+			// Defensive: currently a no-op because AddAssistant has not been called
+			// yet on this path, but protects against future reorderings.
 			synthesizeMissingToolResults(a.conversation, "stream error")
 			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError)
 			return

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -855,9 +855,12 @@ func (a *Agent) Turn(ctx context.Context, userMessage string) (<-chan TurnEvent,
 
 	a.conversation.AddUser(userMessage)
 	a.persistMessage("user", []provider.ContentBlock{{Type: "text", Text: userMessage}})
-	if err := a.context.Compact(ctx, a.conversation); err != nil && errors.Is(err, ErrCompactionExhausted) {
+	if err := a.context.Compact(ctx, a.conversation); err != nil {
 		a.turnMu.Unlock()
-		return nil, fmt.Errorf("compaction exhausted before turn start: %w", err)
+		if errors.Is(err, ErrCompactionExhausted) {
+			return nil, fmt.Errorf("compaction exhausted before turn start: %w", err)
+		}
+		return nil, fmt.Errorf("compact before turn: %w", err)
 	}
 	a.saveSnapshotIfNeeded()
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1395,14 +1395,10 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// emit an error and add a placeholder assistant message to keep the
 		// conversation valid (every user message must be followed by an
 		// assistant message).
-		if len(blocks) == 0 && len(pendingTools) == 0 {
-			placeholder := "[empty response from model]"
-			blocks = append(blocks, provider.ContentBlock{Type: "text", Text: placeholder})
-			ch <- TurnEvent{Type: "error", Error: fmt.Errorf("empty response from model")}
-		}
-
 		emptyResponseExit := false
-		if len(blocks) == 1 && blocks[0].Type == "text" && blocks[0].Text == "[empty response from model]" {
+		if len(blocks) == 0 && len(pendingTools) == 0 {
+			blocks = append(blocks, provider.ContentBlock{Type: "text", Text: "[empty response from model]"})
+			ch <- TurnEvent{Type: "error", Error: fmt.Errorf("empty response from model")}
 			emptyResponseExit = true
 		}
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1270,6 +1270,13 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		var toolInputBuf string
 		var thinkingBuf string
 
+		// Streaming dispatch: concurrency-safe tools run in the
+		// background as their tool_use blocks finalize during the stream,
+		// overlapping with any remaining model text.
+		execStream := newStreamingToolExecutor(maxParallelTools, func(sctx context.Context, tc provider.ToolUseBlock) toolExecResult {
+			return a.executeSingleTool(sctx, ch, tc)
+		})
+
 		finalizeTool := func() {
 			if currentTool != nil {
 				if toolInputBuf != "" {
@@ -1282,6 +1289,22 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 					Name:  currentTool.Name,
 					Input: currentTool.Input,
 				})
+
+				// Streaming dispatch: if the tool is concurrency-safe
+				// and auto-approved, start executing it now so it runs
+				// in parallel with the remaining model stream.
+				if a.approvalChecker != nil {
+					if tool, ok := a.tools.Get(currentTool.Name); ok {
+						approval := a.approvalChecker.CheckApproval(currentTool.Name, currentTool.Input)
+						if isStreamingEligible(tool, approval) {
+							// Dispatch in background; executeTools
+							// will emit the tool_call event when it
+							// sees the cached result.
+							execStream.Dispatch(ctx, *currentTool)
+						}
+					}
+				}
+
 				currentTool = nil
 				toolInputBuf = ""
 			}
@@ -1378,6 +1401,10 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 
 		// On stream error, discard partial blocks to prevent conversation corruption
 		if streamErr {
+			// Drain background streaming dispatches before discarding
+			// their results — prevents goroutine leaks and honours the
+			// executor's semantics (Drain unconditionally waits).
+			_ = execStream.Drain()
 			// Defensive: currently a no-op because AddAssistant has not been called
 			// yet on this path, but protects against future reorderings.
 			synthesizeMissingToolResults(a.conversation, "stream error")
@@ -1429,14 +1456,27 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			a.persistMessage("assistant", blocks)
 		}
 
-		// If no pending tool calls, we're done
+		// If no pending tool calls, we're done. Drain any background
+		// dispatches so goroutines don't outlive the turn (should be
+		// empty in this branch, but Drain is cheap and safe).
 		if len(pendingTools) == 0 {
+			_ = execStream.Drain()
 			reason := agentsdk.ExitCompleted
 			if emptyResponseExit {
 				reason = agentsdk.ExitEmptyResponse
 			}
 			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, reason)
 			return
+		}
+
+		// Drain any tools dispatched during streaming; executeTools
+		// will merge these results into its output by tool_use ID.
+		var streamedResults map[string]toolExecResult
+		if drained := execStream.Drain(); len(drained) > 0 {
+			streamedResults = make(map[string]toolExecResult, len(drained))
+			for _, r := range drained {
+				streamedResults[r.toolUseID] = r
+			}
 		}
 
 		signature := pendingToolSignature(pendingTools)
@@ -1457,14 +1497,14 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// the model often pairs task_complete with a final write or commit.
 		for _, tc := range pendingTools {
 			if tc.Name == tools.TaskCompleteName {
-				a.executeTools(ctx, ch, pendingTools)
+				a.executeTools(ctx, ch, pendingTools, streamedResults)
 				ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitTaskComplete)
 				return
 			}
 		}
 
 		// Execute tool calls — parallelize auto-approved tools when possible.
-		if cancelled := a.executeTools(ctx, ch, pendingTools); cancelled {
+		if cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults); cancelled {
 			synthesizeMissingToolResults(a.conversation, "cancelled during tool execution")
 			ch <- TurnEvent{Type: "error", Error: ctx.Err()}
 			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCancelled)
@@ -1591,13 +1631,53 @@ func (a *Agent) approvalToolErrorResult(tc provider.ToolUseBlock, msg string, er
 
 // executeTools runs the pending tool calls, parallelizing auto-approved ones.
 // Returns true if the context was cancelled during execution.
-func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTools []provider.ToolUseBlock) bool {
+//
+// streamedResults holds outcomes for tools that were already dispatched
+// during streaming (via streamingToolExecutor). Entries keyed by
+// tool_use ID are placed directly into the results slice at their
+// original position and skipped during planning/partitioning. Pass nil
+// if no streaming dispatch occurred.
+func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTools []provider.ToolUseBlock, streamedResults map[string]toolExecResult) bool {
 	if a.approvalChecker == nil {
 		// No checker — fall back to sequential execution.
-		return a.executePlannedToolsSequential(ctx, ch, a.planToolCalls(pendingTools))
+		return a.executePlannedToolsSequential(ctx, ch, a.planToolCalls(pendingTools), streamedResults)
 	}
 
-	plannedTools := a.planToolCalls(pendingTools)
+	// Pre-populate results for tools already executed during streaming;
+	// the remaining (planned) subset goes through the normal partition
+	// and execution path.
+	results := make([]toolExecResult, len(pendingTools))
+	plannedTools := make([]plannedToolCall, 0, len(pendingTools))
+	for i, tc := range pendingTools {
+		if r, ok := streamedResults[tc.ID]; ok {
+			results[i] = r
+			// Emit the tool_call event so UIs still see it.
+			ch <- TurnEvent{
+				Type:     "tool_call",
+				ToolCall: &ToolCallEvent{ID: tc.ID, Name: tc.Name, Input: tc.Input},
+			}
+			continue
+		}
+		plannedTools = append(plannedTools, plannedToolCall{
+			index:          i,
+			tc:             tc,
+			approvalResult: a.approvalResultForTool(tc),
+		})
+	}
+
+	// If every tool was already streamed, skip partition/execute and
+	// jump straight to result emission.
+	if len(plannedTools) == 0 {
+		for i := range pendingTools {
+			r := results[i]
+			a.conversation.AddToolResult(r.toolUseID, r.content, r.isError)
+			a.persistToolResult(r.toolUseID, r.content, r.isError)
+			ch <- r.event
+			a.recordToolProgress(pendingTools[i], r)
+		}
+		a.saveSnapshotIfNeeded()
+		return false
+	}
 
 	// Partition into auto-approved and needs-approval using input-sensitive check.
 	var autoApproved, autoDenied, needsApproval []plannedToolCall
@@ -1640,9 +1720,6 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 			},
 		}
 	}
-
-	// Results array indexed by original position.
-	results := make([]toolExecResult, len(pendingTools))
 
 	// Emit tool_call events for auto-denied tools so headless runners can
 	// match results by call ID, then fill in denied results immediately.
@@ -1736,10 +1813,28 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 	return false
 }
 
-func (a *Agent) executePlannedToolsSequential(ctx context.Context, ch chan<- TurnEvent, plannedTools []plannedToolCall) bool {
+func (a *Agent) executePlannedToolsSequential(ctx context.Context, ch chan<- TurnEvent, plannedTools []plannedToolCall, streamedResults map[string]toolExecResult) bool {
 	for _, planned := range plannedTools {
 		if ctx.Err() != nil {
 			return true
+		}
+
+		// Streaming dispatch already ran this tool — emit the tool_call
+		// and cached result directly without re-executing.
+		if r, ok := streamedResults[planned.tc.ID]; ok {
+			ch <- TurnEvent{
+				Type: "tool_call",
+				ToolCall: &ToolCallEvent{
+					ID:    planned.tc.ID,
+					Name:  planned.tc.Name,
+					Input: planned.tc.Input,
+				},
+			}
+			a.conversation.AddToolResult(r.toolUseID, r.content, r.isError)
+			a.persistToolResult(r.toolUseID, r.content, r.isError)
+			ch <- r.event
+			a.recordToolProgress(planned.tc, r)
+			continue
 		}
 
 		ch <- TurnEvent{

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -854,7 +855,10 @@ func (a *Agent) Turn(ctx context.Context, userMessage string) (<-chan TurnEvent,
 
 	a.conversation.AddUser(userMessage)
 	a.persistMessage("user", []provider.ContentBlock{{Type: "text", Text: userMessage}})
-	a.context.Compact(ctx, a.conversation)
+	if err := a.context.Compact(ctx, a.conversation); err != nil && errors.Is(err, ErrCompactionExhausted) {
+		a.turnMu.Unlock()
+		return nil, fmt.Errorf("compaction exhausted before turn start: %w", err)
+	}
 	a.saveSnapshotIfNeeded()
 
 	// Reset the diff tracker so each turn starts with a clean slate.
@@ -1174,6 +1178,16 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			ch <- TurnEvent{Type: "error", Error: ctx.Err()}
 			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCancelled)
 			return
+		}
+
+		if err := a.context.Compact(ctx, a.conversation); err != nil {
+			if errors.Is(err, ErrCompactionExhausted) {
+				ch <- TurnEvent{Type: "error", Error: err}
+				ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCompactionFailed)
+				return
+			}
+			// Non-breaker errors are not expected today; log and continue.
+			a.logger.Warn("compaction returned unexpected error: %v", err)
 		}
 
 		// Build the system prompt with cache breakpoints.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -870,6 +870,7 @@ func (a *Agent) Turn(ctx context.Context, userMessage string) (<-chan TurnEvent,
 			if r := recover(); r != nil {
 				stack := debug.Stack()
 				a.logger.Error("agent panic recovered: %v\n%s", r, stack)
+				synthesizeMissingToolResults(a.conversation, "agent panic")
 				// Non-blocking send to avoid deadlocking turnMu if channel
 				// buffer is full (e.g., reader stopped consuming events).
 				select {
@@ -1360,6 +1361,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 
 		// On stream error, discard partial blocks to prevent conversation corruption
 		if streamErr {
+			synthesizeMissingToolResults(a.conversation, "stream error")
 			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError)
 			return
 		}
@@ -1444,6 +1446,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 
 		// Execute tool calls — parallelize auto-approved tools when possible.
 		if cancelled := a.executeTools(ctx, ch, pendingTools); cancelled {
+			synthesizeMissingToolResults(a.conversation, "cancelled during tool execution")
 			ch <- TurnEvent{Type: "error", Error: ctx.Err()}
 			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCancelled)
 			return

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1884,6 +1884,20 @@ func (a *Agent) executeSingleTool(ctx context.Context, ch chan<- TurnEvent, tc p
 	result := a.pipeline.Execute(toolexec.WithToolEventEmitter(ctx, emit), toolexec.ToolCall{
 		ID: tc.ID, Name: tc.Name, Input: tc.Input,
 	})
+	// Apply per-tool result cap (Claude Code parity: query.ts Layer 0
+	// applyToolResultBudget). Tools that implement agentsdk.ResultCapped
+	// get their oversize output truncated with a head+tail slice plus a
+	// marker; tools that don't implement the interface pass through
+	// unchanged. Without this, a single chatty command can dump megabytes
+	// into one tool_result and dominate the context window.
+	if tool, ok := a.tools.Get(tc.Name); ok {
+		capped := applyResultCap(tool, agentsdk.ToolResult{
+			Content:        result.Content,
+			DisplayContent: result.DisplayContent,
+			IsError:        result.IsError,
+		})
+		result.Content = capped.Content
+	}
 	return toolExecResult{
 		toolUseID: tc.ID,
 		content:   result.Content,

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -3425,3 +3425,31 @@ func TestBuildBootstrapSystemPromptPrefixNil(t *testing.T) {
 	prefix := BuildBootstrapSystemPromptPrefix(nil)
 	assert.Empty(t, prefix)
 }
+
+func TestTurnEmitsExitReasonCompleted(t *testing.T) {
+	t.Parallel()
+	mp := &mockProvider{
+		events: []provider.StreamEvent{
+			{Type: "text_delta", Text: "done."},
+			{Type: "stop"},
+		},
+	}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	ag := New(mp, reg, autoApprove, cfg)
+
+	ch, err := ag.Turn(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+	var last TurnEvent
+	for ev := range ch {
+		last = ev
+	}
+	if last.Type != "done" {
+		t.Fatalf("want last event type=done, got %q", last.Type)
+	}
+	if last.ExitReason != agentsdk.ExitCompleted {
+		t.Fatalf("want ExitCompleted, got %v", last.ExitReason)
+	}
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -2319,7 +2319,7 @@ func TestExecutePlannedToolsSequentialUsesPrecomputedApprovalResults(t *testing.
 	}}
 
 	ch := make(chan TurnEvent, 4)
-	cancelled := a.executePlannedToolsSequential(context.Background(), ch, planned)
+	cancelled := a.executePlannedToolsSequential(context.Background(), ch, planned, nil)
 	require.False(t, cancelled)
 	assert.Equal(t, 0, checker.Calls(), "sequential execution should use the precomputed approval result")
 }
@@ -2345,7 +2345,7 @@ func TestExecuteToolsWithoutApprovalCheckerUsesSequentialPlan(t *testing.T) {
 		ID:    "t1",
 		Name:  "tool_a",
 		Input: json.RawMessage(`{}`),
-	}})
+	}}, nil)
 	require.False(t, cancelled)
 
 	var events []TurnEvent

--- a/internal/agent/compaction_breaker_test.go
+++ b/internal/agent/compaction_breaker_test.go
@@ -1,0 +1,136 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/config"
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/tools"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// alwaysFailingStrategy returns a non-nil error from every Compact call.
+type alwaysFailingStrategy struct{ name string }
+
+func (s *alwaysFailingStrategy) Name() string { return s.name }
+func (s *alwaysFailingStrategy) Compact(_ context.Context, msgs []provider.Message, _ int) ([]provider.Message, error) {
+	return msgs, errors.New("boom")
+}
+
+func TestCompactionCircuitBreakerTripsAfterThreeFailures(t *testing.T) {
+	t.Parallel()
+	cm := NewContextManager(100, 10) // tiny budget to force compaction
+	cm.SetStrategies([]agentsdk.CompactionStrategy{&alwaysFailingStrategy{name: "fail"}})
+
+	conv := NewConversation("system")
+	for i := 0; i < 50; i++ {
+		conv.AddUser("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	}
+
+	for i := 0; i < 2; i++ {
+		err := cm.Compact(context.Background(), conv)
+		if err != nil {
+			t.Fatalf("attempt %d: want nil, got %v", i+1, err)
+		}
+	}
+	if err := cm.Compact(context.Background(), conv); !errors.Is(err, ErrCompactionExhausted) {
+		t.Fatalf("want ErrCompactionExhausted on third failure, got %v", err)
+	}
+}
+
+func TestCompactionCircuitBreakerResetsOnSuccess(t *testing.T) {
+	t.Parallel()
+	cm := NewContextManager(100, 10)
+	succeedNext := false
+	strat := &fakeStrategyWithToggle{succeed: &succeedNext}
+	cm.SetStrategies([]agentsdk.CompactionStrategy{strat})
+
+	conv := NewConversation("system")
+	for i := 0; i < 50; i++ {
+		conv.AddUser("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	}
+
+	_ = cm.Compact(context.Background(), conv)
+	_ = cm.Compact(context.Background(), conv)
+	succeedNext = true
+	if err := cm.Compact(context.Background(), conv); err != nil {
+		t.Fatalf("success should reset counter, got %v", err)
+	}
+	succeedNext = false
+	for i := 0; i < 40; i++ {
+		conv.AddUser("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	}
+	// After reset, three new failures needed to trip.
+	_ = cm.Compact(context.Background(), conv)
+	_ = cm.Compact(context.Background(), conv)
+	if err := cm.Compact(context.Background(), conv); !errors.Is(err, ErrCompactionExhausted) {
+		t.Fatalf("want trip after 3 new failures, got %v", err)
+	}
+}
+
+// fakeStrategyWithToggle succeeds (by halving the message slice) iff *succeed is true.
+type fakeStrategyWithToggle struct{ succeed *bool }
+
+func (s *fakeStrategyWithToggle) Name() string { return "toggle" }
+func (s *fakeStrategyWithToggle) Compact(_ context.Context, msgs []provider.Message, _ int) ([]provider.Message, error) {
+	if *s.succeed {
+		if len(msgs) > 2 {
+			return msgs[len(msgs)/2:], nil
+		}
+		return msgs, nil
+	}
+	return msgs, errors.New("boom")
+}
+
+// TestRunLoopExitsWithCompactionFailed verifies the agent loop surfaces
+// ErrCompactionExhausted via Turn() (either as a sync error from the
+// pre-turn Compact call, or as ExitCompactionFailed on the done event).
+func TestRunLoopExitsWithCompactionFailed(t *testing.T) {
+	t.Parallel()
+
+	mp := &mockProvider{
+		events: []provider.StreamEvent{
+			{Type: "text_delta", Text: "ok"},
+			{Type: "stop"},
+		},
+	}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	ag := New(mp, reg, autoApprove, cfg)
+
+	// Replace the ContextManager with one that uses an always-failing
+	// strategy and a tiny budget so ShouldCompact fires.
+	cm := NewContextManager(100, 10)
+	cm.SetStrategies([]agentsdk.CompactionStrategy{&alwaysFailingStrategy{name: "fail"}})
+	ag.context = cm
+	ag.customStrategies = true
+
+	// Bloat the conversation so compaction actually runs.
+	for i := 0; i < 50; i++ {
+		ag.conversation.AddUser("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	}
+
+	// Pre-trip the breaker to failure count = 2.
+	_ = cm.Compact(context.Background(), ag.conversation)
+	_ = cm.Compact(context.Background(), ag.conversation)
+
+	ch, err := ag.Turn(context.Background(), "trigger")
+	if err != nil {
+		if !errors.Is(err, ErrCompactionExhausted) {
+			t.Fatalf("sync Turn error: want ErrCompactionExhausted, got %v", err)
+		}
+		return // synchronous path taken — breaker wired correctly
+	}
+	var last TurnEvent
+	for ev := range ch {
+		last = ev
+	}
+	if last.Type != "done" {
+		t.Fatalf("want last event type=done, got %q", last.Type)
+	}
+	if last.ExitReason != agentsdk.ExitCompactionFailed {
+		t.Fatalf("want ExitCompactionFailed, got %v", last.ExitReason)
+	}
+}

--- a/internal/agent/compaction_breaker_test.go
+++ b/internal/agent/compaction_breaker_test.go
@@ -84,6 +84,37 @@ func (s *fakeStrategyWithToggle) Compact(_ context.Context, msgs []provider.Mess
 	return msgs, errors.New("boom")
 }
 
+// silentNoOpStrategy returns msgs unchanged (no error, no shrink).
+// This is the exact failure mode the breaker was designed to catch —
+// a broken summarizer that silently returns success without actually
+// reducing token count.
+type silentNoOpStrategy struct{}
+
+func (s *silentNoOpStrategy) Name() string { return "noop" }
+func (s *silentNoOpStrategy) Compact(_ context.Context, msgs []provider.Message, _ int) ([]provider.Message, error) {
+	return msgs, nil
+}
+
+func TestCompactionCircuitBreakerTripsOnSilentNoOp(t *testing.T) {
+	t.Parallel()
+	cm := NewContextManager(100, 10)
+	cm.SetStrategies([]agentsdk.CompactionStrategy{&silentNoOpStrategy{}})
+
+	conv := NewConversation("system")
+	for i := 0; i < 50; i++ {
+		conv.AddUser("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := cm.Compact(context.Background(), conv); err != nil {
+			t.Fatalf("attempt %d: want nil, got %v", i+1, err)
+		}
+	}
+	if err := cm.Compact(context.Background(), conv); !errors.Is(err, ErrCompactionExhausted) {
+		t.Fatalf("silent no-op strategy should trip breaker on third call, got %v", err)
+	}
+}
+
 // TestRunLoopExitsWithCompactionFailed verifies the agent loop surfaces
 // ErrCompactionExhausted via Turn() (either as a sync error from the
 // pre-turn Compact call, or as ExitCompactionFailed on the done event).

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -52,7 +52,7 @@ func TestCompactRunsStrategiesInOrder(t *testing.T) {
 
 	require.True(t, cm.ExceedsBudget(conv))
 
-	cm.Compact(context.Background(), conv)
+	_ = cm.Compact(context.Background(), conv)
 
 	// First strategy should be called
 	assert.True(t, s1.called, "first strategy should be called")
@@ -72,7 +72,7 @@ func TestCompactFallsBackToTruncation(t *testing.T) {
 	require.True(t, cm.ExceedsBudget(conv))
 
 	// Default strategies include truncation as fallback
-	cm.Compact(context.Background(), conv)
+	_ = cm.Compact(context.Background(), conv)
 
 	assert.False(t, cm.ExceedsBudget(conv), "should be within budget after compaction")
 	assert.GreaterOrEqual(t, len(conv.Messages()), 2)
@@ -90,7 +90,7 @@ func TestCompactEmptyStrategiesUsesTruncation(t *testing.T) {
 
 	require.True(t, cm.ExceedsBudget(conv))
 
-	cm.Compact(context.Background(), conv)
+	_ = cm.Compact(context.Background(), conv)
 
 	assert.False(t, cm.ExceedsBudget(conv))
 	assert.GreaterOrEqual(t, len(conv.Messages()), 2)
@@ -107,7 +107,7 @@ func TestCompactNoOpWhenWithinBudget(t *testing.T) {
 
 	require.False(t, cm.ExceedsBudget(conv))
 
-	cm.Compact(context.Background(), conv)
+	_ = cm.Compact(context.Background(), conv)
 
 	// Strategy should not be called when already within budget
 	assert.False(t, s.called, "strategy should not be called when within budget")
@@ -132,7 +132,7 @@ func TestCompactStopsWhenUnderBudget(t *testing.T) {
 		t.Skip("test requires conversation to exceed budget")
 	}
 
-	cm.Compact(context.Background(), conv)
+	_ = cm.Compact(context.Background(), conv)
 
 	assert.True(t, s1.called, "first strategy should be called")
 	assert.False(t, cm.ExceedsBudget(conv), "conversation should fit within budget after compaction")
@@ -207,7 +207,7 @@ func TestCompactTriggersProactively(t *testing.T) {
 	require.Greater(t, tokens, 693, "test requires >95%% budget used")
 	require.LessOrEqual(t, tokens, 730, "test requires <=100%% budget (not exceeding)")
 
-	cm.Compact(context.Background(), conv)
+	_ = cm.Compact(context.Background(), conv)
 	assert.True(t, s.called, "strategy should be called proactively when above 95%% threshold")
 }
 
@@ -221,7 +221,7 @@ func TestCompactCustomTriggerRatio(t *testing.T) {
 	conv := NewConversation("sys")
 	conv.AddUser("hello")
 
-	cm.Compact(context.Background(), conv)
+	_ = cm.Compact(context.Background(), conv)
 	assert.True(t, s.called, "strategy should be called with custom low trigger ratio")
 }
 

--- a/internal/agent/compaction_toolclear_test.go
+++ b/internal/agent/compaction_toolclear_test.go
@@ -275,7 +275,7 @@ func TestToolResultClearingIntegrationWithCompact(t *testing.T) {
 
 	require.True(t, cm.ExceedsBudget(conv))
 
-	cm.Compact(context.Background(), conv)
+	_ = cm.Compact(context.Background(), conv)
 
 	// After compaction, the large tool result should be cleared
 	assert.False(t, cm.ExceedsBudget(conv))

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -12,13 +13,26 @@ import (
 // CompactionStrategy, ContextBudget, and CompactResult are defined in
 // pkg/agentsdk/ and re-exported via sdk_aliases.go.
 
+// ErrCompactionExhausted is returned from Compact when the strategy
+// chain has failed MaxConsecutiveCompactionFailures times in a row
+// without reducing token count. The loop must terminate rather than
+// retry — infinite compact-fail-retry burns API budget with no
+// progress. Observed in Claude Code's query.ts as the
+// "250K API calls/day" incident that motivated its circuit breaker.
+var ErrCompactionExhausted = errors.New("compaction failed repeatedly; circuit breaker tripped")
+
+// MaxConsecutiveCompactionFailures is the threshold for the circuit
+// breaker. Matches Claude Code's MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES=3.
+const MaxConsecutiveCompactionFailures = 3
+
 // ContextManager tracks token usage and compacts conversation history
 // to stay within a configured budget using a chain of strategies.
 type ContextManager struct {
-	budget         ContextBudget
-	compactTrigger float64 // fraction of effective window to trigger compaction (default 0.95)
-	hardBlock      float64 // fraction of effective window to block new messages (default 0.98)
-	strategies     []CompactionStrategy
+	budget              ContextBudget
+	compactTrigger      float64 // fraction of effective window to trigger compaction (default 0.95)
+	hardBlock           float64 // fraction of effective window to block new messages (default 0.98)
+	strategies          []CompactionStrategy
+	consecutiveFailures int // circuit breaker counter for repeated no-shrink Compact calls
 }
 
 // NewContextManager creates a new ContextManager with the given total budget
@@ -84,9 +98,9 @@ func (cm *ContextManager) IsBlocked(conv *Conversation) bool {
 // as soon as the conversation is under budget. Triggers proactively at
 // the configured trigger ratio (default 95%) to leave headroom for quality
 // summarization.
-func (cm *ContextManager) Compact(ctx context.Context, conv *Conversation) {
+func (cm *ContextManager) Compact(ctx context.Context, conv *Conversation) error {
 	if !cm.ShouldCompact(conv) {
-		return
+		return nil
 	}
 	// Subtract system prompt overhead so strategies only need to fit messages.
 	systemTokens := len(conv.SystemPrompt())/4 + 10
@@ -102,18 +116,38 @@ func (cm *ContextManager) Compact(ctx context.Context, conv *Conversation) {
 		}
 	}
 
+	beforeTokens := estimateMessageTokens(conv.messages)
+	anyStrategySucceeded := false
+
 	for i, s := range cm.strategies {
 		// First strategy always runs (we passed ShouldCompact).
 		// Subsequent strategies only run if still over 100% budget.
 		if i > 0 && !cm.ExceedsBudget(conv) {
-			return
+			break
 		}
 		result, err := s.Compact(ctx, conv.messages, messageBudget)
 		if err != nil {
 			continue
 		}
 		conv.messages = result
+		anyStrategySucceeded = true
 	}
+
+	afterTokens := estimateMessageTokens(conv.messages)
+	shrank := afterTokens < beforeTokens
+
+	// Real progress requires BOTH a non-erroring strategy AND an actual
+	// token reduction. Silent no-op strategies must not reset the breaker.
+	if anyStrategySucceeded && shrank {
+		cm.consecutiveFailures = 0
+		return nil
+	}
+
+	cm.consecutiveFailures++
+	if cm.consecutiveFailures >= MaxConsecutiveCompactionFailures {
+		return ErrCompactionExhausted
+	}
+	return nil
 }
 
 // EstimateTokens estimates the token count for a conversation using
@@ -220,7 +254,7 @@ func (cm *ContextManager) ExceedsBudget(conv *Conversation) bool {
 // Truncate removes the oldest messages until the conversation is within budget.
 // Deprecated: use Compact() which runs the full strategy chain.
 func (cm *ContextManager) Truncate(conv *Conversation) {
-	cm.Compact(context.Background(), conv)
+	_ = cm.Compact(context.Background(), conv)
 }
 
 // truncateStrategy is the last-resort compaction strategy that removes

--- a/internal/agent/orphan.go
+++ b/internal/agent/orphan.go
@@ -2,6 +2,21 @@ package agent
 
 import "fmt"
 
+// Reason strings passed to synthesizeMissingToolResults. Embedded in
+// the synthesized tool_result content so the model (and anyone
+// reading a captured conversation) can distinguish why each orphan
+// was sealed.
+const (
+	orphanReasonStreamError = "stream error"
+	orphanReasonToolCancel  = "cancelled during tool execution"
+	orphanReasonPanic       = "agent panic"
+)
+
+// emptyModelResponseText is the placeholder inserted when the model
+// returns no blocks and no tool calls. Keeping it as a single source
+// of truth makes the ExitEmptyResponse classification unambiguous.
+const emptyModelResponseText = "[empty response from model]"
+
 // synthesizeMissingToolResults walks the conversation and, for every
 // tool_use block in the most recent assistant message that does not have
 // a matching tool_result in a subsequent message, appends an error

--- a/internal/agent/orphan.go
+++ b/internal/agent/orphan.go
@@ -36,14 +36,17 @@ func synthesizeMissingToolResults(conv *Conversation, reason string) int {
 		return 0
 	}
 
-	// Collect tool_use IDs in that assistant message.
-	var pendingIDs []string
+	// Collect tool_use IDs and names in that assistant message.
+	type pendingToolUse struct {
+		id, name string
+	}
+	var pending []pendingToolUse
 	for _, block := range msgs[assistantIdx].Content {
 		if block.Type == "tool_use" && block.ID != "" {
-			pendingIDs = append(pendingIDs, block.ID)
+			pending = append(pending, pendingToolUse{id: block.ID, name: block.Name})
 		}
 	}
-	if len(pendingIDs) == 0 {
+	if len(pending) == 0 {
 		return 0
 	}
 
@@ -58,12 +61,16 @@ func synthesizeMissingToolResults(conv *Conversation, reason string) int {
 	}
 
 	sealed := 0
-	for _, id := range pendingIDs {
-		if answered[id] {
+	for _, p := range pending {
+		if answered[p.id] {
 			continue
 		}
-		conv.AddToolResult(id,
-			fmt.Sprintf("tool execution did not complete: %s", reason),
+		toolName := p.name
+		if toolName == "" {
+			toolName = "<unknown>"
+		}
+		conv.AddToolResult(p.id,
+			fmt.Sprintf("tool %s did not complete: %s", toolName, reason),
 			true,
 		)
 		sealed++

--- a/internal/agent/orphan.go
+++ b/internal/agent/orphan.go
@@ -1,0 +1,72 @@
+package agent
+
+import "fmt"
+
+// synthesizeMissingToolResults walks the conversation and, for every
+// tool_use block in the most recent assistant message that does not have
+// a matching tool_result in a subsequent message, appends an error
+// tool_result. Returns the number of orphans sealed.
+//
+// This exists because the Anthropic/OpenAI wire protocol requires every
+// tool_use block to be followed by a tool_result. If the stream dies
+// between tool_use emission and tool execution — or if execution is
+// cancelled after the assistant message has been committed — the next
+// API call fails with a 400 protocol error. Sealing orphans with a
+// synthetic error result keeps the conversation valid for retry and
+// for resume from a persisted snapshot.
+//
+// Called from every agent-loop exit path that follows a stream which
+// may have emitted tool_use blocks: provider stream error, mid-stream
+// error event, tool execution cancel, and the deferred panic handler.
+func synthesizeMissingToolResults(conv *Conversation, reason string) int {
+	msgs := conv.Messages()
+	if len(msgs) == 0 {
+		return 0
+	}
+
+	// Find the last assistant message.
+	assistantIdx := -1
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == "assistant" {
+			assistantIdx = i
+			break
+		}
+	}
+	if assistantIdx == -1 {
+		return 0
+	}
+
+	// Collect tool_use IDs in that assistant message.
+	var pendingIDs []string
+	for _, block := range msgs[assistantIdx].Content {
+		if block.Type == "tool_use" && block.ID != "" {
+			pendingIDs = append(pendingIDs, block.ID)
+		}
+	}
+	if len(pendingIDs) == 0 {
+		return 0
+	}
+
+	// Collect tool_result IDs that appear after the assistant message.
+	answered := map[string]bool{}
+	for i := assistantIdx + 1; i < len(msgs); i++ {
+		for _, block := range msgs[i].Content {
+			if block.Type == "tool_result" && block.ToolUseID != "" {
+				answered[block.ToolUseID] = true
+			}
+		}
+	}
+
+	sealed := 0
+	for _, id := range pendingIDs {
+		if answered[id] {
+			continue
+		}
+		conv.AddToolResult(id,
+			fmt.Sprintf("tool execution did not complete: %s", reason),
+			true,
+		)
+		sealed++
+	}
+	return sealed
+}

--- a/internal/agent/orphan_test.go
+++ b/internal/agent/orphan_test.go
@@ -1,0 +1,182 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/config"
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/tools"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+func TestSynthesizeMissingToolResultsFillsOrphans(t *testing.T) {
+	t.Parallel()
+	conv := NewConversation("sys")
+	conv.AddUser("hi")
+	conv.AddAssistant([]provider.ContentBlock{
+		{Type: "text", Text: "using tools"},
+		{Type: "tool_use", ID: "call_1", Name: "read_file", Input: json.RawMessage(`{"path":"a"}`)},
+		{Type: "tool_use", ID: "call_2", Name: "read_file", Input: json.RawMessage(`{"path":"b"}`)},
+	})
+
+	n := synthesizeMissingToolResults(conv, "stream aborted")
+	if n != 2 {
+		t.Fatalf("want 2 orphans sealed, got %d", n)
+	}
+
+	msgs := conv.Messages()
+	got := map[string]bool{}
+	for _, m := range msgs {
+		for _, b := range m.Content {
+			if b.Type == "tool_result" {
+				got[b.ToolUseID] = true
+			}
+		}
+	}
+	if !got["call_1"] || !got["call_2"] {
+		t.Fatalf("missing tool_result for orphans: %v", got)
+	}
+}
+
+func TestSynthesizeMissingToolResultsSkipsIfAlreadyAnswered(t *testing.T) {
+	t.Parallel()
+	conv := NewConversation("sys")
+	conv.AddUser("hi")
+	conv.AddAssistant([]provider.ContentBlock{
+		{Type: "tool_use", ID: "call_1", Name: "read_file", Input: json.RawMessage(`{}`)},
+	})
+	conv.AddToolResult("call_1", "ok", false)
+
+	n := synthesizeMissingToolResults(conv, "reason")
+	if n != 0 {
+		t.Fatalf("want 0 orphans, got %d", n)
+	}
+}
+
+func TestSynthesizeMissingToolResultsNoAssistantTail(t *testing.T) {
+	t.Parallel()
+	conv := NewConversation("sys")
+	conv.AddUser("hi")
+
+	n := synthesizeMissingToolResults(conv, "reason")
+	if n != 0 {
+		t.Fatalf("want 0 when last message is user, got %d", n)
+	}
+}
+
+func TestSynthesizeMissingToolResultsPartialOrphans(t *testing.T) {
+	t.Parallel()
+	conv := NewConversation("sys")
+	conv.AddUser("hi")
+	conv.AddAssistant([]provider.ContentBlock{
+		{Type: "tool_use", ID: "call_1", Name: "read_file", Input: json.RawMessage(`{}`)},
+		{Type: "tool_use", ID: "call_2", Name: "read_file", Input: json.RawMessage(`{}`)},
+	})
+	conv.AddToolResult("call_1", "ok", false)
+
+	n := synthesizeMissingToolResults(conv, "reason")
+	if n != 1 {
+		t.Fatalf("want 1 orphan (call_2 only), got %d", n)
+	}
+}
+
+// cancelOnExecuteTool is a test tool that cancels a pre-supplied context the
+// first time it executes. Used to simulate a mid-tool-execution cancellation
+// so the runLoop "cancelled during tool execution" exit path fires.
+type cancelOnExecuteTool struct {
+	cancel  context.CancelFunc
+	invoked bool
+}
+
+func (c *cancelOnExecuteTool) Name() string        { return "cancel_tool" }
+func (c *cancelOnExecuteTool) Description() string { return "cancels the agent context" }
+func (c *cancelOnExecuteTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{"type":"object"}`)
+}
+func (c *cancelOnExecuteTool) Execute(_ context.Context, _ json.RawMessage) (agentsdk.ToolResult, error) {
+	c.invoked = true
+	c.cancel()
+	return agentsdk.ToolResult{Content: "cancelled"}, nil
+}
+
+// TestRunLoopToolCancelLeavesNoOrphans verifies that the sweeper is wired into
+// the runLoop path that exits when the context is cancelled mid-tool-execution.
+// We provide a batch of two tool calls, the first of which cancels the ctx.
+// After the first tool records its result, the sequential executor observes
+// ctx.Err() and returns early, leaving the second tool_use without a result.
+// The sweeper must seal it before the runLoop emits "done".
+func TestRunLoopToolCancelLeavesNoOrphans(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cancelTool := &cancelOnExecuteTool{cancel: cancel}
+
+	mp := &mockProvider{
+		events: []provider.StreamEvent{
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "t1", Name: "cancel_tool", Input: json.RawMessage(`{}`)}},
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "t2", Name: "cancel_tool", Input: json.RawMessage(`{}`)}},
+			{Type: "stop"},
+		},
+	}
+
+	reg := tools.NewRegistry()
+	if err := reg.Register(cancelTool); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	cfg := config.DefaultConfig()
+	a := New(mp, reg, autoApprove, cfg)
+
+	ch, err := a.Turn(ctx, "run the tool")
+	if err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+	for range ch {
+	}
+
+	if !cancelTool.invoked {
+		t.Fatalf("cancel tool was not invoked — test precondition failed")
+	}
+
+	// Walk the conversation: every tool_use in the final assistant message
+	// must have a matching tool_result somewhere after it.
+	msgs := a.conversation.Messages()
+	var assistantIdx = -1
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == "assistant" {
+			assistantIdx = i
+			break
+		}
+	}
+	if assistantIdx == -1 {
+		t.Fatalf("no assistant message found in conversation")
+	}
+
+	var pending []string
+	for _, b := range msgs[assistantIdx].Content {
+		if b.Type == "tool_use" {
+			pending = append(pending, b.ID)
+		}
+	}
+	if len(pending) == 0 {
+		t.Fatalf("expected tool_use blocks in assistant message; got none")
+	}
+
+	answered := map[string]bool{}
+	for i := assistantIdx + 1; i < len(msgs); i++ {
+		for _, b := range msgs[i].Content {
+			if b.Type == "tool_result" {
+				answered[b.ToolUseID] = true
+			}
+		}
+	}
+	for _, id := range pending {
+		if !answered[id] {
+			t.Fatalf("orphan tool_use %q has no matching tool_result; sweeper not wired", id)
+		}
+	}
+}

--- a/internal/agent/orphan_test.go
+++ b/internal/agent/orphan_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/julianshen/rubichan/internal/config"
@@ -37,6 +38,44 @@ func TestSynthesizeMissingToolResultsFillsOrphans(t *testing.T) {
 	}
 	if !got["call_1"] || !got["call_2"] {
 		t.Fatalf("missing tool_result for orphans: %v", got)
+	}
+
+	for _, m := range msgs {
+		for _, b := range m.Content {
+			if b.Type == "tool_result" && b.ToolUseID == "call_1" {
+				if !strings.Contains(b.Text, "read_file") {
+					t.Errorf("synthesized content missing tool name: %q", b.Text)
+				}
+				if !strings.Contains(b.Text, "stream aborted") {
+					t.Errorf("synthesized content missing reason: %q", b.Text)
+				}
+			}
+		}
+	}
+}
+
+func TestSynthesizeMissingToolResultsEmptyToolName(t *testing.T) {
+	t.Parallel()
+	conv := NewConversation("sys")
+	conv.AddUser("hi")
+	conv.AddAssistant([]provider.ContentBlock{
+		{Type: "tool_use", ID: "call_x", Name: "", Input: json.RawMessage(`{}`)},
+	})
+	n := synthesizeMissingToolResults(conv, "boom")
+	if n != 1 {
+		t.Fatalf("want 1 sealed, got %d", n)
+	}
+	msgs := conv.Messages()
+	var content string
+	for _, m := range msgs {
+		for _, b := range m.Content {
+			if b.Type == "tool_result" && b.ToolUseID == "call_x" {
+				content = b.Text
+			}
+		}
+	}
+	if !strings.Contains(content, "<unknown>") {
+		t.Fatalf("empty tool name should render as <unknown>, got %q", content)
 	}
 }
 

--- a/internal/agent/result_cap.go
+++ b/internal/agent/result_cap.go
@@ -1,0 +1,52 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// applyResultCap truncates a tool result if the tool implements
+// agentsdk.ResultCapped and the content exceeds its declared cap.
+// Exempt tools (nil, no interface, or cap <= 0) pass through unchanged.
+//
+// The truncation strategy preserves both the head and tail of the
+// content, with a marker inserted between them. This beats head-only
+// truncation because tool output often has essential information at
+// both ends — shell commands put errors at the tail, file reads put
+// context at the head. When the cap is too small to hold the marker
+// plus meaningful head+tail slices, the helper falls back to a
+// head-only trim.
+func applyResultCap(tool any, res agentsdk.ToolResult) agentsdk.ToolResult {
+	capped, ok := tool.(agentsdk.ResultCapped)
+	if !ok {
+		return res
+	}
+	maxBytes := capped.MaxResultBytes()
+	if maxBytes <= 0 {
+		return res
+	}
+	if len(res.Content) <= maxBytes {
+		return res
+	}
+
+	marker := fmt.Sprintf("\n\n[... truncated: %d bytes exceeded %d byte cap ...]\n\n",
+		len(res.Content), maxBytes)
+
+	// If the cap is too small to hold the marker plus meaningful
+	// head+tail slices, fall back to head-only.
+	sliceBudget := maxBytes - len(marker)
+	const minSidePerEnd = 100 // bytes
+	if sliceBudget < 2*minSidePerEnd {
+		if sliceBudget < 0 {
+			sliceBudget = 0
+		}
+		res.Content = res.Content[:sliceBudget] + marker
+		return res
+	}
+
+	head := sliceBudget / 2
+	tail := sliceBudget - head
+	res.Content = res.Content[:head] + marker + res.Content[len(res.Content)-tail:]
+	return res
+}

--- a/internal/agent/result_cap.go
+++ b/internal/agent/result_cap.go
@@ -17,7 +17,7 @@ import (
 // context at the head. When the cap is too small to hold the marker
 // plus meaningful head+tail slices, the helper falls back to a
 // head-only trim.
-func applyResultCap(tool any, res agentsdk.ToolResult) agentsdk.ToolResult {
+func applyResultCap(tool agentsdk.Tool, res agentsdk.ToolResult) agentsdk.ToolResult {
 	capped, ok := tool.(agentsdk.ResultCapped)
 	if !ok {
 		return res

--- a/internal/agent/result_cap_test.go
+++ b/internal/agent/result_cap_test.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/tools"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// fakeCappedTool implements agentsdk.ResultCapped with a configurable byte cap.
+// It only has the methods the applyResultCap helper needs — not the full Tool interface.
+type fakeCappedTool struct {
+	capBytes int
+}
+
+func (t *fakeCappedTool) MaxResultBytes() int { return t.capBytes }
+
+// plainTool does not implement ResultCapped — it is exempt.
+type plainTool struct{}
+
+func TestApplyResultCapBelowCap(t *testing.T) {
+	t.Parallel()
+	res := agentsdk.ToolResult{Content: "hello"}
+	capped := applyResultCap(&fakeCappedTool{capBytes: 100}, res)
+	if capped.Content != "hello" {
+		t.Fatalf("unexpected content: %q", capped.Content)
+	}
+}
+
+func TestApplyResultCapAboveCapTruncatesAndMarks(t *testing.T) {
+	t.Parallel()
+	big := strings.Repeat("a", 10000)
+	res := agentsdk.ToolResult{Content: big}
+	capped := applyResultCap(&fakeCappedTool{capBytes: 500}, res)
+	if len(capped.Content) > 600 {
+		t.Fatalf("content not truncated, got %d bytes", len(capped.Content))
+	}
+	if !strings.Contains(capped.Content, "truncated") {
+		t.Fatalf("truncation marker missing from: %q", capped.Content)
+	}
+	// Head and tail should both be preserved (both are 'a's, but we
+	// verify via length that we didn't just keep the head.
+	if !strings.HasPrefix(capped.Content, "a") || !strings.HasSuffix(capped.Content, "a") {
+		t.Fatalf("head or tail missing")
+	}
+}
+
+func TestApplyResultCapNilToolIsNoOp(t *testing.T) {
+	t.Parallel()
+	big := strings.Repeat("a", 10000)
+	res := agentsdk.ToolResult{Content: big}
+	capped := applyResultCap(nil, res)
+	if capped.Content != big {
+		t.Fatalf("nil tool should be no-op")
+	}
+}
+
+func TestApplyResultCapUncappedToolIsNoOp(t *testing.T) {
+	t.Parallel()
+	big := strings.Repeat("a", 10000)
+	res := agentsdk.ToolResult{Content: big}
+	capped := applyResultCap(plainTool{}, res)
+	if capped.Content != big {
+		t.Fatalf("plain tool should be exempt")
+	}
+}
+
+func TestApplyResultCapZeroCapIsNoOp(t *testing.T) {
+	t.Parallel()
+	big := strings.Repeat("a", 10000)
+	res := agentsdk.ToolResult{Content: big}
+	capped := applyResultCap(&fakeCappedTool{capBytes: 0}, res)
+	if capped.Content != big {
+		t.Fatalf("cap=0 should be exempt (opt-out)")
+	}
+}
+
+func TestApplyResultCapNegativeCapIsNoOp(t *testing.T) {
+	t.Parallel()
+	big := strings.Repeat("a", 10000)
+	res := agentsdk.ToolResult{Content: big}
+	capped := applyResultCap(&fakeCappedTool{capBytes: -1}, res)
+	if capped.Content != big {
+		t.Fatalf("negative cap should be exempt")
+	}
+}
+
+func TestApplyResultCapTinyCapKeepsHeadOnly(t *testing.T) {
+	t.Parallel()
+	// When the cap is too small to split head+tail around the marker,
+	// the helper should still truncate without crashing. The exact
+	// behavior (head-only vs head+tail) is an impl detail — but the
+	// result must be smaller than the original and contain the marker.
+	big := strings.Repeat("a", 10000)
+	res := agentsdk.ToolResult{Content: big}
+	capped := applyResultCap(&fakeCappedTool{capBytes: 80}, res)
+	if len(capped.Content) >= len(big) {
+		t.Fatalf("tiny cap should still shrink content")
+	}
+	if !strings.Contains(capped.Content, "truncated") {
+		t.Fatalf("truncation marker missing")
+	}
+}
+
+// TestShellToolReportsCap guards against a future refactor accidentally
+// removing the shell tool's ResultCapped opt-in. The shell tool must
+// implement agentsdk.ResultCapped with a positive byte cap.
+func TestShellToolReportsCap(t *testing.T) {
+	t.Parallel()
+	st := tools.NewShellTool(t.TempDir(), 0)
+	capped, ok := interface{}(st).(agentsdk.ResultCapped)
+	if !ok {
+		t.Fatalf("shell tool does not implement agentsdk.ResultCapped")
+	}
+	if capped.MaxResultBytes() <= 0 {
+		t.Fatalf("shell tool cap must be positive, got %d", capped.MaxResultBytes())
+	}
+}

--- a/internal/agent/result_cap_test.go
+++ b/internal/agent/result_cap_test.go
@@ -30,19 +30,28 @@ func TestApplyResultCapBelowCap(t *testing.T) {
 
 func TestApplyResultCapAboveCapTruncatesAndMarks(t *testing.T) {
 	t.Parallel()
-	big := strings.Repeat("a", 10000)
+	// Use distinct head/tail sentinels so a head-only regression would
+	// be caught — a plain strings.Repeat("a", ...) payload tautologically
+	// passes HasPrefix/HasSuffix checks even if the tail was dropped.
+	head := "HEAD_SENTINEL_"
+	tail := "_TAIL_SENTINEL"
+	body := strings.Repeat("x", 10000)
+	big := head + body + tail
+
 	res := agentsdk.ToolResult{Content: big}
-	capped := applyResultCap(&fakeCappedTool{capBytes: 500}, res)
-	if len(capped.Content) > 600 {
-		t.Fatalf("content not truncated, got %d bytes", len(capped.Content))
+	capped := applyResultCap(&fakeCappedTool{capBytes: 2000}, res)
+
+	if len(capped.Content) >= len(big) {
+		t.Fatalf("content not truncated, got %d bytes (original %d)", len(capped.Content), len(big))
 	}
 	if !strings.Contains(capped.Content, "truncated") {
 		t.Fatalf("truncation marker missing from: %q", capped.Content)
 	}
-	// Head and tail should both be preserved (both are 'a's, but we
-	// verify via length that we didn't just keep the head.
-	if !strings.HasPrefix(capped.Content, "a") || !strings.HasSuffix(capped.Content, "a") {
-		t.Fatalf("head or tail missing")
+	if !strings.Contains(capped.Content, head) {
+		t.Fatalf("head sentinel missing from truncated content — head slice regression?")
+	}
+	if !strings.Contains(capped.Content, tail) {
+		t.Fatalf("tail sentinel missing from truncated content — tail slice regression (head-only truncation)?")
 	}
 }
 

--- a/internal/agent/result_cap_test.go
+++ b/internal/agent/result_cap_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -8,16 +10,28 @@ import (
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
-// fakeCappedTool implements agentsdk.ResultCapped with a configurable byte cap.
-// It only has the methods the applyResultCap helper needs — not the full Tool interface.
+// stubTool is the minimal agentsdk.Tool implementation shared by
+// applyResultCap's test fixtures. Tests layer additional methods on
+// embedded stubTool to opt into extension interfaces like ResultCapped.
+type stubTool struct{ name string }
+
+func (s stubTool) Name() string                 { return s.name }
+func (s stubTool) Description() string          { return "" }
+func (s stubTool) InputSchema() json.RawMessage { return nil }
+func (s stubTool) Execute(context.Context, json.RawMessage) (agentsdk.ToolResult, error) {
+	return agentsdk.ToolResult{}, nil
+}
+
+// fakeCappedTool implements agentsdk.ResultCapped on top of stubTool.
 type fakeCappedTool struct {
+	stubTool
 	capBytes int
 }
 
 func (t *fakeCappedTool) MaxResultBytes() int { return t.capBytes }
 
-// plainTool does not implement ResultCapped — it is exempt.
-type plainTool struct{}
+// plainTool satisfies agentsdk.Tool but does not implement ResultCapped — it is exempt.
+type plainTool struct{ stubTool }
 
 func TestApplyResultCapBelowCap(t *testing.T) {
 	t.Parallel()
@@ -59,7 +73,8 @@ func TestApplyResultCapNilToolIsNoOp(t *testing.T) {
 	t.Parallel()
 	big := strings.Repeat("a", 10000)
 	res := agentsdk.ToolResult{Content: big}
-	capped := applyResultCap(nil, res)
+	var tool agentsdk.Tool // typed nil interface
+	capped := applyResultCap(tool, res)
 	if capped.Content != big {
 		t.Fatalf("nil tool should be no-op")
 	}

--- a/internal/agent/stream_tool_exec.go
+++ b/internal/agent/stream_tool_exec.go
@@ -102,16 +102,25 @@ func (e *streamingToolExecutor) Dispatch(ctx context.Context, tc provider.ToolUs
 // Drain waits for every dispatched future to complete and returns
 // their results in dispatch order. Safe to call only once per executor
 // instance; subsequent calls return an empty slice.
+//
+// Lock scope is deliberately narrow: we snapshot the futures slice
+// under e.mu, then release the lock before reading f.done/f.result.
+// wg.Wait() has already guaranteed all dispatch goroutines have
+// finished, so the <-f.done reads are redundant no-ops kept as a
+// safety net. Holding the lock across those reads would create a
+// lock-order hazard for any future dispatch goroutine that acquires
+// e.mu — this shape keeps the no-deadlock invariant obvious.
 func (e *streamingToolExecutor) Drain() []toolExecResult {
 	e.wg.Wait()
 	e.mu.Lock()
-	defer e.mu.Unlock()
-	out := make([]toolExecResult, 0, len(e.futures))
-	for _, f := range e.futures {
-		<-f.done
+	futures := e.futures
+	e.futures = nil
+	e.mu.Unlock()
+	out := make([]toolExecResult, 0, len(futures))
+	for _, f := range futures {
+		<-f.done // redundant after wg.Wait, kept as a safety net
 		out = append(out, f.result)
 	}
-	e.futures = nil
 	return out
 }
 

--- a/internal/agent/stream_tool_exec.go
+++ b/internal/agent/stream_tool_exec.go
@@ -1,0 +1,132 @@
+package agent
+
+import (
+	"context"
+	"sync"
+
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// toolExecFn runs a single tool call and returns its toolExecResult.
+// The executor is agnostic about where the tool actually runs — the
+// agent wires in a closure that dispatches through the pipeline
+// (executeSingleTool), while unit tests wire in a direct invocation.
+type toolExecFn func(ctx context.Context, tc provider.ToolUseBlock) toolExecResult
+
+// streamingToolExecutor dispatches concurrency-safe tools as soon as
+// their tool_use block finalizes during a streaming model response.
+// Results are collected and returned in dispatch order from Drain().
+//
+// Ordering: tools are dispatched in the order the model emits their
+// tool_use blocks. Drain() returns them in that same dispatch order,
+// regardless of execution wall time. This matches the wire protocol
+// requirement that tool_result messages follow their matching tool_use
+// in conversation order.
+//
+// Parallelism is bounded by maxParallel; excess dispatches block in a
+// goroutine pool. Callers typically set this to maxParallelTools.
+//
+// Claude Code's query.ts uses this pattern to overlap slow tool I/O
+// (file reads, greps) with the trailing portion of the model's
+// streaming response, eliminating 1–3s of sequential wait time on
+// typical reason-then-read turns.
+type streamingToolExecutor struct {
+	sem     chan struct{}
+	run     toolExecFn
+	mu      sync.Mutex
+	futures []*toolFuture
+	wg      sync.WaitGroup
+}
+
+// toolFuture holds the in-flight state of one dispatched tool call.
+// done is closed when the result is populated; callers block on it.
+type toolFuture struct {
+	toolUseID string
+	toolName  string
+	done      chan struct{}
+	result    toolExecResult
+}
+
+// newStreamingToolExecutor creates an executor with the given
+// parallelism bound and exec function. maxParallel is clamped to 1
+// when zero or negative.
+func newStreamingToolExecutor(maxParallel int, run toolExecFn) *streamingToolExecutor {
+	if maxParallel < 1 {
+		maxParallel = 1
+	}
+	return &streamingToolExecutor{
+		sem: make(chan struct{}, maxParallel),
+		run: run,
+	}
+}
+
+// Dispatch starts execution of a concurrency-safe tool in the background.
+// If ctx is already cancelled, the future is completed immediately with
+// an error result — the tool is not executed. Dispatch is O(1); actual
+// execution runs in a background goroutine.
+func (e *streamingToolExecutor) Dispatch(ctx context.Context, tc provider.ToolUseBlock) {
+	f := &toolFuture{
+		toolUseID: tc.ID,
+		toolName:  tc.Name,
+		done:      make(chan struct{}),
+	}
+	e.mu.Lock()
+	e.futures = append(e.futures, f)
+	e.mu.Unlock()
+
+	if ctx.Err() != nil {
+		f.result = toolErrorResult(tc, "context cancelled before tool dispatch")
+		close(f.done)
+		return
+	}
+
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+		// Bound parallelism.
+		select {
+		case e.sem <- struct{}{}:
+		case <-ctx.Done():
+			f.result = toolErrorResult(tc, "context cancelled while waiting for executor slot")
+			close(f.done)
+			return
+		}
+		defer func() { <-e.sem }()
+
+		f.result = e.run(ctx, tc)
+		close(f.done)
+	}()
+}
+
+// Drain waits for every dispatched future to complete and returns
+// their results in dispatch order. Safe to call only once per executor
+// instance; subsequent calls return an empty slice.
+func (e *streamingToolExecutor) Drain() []toolExecResult {
+	e.wg.Wait()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]toolExecResult, 0, len(e.futures))
+	for _, f := range e.futures {
+		<-f.done
+		out = append(out, f.result)
+	}
+	e.futures = nil
+	return out
+}
+
+// isStreamingEligible returns true if a tool can be dispatched during
+// streaming. Requires the ConcurrencySafeTool marker returning true AND
+// auto-approval (either AutoApproved or TrustRuleApproved).
+//
+// Tools that need user approval are NOT dispatched during streaming
+// because approval prompts would interrupt the model's response and
+// the semantic boundary between "model output" and "tool execution"
+// must remain clear for the user.
+func isStreamingEligible(tool agentsdk.Tool, result ApprovalResult) bool {
+	cs, ok := tool.(agentsdk.ConcurrencySafeTool)
+	if !ok || !cs.IsConcurrencySafe() {
+		return false
+	}
+	return result == AutoApproved || result == TrustRuleApproved
+}

--- a/internal/agent/stream_tool_exec.go
+++ b/internal/agent/stream_tool_exec.go
@@ -103,13 +103,9 @@ func (e *streamingToolExecutor) Dispatch(ctx context.Context, tc provider.ToolUs
 // their results in dispatch order. Safe to call only once per executor
 // instance; subsequent calls return an empty slice.
 //
-// Lock scope is deliberately narrow: we snapshot the futures slice
-// under e.mu, then release the lock before reading f.done/f.result.
-// wg.Wait() has already guaranteed all dispatch goroutines have
-// finished, so the <-f.done reads are redundant no-ops kept as a
-// safety net. Holding the lock across those reads would create a
-// lock-order hazard for any future dispatch goroutine that acquires
-// e.mu — this shape keeps the no-deadlock invariant obvious.
+// wg.Wait() establishes a happens-before for every f.result write, so
+// we only hold e.mu long enough to snapshot the futures slice and then
+// iterate it lock-free.
 func (e *streamingToolExecutor) Drain() []toolExecResult {
 	e.wg.Wait()
 	e.mu.Lock()
@@ -118,7 +114,6 @@ func (e *streamingToolExecutor) Drain() []toolExecResult {
 	e.mu.Unlock()
 	out := make([]toolExecResult, 0, len(futures))
 	for _, f := range futures {
-		<-f.done // redundant after wg.Wait, kept as a safety net
 		out = append(out, f.result)
 	}
 	return out

--- a/internal/agent/stream_tool_exec_test.go
+++ b/internal/agent/stream_tool_exec_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,12 +17,15 @@ import (
 
 // fakeConcurrencySafeTool is a minimal tool that implements the
 // agentsdk.Tool interface + ConcurrencySafeTool marker. It sleeps for
-// execDelay before returning returnText to simulate I/O latency.
+// execDelay before returning returnText to simulate I/O latency. If
+// onStart is non-nil, it is invoked on the very first line of Execute
+// — used by timing-sensitive tests to signal "tool has started".
 type fakeConcurrencySafeTool struct {
 	name       string
 	execDelay  time.Duration
 	called     atomic.Int32
 	returnText string
+	onStart    func()
 }
 
 func (t *fakeConcurrencySafeTool) Name() string                 { return t.name }
@@ -30,6 +34,9 @@ func (t *fakeConcurrencySafeTool) InputSchema() json.RawMessage { return nil }
 func (t *fakeConcurrencySafeTool) IsConcurrencySafe() bool      { return true }
 func (t *fakeConcurrencySafeTool) Execute(ctx context.Context, _ json.RawMessage) (agentsdk.ToolResult, error) {
 	t.called.Add(1)
+	if t.onStart != nil {
+		t.onStart()
+	}
 	select {
 	case <-time.After(t.execDelay):
 	case <-ctx.Done():
@@ -61,10 +68,12 @@ func runnerFromTool(tool agentsdk.Tool) toolExecFn {
 func TestStreamingExecutorDispatchesSafeToolsInParallel(t *testing.T) {
 	t.Parallel()
 	// Two slow concurrency-safe tools. Sequential execution would take
-	// ~200ms; parallel dispatch should complete in ~100ms.
+	// ~400ms; parallel dispatch should complete in ~200ms. The 350ms
+	// budget gives 150ms headroom on the parallel path while still
+	// catching a sequential regression (which would take ≥400ms).
 	tool := &fakeConcurrencySafeTool{
 		name:       "read_file",
-		execDelay:  100 * time.Millisecond,
+		execDelay:  200 * time.Millisecond,
 		returnText: "ok",
 	}
 	ex := newStreamingToolExecutor(2, runnerFromTool(tool))
@@ -79,7 +88,7 @@ func TestStreamingExecutorDispatchesSafeToolsInParallel(t *testing.T) {
 	if len(results) != 2 {
 		t.Fatalf("want 2 results, got %d", len(results))
 	}
-	if elapsed > 180*time.Millisecond {
+	if elapsed > 350*time.Millisecond {
 		t.Fatalf("tools ran sequentially (%v) — expected parallel dispatch", elapsed)
 	}
 	if tool.called.Load() != 2 {
@@ -373,12 +382,15 @@ func TestExecutePlannedToolsSequentialWithStreamedResults(t *testing.T) {
 	require.Equal(t, 1, toolResultBlocks)
 }
 
-// TestRunLoopStreamsConcurrencySafeToolsDuringModelResponse is a
-// liveness test: it registers a fake concurrency-safe tool, drives the
-// agent through a turn that emits a tool_use for it, and confirms via
-// atomic counter that the tool was invoked exactly once and the result
-// was emitted to the event channel.
-func TestRunLoopStreamsConcurrencySafeToolsDuringModelResponse(t *testing.T) {
+// TestRunLoopWiresStreamingToolsIntoTurnResults is a wiring test: it
+// registers a fake concurrency-safe tool, drives the agent through a
+// turn that emits a tool_use for it, and confirms via atomic counter
+// that the tool was invoked exactly once and the result was emitted
+// to the event channel. It proves end-to-end wiring (tool called,
+// result emitted), but does NOT prove streaming-during-response
+// timing — see TestRunLoopDispatchesStreamingToolDuringStream for
+// that guarantee.
+func TestRunLoopWiresStreamingToolsIntoTurnResults(t *testing.T) {
 	t.Parallel()
 	tool := &fakeConcurrencySafeTool{
 		name:       "fake_read",
@@ -435,5 +447,102 @@ func TestRunLoopStreamsConcurrencySafeToolsDuringModelResponse(t *testing.T) {
 	}
 	if doneCount != 1 {
 		t.Fatalf("want 1 done event, got %d", doneCount)
+	}
+}
+
+// blockingStreamProvider is a minimal provider whose first Stream()
+// emits two tool_use events back-to-back and then blocks until the
+// first tool has started executing (waitForTool is closed) before
+// emitting the stop event. This creates a hard liveness dependency:
+// the stream only completes if the agent dispatches the first tool
+// concurrently with the stream. If streaming dispatch regresses and
+// tools run only post-stream, the provider goroutine blocks on
+// waitForTool forever — the test detects that via context timeout.
+//
+// Subsequent Stream() calls (the agent's follow-up turn after tool
+// results) simply emit a text_delta + stop.
+type blockingStreamProvider struct {
+	waitForTool <-chan struct{}
+	callIdx     int
+}
+
+func (p *blockingStreamProvider) Stream(_ context.Context, _ provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
+	idx := p.callIdx
+	p.callIdx++
+	ch := make(chan provider.StreamEvent)
+	go func() {
+		defer close(ch)
+		if idx == 0 {
+			// First tool_use — agent stores as currentTool.
+			ch <- provider.StreamEvent{Type: "tool_use", ToolUse: &provider.ToolUseBlock{
+				ID: "call-1", Name: "fake_read", Input: json.RawMessage(`{}`),
+			}}
+			// Second tool_use — triggers finalizeTool on the first,
+			// which dispatches it via streamingToolExecutor.
+			ch <- provider.StreamEvent{Type: "tool_use", ToolUse: &provider.ToolUseBlock{
+				ID: "call-2", Name: "fake_read", Input: json.RawMessage(`{}`),
+			}}
+			// Block until the first tool has actually started
+			// executing. Without streaming dispatch, this never
+			// happens and the test hits its context timeout.
+			<-p.waitForTool
+			ch <- provider.StreamEvent{Type: "stop"}
+			return
+		}
+		ch <- provider.StreamEvent{Type: "text_delta", Text: "done"}
+		ch <- provider.StreamEvent{Type: "stop"}
+	}()
+	return ch, nil
+}
+
+// TestRunLoopDispatchesStreamingToolDuringStream genuinely proves
+// that concurrency-safe tools are dispatched during the model stream,
+// not after it. The blocking provider refuses to emit stop until the
+// tool's Execute has started; if streaming dispatch is wired correctly
+// the tool runs mid-stream and the turn completes, otherwise the
+// provider deadlocks and the context times out.
+func TestRunLoopDispatchesStreamingToolDuringStream(t *testing.T) {
+	t.Parallel()
+	toolRan := make(chan struct{})
+	var once sync.Once
+	tool := &fakeConcurrencySafeTool{
+		name:       "fake_read",
+		execDelay:  1 * time.Millisecond,
+		returnText: "file contents",
+		onStart:    func() { once.Do(func() { close(toolRan) }) },
+	}
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(tool))
+
+	prov := &blockingStreamProvider{waitForTool: toolRan}
+	cfg := config.DefaultConfig()
+	cfg.Agent.MaxTurns = 5
+	// Streaming dispatch requires a non-nil approvalChecker returning
+	// an auto-approval verdict (see agent.go:1296-1305).
+	a := New(prov, reg, autoApprove, cfg,
+		WithApprovalChecker(&countingApprovalChecker{result: AutoApproved}),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	events, err := a.Turn(ctx, "read the file")
+	require.NoError(t, err)
+	for ev := range events {
+		_ = ev
+	}
+
+	// toolRan must be closed. If the stream completed without the
+	// tool ever executing (dispatch regression), the channel would
+	// still be open — but the provider would have deadlocked before
+	// ever emitting stop, so in practice we'd fail via context
+	// timeout above, not here. This select is defence-in-depth.
+	select {
+	case <-toolRan:
+		// Ok — tool was dispatched and started during the stream.
+	default:
+		t.Fatal("tool never ran — streaming dispatch regression")
+	}
+	if got := tool.called.Load(); got < 1 {
+		t.Fatalf("want tool called at least once, got %d", got)
 	}
 }

--- a/internal/agent/stream_tool_exec_test.go
+++ b/internal/agent/stream_tool_exec_test.go
@@ -1,0 +1,282 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/julianshen/rubichan/internal/config"
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/tools"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeConcurrencySafeTool is a minimal tool that implements the
+// agentsdk.Tool interface + ConcurrencySafeTool marker. It sleeps for
+// execDelay before returning returnText to simulate I/O latency.
+type fakeConcurrencySafeTool struct {
+	name       string
+	execDelay  time.Duration
+	called     atomic.Int32
+	returnText string
+}
+
+func (t *fakeConcurrencySafeTool) Name() string                 { return t.name }
+func (t *fakeConcurrencySafeTool) Description() string          { return "" }
+func (t *fakeConcurrencySafeTool) InputSchema() json.RawMessage { return nil }
+func (t *fakeConcurrencySafeTool) IsConcurrencySafe() bool      { return true }
+func (t *fakeConcurrencySafeTool) Execute(ctx context.Context, _ json.RawMessage) (agentsdk.ToolResult, error) {
+	t.called.Add(1)
+	select {
+	case <-time.After(t.execDelay):
+	case <-ctx.Done():
+		return agentsdk.ToolResult{}, ctx.Err()
+	}
+	return agentsdk.ToolResult{Content: t.returnText}, nil
+}
+
+// runnerFromTool builds an execFn that invokes tool.Execute directly,
+// applies the result cap, and wraps the outcome in a toolExecResult.
+// This mirrors what the agent does via executeSingleTool, but without
+// the pipeline — sufficient for executor-level unit tests.
+func runnerFromTool(tool agentsdk.Tool) toolExecFn {
+	return func(ctx context.Context, tc provider.ToolUseBlock) toolExecResult {
+		res, err := tool.Execute(ctx, tc.Input)
+		if err != nil {
+			return toolErrorResult(tc, err.Error())
+		}
+		res = applyResultCap(tool, res)
+		return toolExecResult{
+			toolUseID: tc.ID,
+			content:   res.Content,
+			isError:   res.IsError,
+			event:     makeToolResultEvent(tc.ID, tc.Name, res.Content, res.Display(), res.IsError),
+		}
+	}
+}
+
+func TestStreamingExecutorDispatchesSafeToolsInParallel(t *testing.T) {
+	t.Parallel()
+	// Two slow concurrency-safe tools. Sequential execution would take
+	// ~200ms; parallel dispatch should complete in ~100ms.
+	tool := &fakeConcurrencySafeTool{
+		name:       "read_file",
+		execDelay:  100 * time.Millisecond,
+		returnText: "ok",
+	}
+	ex := newStreamingToolExecutor(2, runnerFromTool(tool))
+	ctx := context.Background()
+
+	start := time.Now()
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "a", Name: "read_file", Input: json.RawMessage(`{}`)})
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "b", Name: "read_file", Input: json.RawMessage(`{}`)})
+	results := ex.Drain()
+	elapsed := time.Since(start)
+
+	if len(results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(results))
+	}
+	if elapsed > 180*time.Millisecond {
+		t.Fatalf("tools ran sequentially (%v) — expected parallel dispatch", elapsed)
+	}
+	if tool.called.Load() != 2 {
+		t.Fatalf("want 2 invocations, got %d", tool.called.Load())
+	}
+}
+
+func TestStreamingExecutorPreservesDispatchOrder(t *testing.T) {
+	t.Parallel()
+	// Order-preserving test needs per-tool delays. We use a router
+	// runner that dispatches to different fake tools based on tc.Name.
+	fast := &fakeConcurrencySafeTool{name: "fast", execDelay: 10 * time.Millisecond, returnText: "fast"}
+	slow := &fakeConcurrencySafeTool{name: "slow", execDelay: 80 * time.Millisecond, returnText: "slow"}
+	byName := map[string]agentsdk.Tool{"fast": fast, "slow": slow}
+	run := func(ctx context.Context, tc provider.ToolUseBlock) toolExecResult {
+		return runnerFromTool(byName[tc.Name])(ctx, tc)
+	}
+	ex := newStreamingToolExecutor(2, run)
+	ctx := context.Background()
+
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "first", Name: "slow"})
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "second", Name: "fast"})
+	results := ex.Drain()
+
+	if len(results) != 2 || results[0].toolUseID != "first" || results[1].toolUseID != "second" {
+		t.Fatalf("order not preserved: %+v", results)
+	}
+	if results[0].content != "slow" || results[1].content != "fast" {
+		t.Fatalf("content mismatch: %+v", results)
+	}
+}
+
+func TestStreamingExecutorCancelProducesErrorResults(t *testing.T) {
+	t.Parallel()
+	tool := &fakeConcurrencySafeTool{name: "read_file", execDelay: 50 * time.Millisecond, returnText: "ok"}
+	ex := newStreamingToolExecutor(2, runnerFromTool(tool))
+	ctx, cancel := context.WithCancel(context.Background())
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "a", Name: "read_file"})
+	cancel()
+	// Dispatch after cancel: must produce an error result, not hang.
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "b", Name: "read_file"})
+	results := ex.Drain()
+	if len(results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(results))
+	}
+	var bResult *toolExecResult
+	for i := range results {
+		if results[i].toolUseID == "b" {
+			bResult = &results[i]
+		}
+	}
+	if bResult == nil || !bResult.isError {
+		t.Fatalf("dispatch-after-cancel should produce an error result, got %+v", bResult)
+	}
+}
+
+func TestStreamingExecutorClampsMaxParallel(t *testing.T) {
+	t.Parallel()
+	// maxParallel <= 0 must be clamped to 1 — tools still run, just
+	// serially. Without clamping, the sem channel would be nil and
+	// Dispatch would hang.
+	tool := &fakeConcurrencySafeTool{name: "read_file", execDelay: 5 * time.Millisecond, returnText: "ok"}
+	ex := newStreamingToolExecutor(0, runnerFromTool(tool))
+	ctx := context.Background()
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "a", Name: "read_file"})
+	results := ex.Drain()
+	if len(results) != 1 || results[0].content != "ok" {
+		t.Fatalf("clamp failure: %+v", results)
+	}
+}
+
+func TestStreamingExecutorCancelWhileWaitingForSlot(t *testing.T) {
+	t.Parallel()
+	// maxParallel=1 plus a slow first dispatch forces the second
+	// dispatch to block on the semaphore; cancelling the context
+	// should unblock it with an error result.
+	tool := &fakeConcurrencySafeTool{name: "read_file", execDelay: 200 * time.Millisecond, returnText: "ok"}
+	ex := newStreamingToolExecutor(1, runnerFromTool(tool))
+	ctx, cancel := context.WithCancel(context.Background())
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "a", Name: "read_file"})
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "b", Name: "read_file"})
+	// Give the second dispatch a moment to park on the semaphore.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	results := ex.Drain()
+	if len(results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(results))
+	}
+	// b either errors from slot-wait cancel or runs with cancelled ctx;
+	// either way it should be an error result, not a hang.
+	var bResult *toolExecResult
+	for i := range results {
+		if results[i].toolUseID == "b" {
+			bResult = &results[i]
+		}
+	}
+	if bResult == nil || !bResult.isError {
+		t.Fatalf("want b to be an error result after cancel, got %+v", bResult)
+	}
+}
+
+func TestIsStreamingEligible(t *testing.T) {
+	t.Parallel()
+	safe := &fakeConcurrencySafeTool{name: "read_file"}
+
+	if !isStreamingEligible(safe, AutoApproved) {
+		t.Errorf("safe+auto-approved should be eligible")
+	}
+	if !isStreamingEligible(safe, TrustRuleApproved) {
+		t.Errorf("safe+trust-rule-approved should be eligible")
+	}
+	if isStreamingEligible(safe, ApprovalRequired) {
+		t.Errorf("safe+approval-required should NOT be eligible")
+	}
+	if isStreamingEligible(safe, AutoDenied) {
+		t.Errorf("safe+auto-denied should NOT be eligible")
+	}
+
+	// Tool without the marker must never be eligible, even with
+	// auto-approval.
+	unsafe := &unmarkedTool{name: "write_file"}
+	if isStreamingEligible(unsafe, AutoApproved) {
+		t.Errorf("unmarked tool should NOT be eligible")
+	}
+}
+
+// unmarkedTool implements agentsdk.Tool but NOT ConcurrencySafeTool.
+type unmarkedTool struct{ name string }
+
+func (u *unmarkedTool) Name() string                 { return u.name }
+func (u *unmarkedTool) Description() string          { return "" }
+func (u *unmarkedTool) InputSchema() json.RawMessage { return nil }
+func (u *unmarkedTool) Execute(context.Context, json.RawMessage) (agentsdk.ToolResult, error) {
+	return agentsdk.ToolResult{}, nil
+}
+
+// TestRunLoopStreamsConcurrencySafeToolsDuringModelResponse is a
+// liveness test: it registers a fake concurrency-safe tool, drives the
+// agent through a turn that emits a tool_use for it, and confirms via
+// atomic counter that the tool was invoked exactly once and the result
+// was emitted to the event channel.
+func TestRunLoopStreamsConcurrencySafeToolsDuringModelResponse(t *testing.T) {
+	t.Parallel()
+	tool := &fakeConcurrencySafeTool{
+		name:       "fake_read",
+		execDelay:  5 * time.Millisecond,
+		returnText: "file contents",
+	}
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(tool))
+
+	// Two-turn dynamic provider: first turn emits a tool_use, second
+	// acknowledges the result and stops.
+	dmp := &dynamicMockProvider{
+		responses: [][]provider.StreamEvent{
+			{
+				{Type: "tool_use", ToolUse: &provider.ToolUseBlock{
+					ID:    "call-1",
+					Name:  "fake_read",
+					Input: json.RawMessage(`{}`),
+				}},
+				{Type: "stop"},
+			},
+			{
+				{Type: "text_delta", Text: "done"},
+				{Type: "stop"},
+			},
+		},
+	}
+	cfg := config.DefaultConfig()
+	cfg.Agent.MaxTurns = 5
+	a := New(dmp, reg, autoApprove, cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	events, err := a.Turn(ctx, "read the file")
+	require.NoError(t, err)
+	var toolResults, doneCount int
+	for ev := range events {
+		switch ev.Type {
+		case "tool_result":
+			toolResults++
+		case "done":
+			doneCount++
+		case "error":
+			if ev.Error != nil {
+				t.Logf("turn error event: %v", ev.Error)
+			}
+		}
+	}
+	if tool.called.Load() != 1 {
+		t.Fatalf("want tool called exactly once, got %d", tool.called.Load())
+	}
+	if toolResults != 1 {
+		t.Fatalf("want 1 tool_result event, got %d", toolResults)
+	}
+	if doneCount != 1 {
+		t.Fatalf("want 1 done event, got %d", doneCount)
+	}
+}

--- a/internal/agent/stream_tool_exec_test.go
+++ b/internal/agent/stream_tool_exec_test.go
@@ -216,6 +216,163 @@ func (u *unmarkedTool) Execute(context.Context, json.RawMessage) (agentsdk.ToolR
 	return agentsdk.ToolResult{}, nil
 }
 
+// TestExecuteToolsAllStreamedFastPath drives executeTools directly with
+// a pendingTools slice where every entry has a pre-populated
+// streamedResults entry. It covers:
+//   - the merge branch at agent.go:1651-1659 (streamed result moved into
+//     results[i] + tool_call emitted)
+//   - the all-streamed fast path at agent.go:1670-1679 (len(planned)==0,
+//     jump straight to result emission without partition/execute dance)
+//
+// Verified: Execute is never called on the registered tool, and both
+// tool_call + tool_result events are emitted per pending tool.
+func TestExecuteToolsAllStreamedFastPath(t *testing.T) {
+	t.Parallel()
+	// Tool registered with executeFn that panics if called — any streamed
+	// result must NOT re-run this tool.
+	neverRun := &mockTool{
+		name:        "tool_a",
+		description: "tool A",
+		inputSchema: json.RawMessage(`{"type":"object"}`),
+		executeFn: func(_ context.Context, _ json.RawMessage) (tools.ToolResult, error) {
+			t.Errorf("tool should not be executed when streamedResults already contains its result")
+			return tools.ToolResult{Content: "unexpected"}, nil
+		},
+	}
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(neverRun))
+
+	cfg := config.DefaultConfig()
+	// Approval checker required so executeTools takes the main path
+	// (not the executePlannedToolsSequential fallback).
+	a := New(&mockProvider{}, reg, autoApprove, cfg,
+		WithApprovalChecker(&countingApprovalChecker{result: AutoApproved}),
+	)
+
+	pendingTools := []provider.ToolUseBlock{
+		{ID: "a", Name: "tool_a", Input: json.RawMessage(`{}`)},
+		{ID: "b", Name: "tool_a", Input: json.RawMessage(`{}`)},
+	}
+	streamed := map[string]toolExecResult{
+		"a": {
+			toolUseID: "a",
+			content:   "result_a",
+			event:     makeToolResultEvent("a", "tool_a", "result_a", "", false),
+		},
+		"b": {
+			toolUseID: "b",
+			content:   "result_b",
+			event:     makeToolResultEvent("b", "tool_a", "result_b", "", false),
+		},
+	}
+
+	ch := make(chan TurnEvent, 16)
+	cancelled := a.executeTools(context.Background(), ch, pendingTools, streamed)
+	require.False(t, cancelled)
+
+	var toolCalls, toolResults []TurnEvent
+	for len(ch) > 0 {
+		ev := <-ch
+		switch ev.Type {
+		case "tool_call":
+			toolCalls = append(toolCalls, ev)
+		case "tool_result":
+			toolResults = append(toolResults, ev)
+		}
+	}
+	require.Len(t, toolCalls, 2, "expected 2 tool_call events")
+	require.Len(t, toolResults, 2, "expected 2 tool_result events")
+
+	// Results must be emitted in original pendingTools order.
+	require.Equal(t, "a", toolResults[0].ToolResult.ID)
+	require.Equal(t, "result_a", toolResults[0].ToolResult.Content)
+	require.Equal(t, "b", toolResults[1].ToolResult.ID)
+	require.Equal(t, "result_b", toolResults[1].ToolResult.Content)
+
+	// Conversation must contain the tool_result blocks.
+	msgs := a.conversation.Messages()
+	var toolResultBlocks int
+	for _, m := range msgs {
+		for _, c := range m.Content {
+			if c.Type == "tool_result" {
+				toolResultBlocks++
+			}
+		}
+	}
+	require.Equal(t, 2, toolResultBlocks, "conversation should contain 2 tool_result blocks")
+}
+
+// TestExecutePlannedToolsSequentialWithStreamedResults covers the
+// streamedResults merge branch in executePlannedToolsSequential (the
+// path taken when approvalChecker == nil and streaming dispatch already
+// produced a result for the tool). Verifies the cached result is
+// emitted without re-invoking the tool's Execute.
+func TestExecutePlannedToolsSequentialWithStreamedResults(t *testing.T) {
+	t.Parallel()
+	neverRun := &mockTool{
+		name:        "tool_a",
+		description: "tool A",
+		inputSchema: json.RawMessage(`{"type":"object"}`),
+		executeFn: func(_ context.Context, _ json.RawMessage) (tools.ToolResult, error) {
+			t.Errorf("tool should not be executed when streamedResults already contains its result")
+			return tools.ToolResult{Content: "unexpected"}, nil
+		},
+	}
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(neverRun))
+
+	cfg := config.DefaultConfig()
+	// approvalChecker == nil => executeTools falls through to
+	// executePlannedToolsSequential.
+	a := New(&mockProvider{}, reg, autoApprove, cfg)
+
+	pendingTools := []provider.ToolUseBlock{
+		{ID: "t1", Name: "tool_a", Input: json.RawMessage(`{}`)},
+	}
+	streamed := map[string]toolExecResult{
+		"t1": {
+			toolUseID: "t1",
+			content:   "streamed_result",
+			event:     makeToolResultEvent("t1", "tool_a", "streamed_result", "", false),
+		},
+	}
+
+	ch := make(chan TurnEvent, 8)
+	cancelled := a.executeTools(context.Background(), ch, pendingTools, streamed)
+	require.False(t, cancelled)
+
+	var toolCall, toolResult *TurnEvent
+	for len(ch) > 0 {
+		ev := <-ch
+		switch ev.Type {
+		case "tool_call":
+			e := ev
+			toolCall = &e
+		case "tool_result":
+			e := ev
+			toolResult = &e
+		}
+	}
+	require.NotNil(t, toolCall, "expected a tool_call event")
+	require.NotNil(t, toolResult, "expected a tool_result event")
+	require.Equal(t, "t1", toolCall.ToolCall.ID)
+	require.Equal(t, "t1", toolResult.ToolResult.ID)
+	require.Equal(t, "streamed_result", toolResult.ToolResult.Content)
+	require.False(t, toolResult.ToolResult.IsError)
+
+	// Conversation contains the tool_result block.
+	msgs := a.conversation.Messages()
+	var toolResultBlocks int
+	for _, m := range msgs {
+		for _, c := range m.Content {
+			if c.Type == "tool_result" {
+				toolResultBlocks++
+			}
+		}
+	}
+	require.Equal(t, 1, toolResultBlocks)
+}
+
 // TestRunLoopStreamsConcurrencySafeToolsDuringModelResponse is a
 // liveness test: it registers a fake concurrency-safe tool, drives the
 // agent through a turn that emits a tool_use for it, and confirms via

--- a/internal/tools/read_result.go
+++ b/internal/tools/read_result.go
@@ -24,6 +24,11 @@ func NewReadResultTool(r ResultRetriever) *ReadResultTool {
 
 func (t *ReadResultTool) Name() string { return "read_result" }
 
+// IsConcurrencySafe declares this tool eligible for streaming dispatch.
+// read_result just retrieves previously-stored tool output by ref ID —
+// a pure read with no side effects.
+func (*ReadResultTool) IsConcurrencySafe() bool { return true }
+
 func (t *ReadResultTool) Description() string {
 	return "Read a previously stored tool result by reference ID. Supports offset and limit for pagination."
 }

--- a/internal/tools/search.go
+++ b/internal/tools/search.go
@@ -45,6 +45,11 @@ func (s *SearchTool) Name() string {
 	return "search"
 }
 
+// IsConcurrencySafe declares this tool eligible for streaming dispatch.
+// search is a pure read over files — no mutations, safe to reorder and
+// run in parallel with other tool calls.
+func (*SearchTool) IsConcurrencySafe() bool { return true }
+
 func (s *SearchTool) SearchHint() string {
 	return "codebase explore analyze review directory listing structure symbol"
 }

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -147,6 +147,12 @@ func (s *ShellTool) Name() string {
 	return "shell"
 }
 
+// MaxResultBytes implements agentsdk.ResultCapped. Shell output is
+// frequently large (verbose builds, recursive listings); 64 KB keeps
+// head+tail context while preventing a single command from dominating
+// the context window.
+func (*ShellTool) MaxResultBytes() int { return 64 * 1024 }
+
 func (s *ShellTool) SearchHint() string {
 	return "terminal bash run deploy npm pip cargo make compile"
 }

--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -26,6 +26,11 @@ func NewToolSearchTool(s ToolSearcher) *ToolSearchTool {
 
 func (t *ToolSearchTool) Name() string { return "tool_search" }
 
+// IsConcurrencySafe declares this tool eligible for streaming dispatch.
+// tool_search only queries the in-memory deferral registry — pure read
+// with no side effects.
+func (*ToolSearchTool) IsConcurrencySafe() bool { return true }
+
 func (t *ToolSearchTool) Description() string {
 	return "Search for tools that have been deferred to save context. Returns tool names, descriptions, and schemas."
 }

--- a/pkg/agentsdk/events.go
+++ b/pkg/agentsdk/events.go
@@ -20,6 +20,7 @@ type TurnEvent struct {
 	DiffSummary    string             // populated for done events: markdown-formatted cumulative file change summary
 	SubagentResult *SubagentResult    // populated for subagent_done events
 	ContextBudget  *ContextBudget     // populated for done events: per-component context usage breakdown
+	ExitReason     TurnExitReason     // populated for done events: why the turn stopped
 }
 
 // ToolCallEvent contains details about a tool being called.

--- a/pkg/agentsdk/exit_reason.go
+++ b/pkg/agentsdk/exit_reason.go
@@ -1,5 +1,12 @@
 package agentsdk
 
+import "fmt"
+
+// Compile-time assertion that TurnExitReason satisfies fmt.Stringer.
+// If someone accidentally changes the receiver signature of String(),
+// this line will fail the build.
+var _ fmt.Stringer = TurnExitReason(0)
+
 // TurnExitReason enumerates why a turn stopped. Every "done" TurnEvent
 // carries exactly one of these. New reasons must be added here and nowhere
 // else; callers switch on this value.

--- a/pkg/agentsdk/exit_reason.go
+++ b/pkg/agentsdk/exit_reason.go
@@ -44,12 +44,14 @@ const (
 	// ExitEmptyResponse: model returned no text and no tool calls.
 	ExitEmptyResponse
 
-	// ExitCompactionFailed: compaction circuit breaker tripped (reserved
-	// for Task 3).
+	// ExitCompactionFailed: compaction circuit breaker tripped after
+	// repeated no-shrink attempts.
 	ExitCompactionFailed
 
-	// ExitProtocolViolation: orphaned tool_use blocks detected and not
-	// recoverable (reserved for Task 2).
+	// ExitProtocolViolation: orphaned tool_use blocks were detected
+	// and could not be recovered. Reserved for future use — not emitted
+	// today because the orphan sweeper always produces a valid
+	// conversation state from non-fatal exit paths.
 	ExitProtocolViolation
 
 	// ExitPanic: a panic was recovered in Turn's deferred handler.

--- a/pkg/agentsdk/exit_reason.go
+++ b/pkg/agentsdk/exit_reason.go
@@ -1,0 +1,82 @@
+package agentsdk
+
+// TurnExitReason enumerates why a turn stopped. Every "done" TurnEvent
+// carries exactly one of these. New reasons must be added here and nowhere
+// else; callers switch on this value.
+type TurnExitReason int
+
+const (
+	// ExitUnknown is the zero value. Emitting a done event with this reason
+	// is a bug — it means a code path forgot to set a reason.
+	ExitUnknown TurnExitReason = iota
+
+	// ExitCompleted: the model returned no tool calls and no error.
+	ExitCompleted
+
+	// ExitMaxTurns: the loop hit its maxTurns ceiling.
+	ExitMaxTurns
+
+	// ExitCancelled: ctx.Err() was observed (user abort, timeout, etc.).
+	ExitCancelled
+
+	// ExitProviderError: the provider returned an unrecoverable error.
+	ExitProviderError
+
+	// ExitRateLimited: the rate limiter returned an error from Wait().
+	ExitRateLimited
+
+	// ExitSkillActivationFailed: skill runtime could not evaluate triggers.
+	ExitSkillActivationFailed
+
+	// ExitTaskComplete: model invoked the task_complete tool.
+	ExitTaskComplete
+
+	// ExitNoProgress: maxRepeatedPendingToolRounds reached.
+	ExitNoProgress
+
+	// ExitEmptyResponse: model returned no text and no tool calls.
+	ExitEmptyResponse
+
+	// ExitCompactionFailed: compaction circuit breaker tripped (reserved
+	// for Task 3).
+	ExitCompactionFailed
+
+	// ExitProtocolViolation: orphaned tool_use blocks detected and not
+	// recoverable (reserved for Task 2).
+	ExitProtocolViolation
+
+	// ExitPanic: a panic was recovered in Turn's deferred handler.
+	ExitPanic
+)
+
+// String returns a stable lowercase identifier usable in logs and tests.
+func (r TurnExitReason) String() string {
+	switch r {
+	case ExitCompleted:
+		return "completed"
+	case ExitMaxTurns:
+		return "max_turns"
+	case ExitCancelled:
+		return "cancelled"
+	case ExitProviderError:
+		return "provider_error"
+	case ExitRateLimited:
+		return "rate_limited"
+	case ExitSkillActivationFailed:
+		return "skill_activation_failed"
+	case ExitTaskComplete:
+		return "task_complete"
+	case ExitNoProgress:
+		return "no_progress"
+	case ExitEmptyResponse:
+		return "empty_response"
+	case ExitCompactionFailed:
+		return "compaction_failed"
+	case ExitProtocolViolation:
+		return "protocol_violation"
+	case ExitPanic:
+		return "panic"
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/agentsdk/tool_caps.go
+++ b/pkg/agentsdk/tool_caps.go
@@ -1,0 +1,28 @@
+package agentsdk
+
+// ResultCapped is an optional extension interface for tools that want
+// the agent to truncate their output before it enters the conversation.
+//
+// Tools that implement this interface report a byte cap via
+// MaxResultBytes. If a result's Content exceeds the cap, the agent
+// replaces it with a head+tail slice plus a truncation marker. Tools
+// that don't implement this interface are exempt — their output flows
+// through unchanged. Implementations may also return a non-positive
+// value to opt out at runtime (e.g., disable the cap via config).
+//
+// Recommended caps:
+//   - shell:       64 KB (head + tail of interleaved stdout/stderr)
+//   - read_file:   256 KB (large files already have pagination)
+//   - grep/search: 64 KB
+//   - http_fetch:  128 KB
+//
+// This matches Claude Code's "Layer 0" context-management step in
+// query.ts (applyToolResultBudget). Enforcing size at emission prevents
+// a single tool_result from dominating the context window and forcing
+// every subsequent compaction pass to trade granular history for one
+// bloated result.
+type ResultCapped interface {
+	// MaxResultBytes returns the maximum byte length of ToolResult.Content.
+	// Return a non-positive value to opt out (treated as exempt).
+	MaxResultBytes() int
+}

--- a/pkg/agentsdk/tool_caps.go
+++ b/pkg/agentsdk/tool_caps.go
@@ -26,3 +26,34 @@ type ResultCapped interface {
 	// Return a non-positive value to opt out (treated as exempt).
 	MaxResultBytes() int
 }
+
+// ConcurrencySafeTool is an optional extension interface. Tools that
+// implement it declare themselves safe to execute as soon as their
+// tool_use block finalizes during streaming — the agent dispatches
+// them without waiting for the full model response.
+//
+// A tool is concurrency-safe if and only if:
+//  1. It has no observable side effects on the filesystem, network,
+//     or process state (pure reads).
+//  2. Its result depends only on the input and on external state that
+//     won't be mutated by another concurrently-dispatched tool.
+//  3. Re-ordering it with respect to sibling tool calls in the same
+//     response is a no-op as far as the user is concerned.
+//
+// Tools that return false (or don't implement the interface) are
+// queued and executed after the stream completes, in declaration
+// order, via the normal executeTools pipeline.
+//
+// Examples of safe tools: read_file, grep, glob, list_dir, code_search,
+// http_get.
+//
+// Examples of unsafe tools: write_file, patch_file, shell, edit, git,
+// database writes, anything with network side effects.
+//
+// This matches Claude Code's StreamingToolExecutor in query.ts: "A tool
+// is dispatched as soon as its tool_use block is finalized during the
+// stream; by the time the model finishes post-tool text, the file
+// contents are already in memory."
+type ConcurrencySafeTool interface {
+	IsConcurrencySafe() bool
+}


### PR DESCRIPTION
## Summary

Five production-readiness fixes for the agent loop, derived from comparing Rubichan's `runLoop` against Claude Code's `query.ts` (Ch. 5 of [claude-code-from-source.com](https://claude-code-from-source.com/ch05-agent-loop/)).

- **`TurnExitReason` enum** on every `done` event (13 reasons) — tests and observability can finally distinguish *why* a turn stopped instead of "did an error event arrive"
- **Orphaned `tool_result` safety net** — `synthesizeMissingToolResults` walks the last assistant message and seals unanswered `tool_use` blocks with error results on stream error, tool-execution cancel, and panic recovery (prevents the 400 "tool_use ids without tool_result" protocol error on retry/resume)
- **Compaction circuit breaker** — `ContextManager.Compact` returns `ErrCompactionExhausted` after 3 consecutive no-shrink attempts; loop exits with `ExitCompactionFailed` instead of burning API budget forever in a compact-fail-retry loop (Claude Code's "250K API calls/day" failure mode)
- **Per-tool result size cap** — new optional `agentsdk.ResultCapped` interface with head+tail+marker truncation; shell tool opts in at 64 KB so a chatty command can't dominate the context window
- **Streaming tool execution** — new optional `agentsdk.ConcurrencySafeTool` marker + `streamingToolExecutor`; read-only tools (`search`, `read_result`, `tool_search`) dispatch the moment their `tool_use` block finalizes during streaming, running in parallel with the remaining model output

## Plan

Full task-by-task plan with TDD checkpoints: [`docs/superpowers/plans/2026-04-13-agent-loop-hardening.md`](docs/superpowers/plans/2026-04-13-agent-loop-hardening.md)

## Test Plan

- [x] `go test -race ./internal/agent/...` passes
- [x] `go test -race ./pkg/agentsdk/...` passes
- [x] `go test ./...` passes
- [x] `gofmt -l .` clean on touched files
- [x] `golangci-lint run ./internal/agent/... ./pkg/agentsdk/... ./internal/tools/...` clean
- [x] Package coverage: **91.0%** (> 90% target)
- [x] New file coverage: `stream_tool_exec.go` 100%, `result_cap.go` 95%, `orphan.go` 92.9%
- [x] All 12 commits reviewed by spec-compliance reviewer + code-quality reviewer per task

## Architecture notes

All five changes are additive and backward compatible:

- `ResultCapped` and `ConcurrencySafeTool` are optional extension interfaces — tools that don't implement them flow through unchanged (`FileTool` correctly stays non-concurrency-safe because it multiplexes read/write/patch via an `Operation` field)
- `TurnExitReason` zero value is `ExitUnknown` — documented as a bug signal; every call site is audited to emit a specific reason
- Circuit breaker only trips after 3 consecutive *no-shrink* compactions (strategy error OR silent no-op that fails to reduce tokens) — healthy sessions are unaffected; successful compaction resets the counter
- Streaming executor uses a bounded semaphore pool (`maxParallelTools`); `Drain()` preserves dispatch order to satisfy the wire protocol's tool_use/tool_result ordering requirement

## Known limitations (future work)

1. **Single-tool responses don't benefit from streaming dispatch yet.** `finalizeTool()` fires at the next `tool_use` or stream end, so a single-tool response dispatches at the same moment as normal `executeTools`. Fix requires exposing `content_block_stop` in the provider event model. Tracked as a follow-up.
2. **Wire protocol doesn't forward `ExitReason`.** `internal/transport/ws/hub.go`'s `wireTurnEvent` needs an `ExitReason` field (as `String()` for cross-language stability) so TUI/WebSocket clients can see the typed reason.
3. **Stream-error path silently discards completed streamed tool results.** The UI sees half-events (tool_call fired but no tool_result). Small follow-up: emit synthetic tool_result events for drained results on streamErr.
4. **`ExitProtocolViolation`** is declared but currently unused. Either wire it into the orphan sweeper's success path or remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Turns now include explicit exit reasons for why an interaction ended.
  * Concurrency-safe tools can run concurrently during model streaming to reduce latency.
  * Tools may opt into output size limits; oversized results are automatically truncated.

* **Bug Fixes**
  * Orphaned/missing tool results are synthesized after interrupted runs.
  * Conversation compaction now trips a circuit-breaker instead of retrying forever.

* **Tests**
  * Added unit and integration tests for exit reasons, compaction breaker, streaming tools, and result capping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->