### PR TITLE
Agent loop hardening follow-ups: drop dead enum, surface streamed results, assert interfaces

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1653,11 +1653,7 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 	for i, tc := range pendingTools {
 		if r, ok := streamedResults[tc.ID]; ok {
 			results[i] = r
-			// Emit the tool_call event so UIs still see it.
-			ch <- TurnEvent{
-				Type:     "tool_call",
-				ToolCall: &ToolCallEvent{ID: tc.ID, Name: tc.Name, Input: tc.Input},
-			}
+			ch <- makeToolCallEvent(tc)
 			continue
 		}
 		plannedTools = append(plannedTools, plannedToolCall{
@@ -1702,27 +1698,13 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 	// Needs-approval tool_call events are emitted just before approval,
 	// matching the sequential path behavior.
 	for _, it := range autoApproved {
-		ch <- TurnEvent{
-			Type: "tool_call",
-			ToolCall: &ToolCallEvent{
-				ID:    it.tc.ID,
-				Name:  it.tc.Name,
-				Input: it.tc.Input,
-			},
-		}
+		ch <- makeToolCallEvent(it.tc)
 	}
 
 	// Emit tool_call events for auto-denied tools so headless runners can
 	// match results by call ID, then fill in denied results immediately.
 	for _, it := range autoDenied {
-		ch <- TurnEvent{
-			Type: "tool_call",
-			ToolCall: &ToolCallEvent{
-				ID:    it.tc.ID,
-				Name:  it.tc.Name,
-				Input: it.tc.Input,
-			},
-		}
+		ch <- makeToolCallEvent(it.tc)
 		results[it.index] = a.approvalToolErrorResult(it.tc, "Tool call denied by user (deny-always).", nil)
 	}
 
@@ -1758,14 +1740,7 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 		if ctx.Err() != nil {
 			return true
 		}
-		ch <- TurnEvent{
-			Type: "tool_call",
-			ToolCall: &ToolCallEvent{
-				ID:    it.tc.ID,
-				Name:  it.tc.Name,
-				Input: it.tc.Input,
-			},
-		}
+		ch <- makeToolCallEvent(it.tc)
 		results[it.index] = a.executeSingleTool(ctx, ch, it.tc)
 	}
 
@@ -1774,16 +1749,7 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 		if ctx.Err() != nil {
 			return true
 		}
-
-		ch <- TurnEvent{
-			Type: "tool_call",
-			ToolCall: &ToolCallEvent{
-				ID:    it.tc.ID,
-				Name:  it.tc.Name,
-				Input: it.tc.Input,
-			},
-		}
-
+		ch <- makeToolCallEvent(it.tc)
 		results[it.index] = a.executeSingleToolWithApproval(ctx, ch, it.tc, it.approvalResult)
 	}
 
@@ -1813,14 +1779,7 @@ func (a *Agent) executePlannedToolsSequential(ctx context.Context, ch chan<- Tur
 		// Streaming dispatch already ran this tool — emit the tool_call
 		// and cached result directly without re-executing.
 		if r, ok := streamedResults[planned.tc.ID]; ok {
-			ch <- TurnEvent{
-				Type: "tool_call",
-				ToolCall: &ToolCallEvent{
-					ID:    planned.tc.ID,
-					Name:  planned.tc.Name,
-					Input: planned.tc.Input,
-				},
-			}
+			ch <- makeToolCallEvent(planned.tc)
 			a.conversation.AddToolResult(r.toolUseID, r.content, r.isError)
 			a.persistToolResult(r.toolUseID, r.content, r.isError)
 			ch <- r.event
@@ -1828,15 +1787,7 @@ func (a *Agent) executePlannedToolsSequential(ctx context.Context, ch chan<- Tur
 			continue
 		}
 
-		ch <- TurnEvent{
-			Type: "tool_call",
-			ToolCall: &ToolCallEvent{
-				ID:    planned.tc.ID,
-				Name:  planned.tc.Name,
-				Input: planned.tc.Input,
-			},
-		}
-
+		ch <- makeToolCallEvent(planned.tc)
 		r := a.executeSingleToolWithApproval(ctx, ch, planned.tc, planned.approvalResult)
 		a.conversation.AddToolResult(r.toolUseID, r.content, r.isError)
 		a.persistToolResult(r.toolUseID, r.content, r.isError)
@@ -2022,6 +1973,20 @@ func makeToolResultEvent(id, name, content, displayContent string, isError bool)
 			Content:        content,
 			DisplayContent: displayContent,
 			IsError:        isError,
+		},
+	}
+}
+
+// makeToolCallEvent builds a tool_call TurnEvent from a ToolUseBlock.
+// All "about to run this tool" emission sites go through here so the
+// wire shape stays uniform.
+func makeToolCallEvent(tc provider.ToolUseBlock) TurnEvent {
+	return TurnEvent{
+		Type: "tool_call",
+		ToolCall: &ToolCallEvent{
+			ID:    tc.ID,
+			Name:  tc.Name,
+			Input: tc.Input,
 		},
 	}
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1402,12 +1402,13 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			}}, blocks...)
 		}
 
-		// On stream error, discard partial blocks to prevent conversation corruption
+		// On stream error, discard partial blocks to prevent conversation
+		// corruption but surface any completed streaming dispatches to the
+		// event channel. executeSingleTool emits tool_progress events as
+		// the tool runs; if we don't also emit a matching tool_call +
+		// tool_result, the UI sees orphan progress with no terminal event.
 		if streamErr {
-			// Drain background streaming dispatches before discarding
-			// their results — prevents goroutine leaks and honours the
-			// executor's semantics (Drain unconditionally waits).
-			_ = execStream.Drain()
+			surfaceStreamedResults(ch, pendingTools, execStream.Drain())
 			// Defensive: currently a no-op because AddAssistant has not been called
 			// yet on this path, but protects against future reorderings.
 			synthesizeMissingToolResults(a.conversation, orphanReasonStreamError)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1408,7 +1408,12 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// the tool runs; if we don't also emit a matching tool_call +
 		// tool_result, the UI sees orphan progress with no terminal event.
 		if streamErr {
-			surfaceStreamedResults(ch, pendingTools, execStream.Drain())
+			if unmatched := surfaceStreamedResults(ch, pendingTools, execStream.Drain()); unmatched > 0 {
+				// Invariant broken: every dispatched tool should have been
+				// appended to pendingTools before Dispatch ran. If this
+				// fires, a future refactor reordered the Dispatch site.
+				a.logger.Warn("streamErr: %d drained tool result(s) had IDs not in pendingTools; tool_call events were skipped", unmatched)
+			}
 			// Defensive: currently a no-op because AddAssistant has not been called
 			// yet on this path, but protects against future reorderings.
 			synthesizeMissingToolResults(a.conversation, orphanReasonStreamError)

--- a/internal/agent/stream_tool_exec.go
+++ b/internal/agent/stream_tool_exec.go
@@ -119,6 +119,40 @@ func (e *streamingToolExecutor) Drain() []toolExecResult {
 	return out
 }
 
+// surfaceStreamedResults emits synthetic tool_call + cached tool_result
+// events for tools that finished via streaming dispatch but whose
+// normal emission path (executeTools) won't run — notably the
+// stream-error branch, which discards partial blocks without reaching
+// executeTools.
+//
+// Without this, the UI sees tool_progress events (emitted by
+// executeSingleTool as the tool runs) with no matching tool_call or
+// tool_result to close them out. Each drained result is matched to
+// its pendingTools entry by ID so the tool_call event carries the
+// original Name and Input.
+func surfaceStreamedResults(ch chan<- TurnEvent, pendingTools []provider.ToolUseBlock, drained []toolExecResult) {
+	if len(drained) == 0 {
+		return
+	}
+	byID := make(map[string]provider.ToolUseBlock, len(pendingTools))
+	for _, tc := range pendingTools {
+		byID[tc.ID] = tc
+	}
+	for _, r := range drained {
+		if tc, ok := byID[r.toolUseID]; ok {
+			ch <- TurnEvent{
+				Type: "tool_call",
+				ToolCall: &ToolCallEvent{
+					ID:    tc.ID,
+					Name:  tc.Name,
+					Input: tc.Input,
+				},
+			}
+		}
+		ch <- r.event
+	}
+}
+
 // isStreamingEligible returns true if a tool can be dispatched during
 // streaming. Requires the ConcurrencySafeTool marker returning true AND
 // auto-approval (either AutoApproved or TrustRuleApproved).

--- a/internal/agent/stream_tool_exec.go
+++ b/internal/agent/stream_tool_exec.go
@@ -119,17 +119,17 @@ func (e *streamingToolExecutor) Drain() []toolExecResult {
 	return out
 }
 
-// surfaceStreamedResults emits synthetic tool_call + cached tool_result
-// events for tools that finished via streaming dispatch but whose
-// normal emission path (executeTools) won't run — notably the
-// stream-error branch, which discards partial blocks without reaching
-// executeTools.
+// surfaceStreamedResults is a terminal-only event flush for the
+// stream-error exit path. Without it, executeSingleTool's tool_progress
+// events from a dispatched tool have no matching tool_call or
+// tool_result and the UI sees an incomplete event loop.
 //
-// Without this, the UI sees tool_progress events (emitted by
-// executeSingleTool as the tool runs) with no matching tool_call or
-// tool_result to close them out. Each drained result is matched to
-// its pendingTools entry by ID so the tool_call event carries the
-// original Name and Input.
+// Events only — the conversation state is intentionally NOT updated
+// (no AddToolResult / persistToolResult / recordToolProgress). The
+// only caller is the streamErr branch, which discards all partial-turn
+// mutations because the assistant message was never committed. A
+// future caller that wants conversation-side persistence must not
+// reuse this helper.
 func surfaceStreamedResults(ch chan<- TurnEvent, pendingTools []provider.ToolUseBlock, drained []toolExecResult) {
 	if len(drained) == 0 {
 		return
@@ -140,14 +140,7 @@ func surfaceStreamedResults(ch chan<- TurnEvent, pendingTools []provider.ToolUse
 	}
 	for _, r := range drained {
 		if tc, ok := byID[r.toolUseID]; ok {
-			ch <- TurnEvent{
-				Type: "tool_call",
-				ToolCall: &ToolCallEvent{
-					ID:    tc.ID,
-					Name:  tc.Name,
-					Input: tc.Input,
-				},
-			}
+			ch <- makeToolCallEvent(tc)
 		}
 		ch <- r.event
 	}

--- a/internal/agent/stream_tool_exec.go
+++ b/internal/agent/stream_tool_exec.go
@@ -130,9 +130,16 @@ func (e *streamingToolExecutor) Drain() []toolExecResult {
 // mutations because the assistant message was never committed. A
 // future caller that wants conversation-side persistence must not
 // reuse this helper.
-func surfaceStreamedResults(ch chan<- TurnEvent, pendingTools []provider.ToolUseBlock, drained []toolExecResult) {
+//
+// Returns the count of drained results whose toolUseID was NOT found
+// in pendingTools. This is an invariant check: every dispatched tool
+// is appended to pendingTools in finalizeTool before Dispatch is
+// called, so unmatched should always be 0. A non-zero count means the
+// invariant broke and the caller should log it so future regressions
+// are visible instead of silently emitting orphan tool_result events.
+func surfaceStreamedResults(ch chan<- TurnEvent, pendingTools []provider.ToolUseBlock, drained []toolExecResult) (unmatched int) {
 	if len(drained) == 0 {
-		return
+		return 0
 	}
 	byID := make(map[string]provider.ToolUseBlock, len(pendingTools))
 	for _, tc := range pendingTools {
@@ -141,9 +148,12 @@ func surfaceStreamedResults(ch chan<- TurnEvent, pendingTools []provider.ToolUse
 	for _, r := range drained {
 		if tc, ok := byID[r.toolUseID]; ok {
 			ch <- makeToolCallEvent(tc)
+		} else {
+			unmatched++
 		}
 		ch <- r.event
 	}
+	return unmatched
 }
 
 // isStreamingEligible returns true if a tool can be dispatched during

--- a/internal/agent/stream_tool_exec_test.go
+++ b/internal/agent/stream_tool_exec_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -18,14 +19,16 @@ import (
 // fakeConcurrencySafeTool is a minimal tool that implements the
 // agentsdk.Tool interface + ConcurrencySafeTool marker. It sleeps for
 // execDelay before returning returnText to simulate I/O latency. If
-// onStart is non-nil, it is invoked on the very first line of Execute
-// — used by timing-sensitive tests to signal "tool has started".
+// onStart is non-nil, it is invoked on the very first line of Execute;
+// onFinish fires just before Execute returns. Both hooks are used by
+// timing-sensitive tests to synchronize with the tool's lifecycle.
 type fakeConcurrencySafeTool struct {
 	name       string
 	execDelay  time.Duration
 	called     atomic.Int32
 	returnText string
 	onStart    func()
+	onFinish   func()
 }
 
 func (t *fakeConcurrencySafeTool) Name() string                 { return t.name }
@@ -41,6 +44,9 @@ func (t *fakeConcurrencySafeTool) Execute(ctx context.Context, _ json.RawMessage
 	case <-time.After(t.execDelay):
 	case <-ctx.Done():
 		return agentsdk.ToolResult{}, ctx.Err()
+	}
+	if t.onFinish != nil {
+		t.onFinish()
 	}
 	return agentsdk.ToolResult{Content: t.returnText}, nil
 }
@@ -544,5 +550,115 @@ func TestRunLoopDispatchesStreamingToolDuringStream(t *testing.T) {
 	}
 	if got := tool.called.Load(); got < 1 {
 		t.Fatalf("want tool called at least once, got %d", got)
+	}
+}
+
+// streamErrAfterDispatchProvider emits a tool_use, a second tool_use
+// (to trigger finalizeTool on the first and dispatch it via the
+// streaming executor), waits until the dispatched tool has completed,
+// then emits a stream error. Used to verify that runLoop surfaces
+// drained streamed results to the event channel before exiting the
+// streamErr path — otherwise the UI sees orphan tool_progress events
+// with no tool_call or tool_result to close them out.
+type streamErrAfterDispatchProvider struct {
+	toolDone <-chan struct{}
+}
+
+func (p *streamErrAfterDispatchProvider) Stream(_ context.Context, _ provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
+	ch := make(chan provider.StreamEvent)
+	go func() {
+		defer close(ch)
+		ch <- provider.StreamEvent{Type: "tool_use", ToolUse: &provider.ToolUseBlock{
+			ID: "call-1", Name: "fake_read", Input: json.RawMessage(`{}`),
+		}}
+		ch <- provider.StreamEvent{Type: "tool_use", ToolUse: &provider.ToolUseBlock{
+			ID: "call-2", Name: "fake_read", Input: json.RawMessage(`{}`),
+		}}
+		// Wait for call-1 to finish executing before erroring.
+		<-p.toolDone
+		ch <- provider.StreamEvent{Type: "error", Error: fmt.Errorf("simulated stream failure")}
+		ch <- provider.StreamEvent{Type: "stop"}
+	}()
+	return ch, nil
+}
+
+// TestRunLoopStreamErrorSurfacesStreamedToolResults verifies that when
+// the stream errors after a concurrency-safe tool has been dispatched
+// and completed, runLoop surfaces the drained tool_call + tool_result
+// events so the UI doesn't see orphan tool_progress events with no
+// terminal event.
+func TestRunLoopStreamErrorSurfacesStreamedToolResults(t *testing.T) {
+	t.Parallel()
+	toolDone := make(chan struct{})
+	var once sync.Once
+	tool := &fakeConcurrencySafeTool{
+		name:       "fake_read",
+		execDelay:  1 * time.Millisecond,
+		returnText: "streamed result",
+		onFinish:   func() { once.Do(func() { close(toolDone) }) },
+	}
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(tool))
+
+	prov := &streamErrAfterDispatchProvider{toolDone: toolDone}
+	cfg := config.DefaultConfig()
+	cfg.Agent.MaxTurns = 5
+	a := New(prov, reg, autoApprove, cfg,
+		WithApprovalChecker(&countingApprovalChecker{result: AutoApproved}),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	events, err := a.Turn(ctx, "read the file")
+	require.NoError(t, err)
+
+	var toolCallIDs, toolResultIDs []string
+	var sawError, sawDone bool
+	var doneReason agentsdk.TurnExitReason
+	for ev := range events {
+		switch ev.Type {
+		case "tool_call":
+			if ev.ToolCall != nil {
+				toolCallIDs = append(toolCallIDs, ev.ToolCall.ID)
+			}
+		case "tool_result":
+			if ev.ToolResult != nil {
+				toolResultIDs = append(toolResultIDs, ev.ToolResult.ID)
+			}
+		case "error":
+			sawError = true
+		case "done":
+			sawDone = true
+			doneReason = ev.ExitReason
+		}
+	}
+
+	if !sawError {
+		t.Fatal("expected an error event from the stream failure")
+	}
+	if !sawDone {
+		t.Fatal("expected a done event")
+	}
+	if doneReason != agentsdk.ExitProviderError {
+		t.Fatalf("want ExitProviderError, got %v", doneReason)
+	}
+	// The dispatched call-1 must surface both tool_call and tool_result
+	// events so the UI has a closed event loop for its progress display.
+	var gotCall, gotResult bool
+	for _, id := range toolCallIDs {
+		if id == "call-1" {
+			gotCall = true
+		}
+	}
+	for _, id := range toolResultIDs {
+		if id == "call-1" {
+			gotResult = true
+		}
+	}
+	if !gotCall {
+		t.Fatalf("streamed tool dispatch did not emit a tool_call event; got IDs %v", toolCallIDs)
+	}
+	if !gotResult {
+		t.Fatalf("streamed tool dispatch did not emit a tool_result event; got IDs %v", toolResultIDs)
 	}
 }

--- a/internal/agent/stream_tool_exec_test.go
+++ b/internal/agent/stream_tool_exec_test.go
@@ -553,6 +553,99 @@ func TestRunLoopDispatchesStreamingToolDuringStream(t *testing.T) {
 	}
 }
 
+// TestSurfaceStreamedResultsEmitsCallAndResultInOrder verifies the
+// happy-path: every drained result produces a tool_call followed by
+// its cached tool_result on the channel.
+func TestSurfaceStreamedResultsEmitsCallAndResultInOrder(t *testing.T) {
+	t.Parallel()
+	ch := make(chan TurnEvent, 16)
+	pending := []provider.ToolUseBlock{
+		{ID: "a", Name: "read_file", Input: json.RawMessage(`{"p":"/tmp/a"}`)},
+		{ID: "b", Name: "read_file", Input: json.RawMessage(`{"p":"/tmp/b"}`)},
+	}
+	drained := []toolExecResult{
+		{toolUseID: "a", content: "A", event: makeToolResultEvent("a", "read_file", "A", "", false)},
+		{toolUseID: "b", content: "B", event: makeToolResultEvent("b", "read_file", "B", "", false)},
+	}
+	unmatched := surfaceStreamedResults(ch, pending, drained)
+	close(ch)
+	if unmatched != 0 {
+		t.Fatalf("want 0 unmatched, got %d", unmatched)
+	}
+	var seq []string
+	for ev := range ch {
+		switch ev.Type {
+		case "tool_call":
+			seq = append(seq, "call:"+ev.ToolCall.ID)
+		case "tool_result":
+			seq = append(seq, "result:"+ev.ToolResult.ID)
+		}
+	}
+	want := []string{"call:a", "result:a", "call:b", "result:b"}
+	if len(seq) != len(want) {
+		t.Fatalf("event sequence length mismatch: want %v, got %v", want, seq)
+	}
+	for i := range want {
+		if seq[i] != want[i] {
+			t.Fatalf("event[%d]: want %q, got %q", i, want[i], seq[i])
+		}
+	}
+}
+
+// TestSurfaceStreamedResultsReportsUnmatchedIDs verifies the invariant
+// check: if a drained result's toolUseID is NOT in pendingTools, the
+// helper skips the synthetic tool_call, still emits the tool_result,
+// and returns a non-zero unmatched count so the caller can log it.
+func TestSurfaceStreamedResultsReportsUnmatchedIDs(t *testing.T) {
+	t.Parallel()
+	ch := make(chan TurnEvent, 8)
+	pending := []provider.ToolUseBlock{
+		{ID: "a", Name: "read_file", Input: json.RawMessage(`{}`)},
+	}
+	drained := []toolExecResult{
+		{toolUseID: "ghost", content: "orphan", event: makeToolResultEvent("ghost", "read_file", "orphan", "", false)},
+	}
+	unmatched := surfaceStreamedResults(ch, pending, drained)
+	close(ch)
+	if unmatched != 1 {
+		t.Fatalf("want 1 unmatched, got %d", unmatched)
+	}
+	var sawCall, sawResult bool
+	for ev := range ch {
+		if ev.Type == "tool_call" {
+			sawCall = true
+		}
+		if ev.Type == "tool_result" && ev.ToolResult.ID == "ghost" {
+			sawResult = true
+		}
+	}
+	if sawCall {
+		t.Fatal("ghost ID should not produce a synthetic tool_call event")
+	}
+	if !sawResult {
+		t.Fatal("ghost tool_result event should still be emitted")
+	}
+}
+
+// TestSurfaceStreamedResultsEmptyDrainIsNoOp verifies the early-return
+// path — no drained results means no events emitted.
+func TestSurfaceStreamedResultsEmptyDrainIsNoOp(t *testing.T) {
+	t.Parallel()
+	ch := make(chan TurnEvent, 4)
+	unmatched := surfaceStreamedResults(ch, nil, nil)
+	close(ch)
+	if unmatched != 0 {
+		t.Fatalf("want 0 unmatched, got %d", unmatched)
+	}
+	count := 0
+	for range ch {
+		count++
+	}
+	if count != 0 {
+		t.Fatalf("want 0 events emitted, got %d", count)
+	}
+}
+
 // streamErrAfterDispatchProvider emits a tool_use, a second tool_use
 // (to trigger finalizeTool on the first and dispatch it via the
 // streaming executor), waits until the dispatched tool has completed,
@@ -612,18 +705,27 @@ func TestRunLoopStreamErrorSurfacesStreamedToolResults(t *testing.T) {
 	events, err := a.Turn(ctx, "read the file")
 	require.NoError(t, err)
 
-	var toolCallIDs, toolResultIDs []string
+	// Index tracking so we can assert tool_call arrives before tool_result
+	// for the same ID — out-of-order emission would reintroduce the orphan
+	// UX bug this test exists to prevent.
+	callIdx := map[string]int{}
+	resultIdx := map[string]int{}
 	var sawError, sawDone bool
 	var doneReason agentsdk.TurnExitReason
+	evIdx := 0
 	for ev := range events {
 		switch ev.Type {
 		case "tool_call":
 			if ev.ToolCall != nil {
-				toolCallIDs = append(toolCallIDs, ev.ToolCall.ID)
+				if _, ok := callIdx[ev.ToolCall.ID]; !ok {
+					callIdx[ev.ToolCall.ID] = evIdx
+				}
 			}
 		case "tool_result":
 			if ev.ToolResult != nil {
-				toolResultIDs = append(toolResultIDs, ev.ToolResult.ID)
+				if _, ok := resultIdx[ev.ToolResult.ID]; !ok {
+					resultIdx[ev.ToolResult.ID] = evIdx
+				}
 			}
 		case "error":
 			sawError = true
@@ -631,6 +733,7 @@ func TestRunLoopStreamErrorSurfacesStreamedToolResults(t *testing.T) {
 			sawDone = true
 			doneReason = ev.ExitReason
 		}
+		evIdx++
 	}
 
 	if !sawError {
@@ -644,21 +747,15 @@ func TestRunLoopStreamErrorSurfacesStreamedToolResults(t *testing.T) {
 	}
 	// The dispatched call-1 must surface both tool_call and tool_result
 	// events so the UI has a closed event loop for its progress display.
-	var gotCall, gotResult bool
-	for _, id := range toolCallIDs {
-		if id == "call-1" {
-			gotCall = true
-		}
-	}
-	for _, id := range toolResultIDs {
-		if id == "call-1" {
-			gotResult = true
-		}
-	}
+	ci, gotCall := callIdx["call-1"]
+	ri, gotResult := resultIdx["call-1"]
 	if !gotCall {
-		t.Fatalf("streamed tool dispatch did not emit a tool_call event; got IDs %v", toolCallIDs)
+		t.Fatalf("streamed tool dispatch did not emit a tool_call event; got call IDs %v", callIdx)
 	}
 	if !gotResult {
-		t.Fatalf("streamed tool dispatch did not emit a tool_result event; got IDs %v", toolResultIDs)
+		t.Fatalf("streamed tool dispatch did not emit a tool_result event; got result IDs %v", resultIdx)
+	}
+	if ci >= ri {
+		t.Fatalf("tool_call for call-1 (evIdx=%d) must arrive before tool_result (evIdx=%d)", ci, ri)
 	}
 }

--- a/internal/tools/interface.go
+++ b/internal/tools/interface.go
@@ -33,5 +33,15 @@ type StreamingTool = agentsdk.StreamingTool
 // for tool_search discovery of deferred tools.
 type SearchHinter = agentsdk.SearchHinter
 
+// ResultCapped is an optional interface for tools that declare a
+// per-result byte cap so oversize output is truncated before entering
+// the conversation.
+type ResultCapped = agentsdk.ResultCapped
+
+// ConcurrencySafeTool is an optional marker interface for tools that
+// can be dispatched during streaming because they have no observable
+// side effects.
+type ConcurrencySafeTool = agentsdk.ConcurrencySafeTool
+
 // ToolResult represents the result of executing a tool.
 type ToolResult = agentsdk.ToolResult

--- a/internal/tools/read_result.go
+++ b/internal/tools/read_result.go
@@ -24,6 +24,9 @@ func NewReadResultTool(r ResultRetriever) *ReadResultTool {
 
 func (t *ReadResultTool) Name() string { return "read_result" }
 
+// Compile-time assertion that ReadResultTool implements ConcurrencySafeTool.
+var _ ConcurrencySafeTool = (*ReadResultTool)(nil)
+
 // IsConcurrencySafe declares this tool eligible for streaming dispatch.
 // read_result just retrieves previously-stored tool output by ref ID —
 // a pure read with no side effects.

--- a/internal/tools/search.go
+++ b/internal/tools/search.go
@@ -45,6 +45,9 @@ func (s *SearchTool) Name() string {
 	return "search"
 }
 
+// Compile-time assertion that SearchTool implements ConcurrencySafeTool.
+var _ ConcurrencySafeTool = (*SearchTool)(nil)
+
 // IsConcurrencySafe declares this tool eligible for streaming dispatch.
 // search is a pure read over files — no mutations, safe to reorder and
 // run in parallel with other tool calls.

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -147,11 +147,18 @@ func (s *ShellTool) Name() string {
 	return "shell"
 }
 
+// Compile-time assertion that ShellTool implements ResultCapped.
+// Catches accidental renames or signature drift at build time.
+var _ ResultCapped = (*ShellTool)(nil)
+
+// shellResultCapBytes is the upper bound on shell tool_result content
+// sent to the LLM. 64 KB keeps head+tail context while preventing a
+// single verbose command from dominating the context window.
+const shellResultCapBytes = 64 * 1024
+
 // MaxResultBytes implements agentsdk.ResultCapped. Shell output is
-// frequently large (verbose builds, recursive listings); 64 KB keeps
-// head+tail context while preventing a single command from dominating
-// the context window.
-func (*ShellTool) MaxResultBytes() int { return 64 * 1024 }
+// frequently large (verbose builds, recursive listings).
+func (*ShellTool) MaxResultBytes() int { return shellResultCapBytes }
 
 func (s *ShellTool) SearchHint() string {
 	return "terminal bash run deploy npm pip cargo make compile"

--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -26,6 +26,9 @@ func NewToolSearchTool(s ToolSearcher) *ToolSearchTool {
 
 func (t *ToolSearchTool) Name() string { return "tool_search" }
 
+// Compile-time assertion that ToolSearchTool implements ConcurrencySafeTool.
+var _ ConcurrencySafeTool = (*ToolSearchTool)(nil)
+
 // IsConcurrencySafe declares this tool eligible for streaming dispatch.
 // tool_search only queries the in-memory deferral registry — pure read
 // with no side effects.

--- a/pkg/agentsdk/exit_reason.go
+++ b/pkg/agentsdk/exit_reason.go
@@ -48,12 +48,6 @@ const (
 	// repeated no-shrink attempts.
 	ExitCompactionFailed
 
-	// ExitProtocolViolation: orphaned tool_use blocks were detected
-	// and could not be recovered. Reserved for future use — not emitted
-	// today because the orphan sweeper always produces a valid
-	// conversation state from non-fatal exit paths.
-	ExitProtocolViolation
-
 	// ExitPanic: a panic was recovered in Turn's deferred handler.
 	ExitPanic
 )
@@ -81,8 +75,6 @@ func (r TurnExitReason) String() string {
 		return "empty_response"
 	case ExitCompactionFailed:
 		return "compaction_failed"
-	case ExitProtocolViolation:
-		return "protocol_violation"
 	case ExitPanic:
 		return "panic"
 	default:


### PR DESCRIPTION
## Summary

Three follow-ups from the PR #231 review (merged as 5daa363):

- **Delete `ExitProtocolViolation`** — declared for future use but never emitted. Dead enum value; delete now, add back if ever needed.
- **Surface streamed tool results on stream error** — `executeSingleTool` emits `tool_progress` events as a dispatched tool runs, but the stream-error path discarded the drained futures, leaving the UI with orphan progress events. New `surfaceStreamedResults` helper emits synthetic `tool_call` (matched to `pendingTools` by ID for the original Name/Input) plus the cached `tool_result` event for each drained future.
- **Compile-time interface assertions** — `var _ ResultCapped = (*ShellTool)(nil)` and `var _ ConcurrencySafeTool = (*SearchTool|ReadResultTool|ToolSearchTool)(nil)` so a future method rename trips the build instead of silently unbinding the interface. Also adds `ResultCapped` / `ConcurrencySafeTool` type aliases in `internal/tools/interface.go` and extracts `shellResultCapBytes` as a named constant.

Two commits, following CLAUDE.md's structural-vs-behavioral discipline:

- \`c61922f [STRUCTURAL] Drop unused exit reason and add interface assertions\`
- \`ba8fb8f [BEHAVIORAL] Surface streamed tool results on stream error\`

## Test Plan

- [x] \`TestRunLoopStreamErrorSurfacesStreamedToolResults\` — new test in \`stream_tool_exec_test.go\` drives a stream that errors after a dispatched tool has completed and asserts both \`tool_call\` and \`tool_result\` events fire for the streamed ID
- [x] \`go test -race ./internal/agent/... ./pkg/agentsdk/... ./internal/tools/\` all pass
- [x] Package coverage: 91.0% (unchanged)
- [x] \`gofmt -l\` clean on touched files
- [x] \`golangci-lint\` only reports pre-existing warnings

## Context

Refs: PR #231 review — issues I1, I2, I3 from the code-reviewer summary. The remaining known follow-ups from #231 (single-tool streaming dispatch via \`content_block_stop\`, WS wire format forwarding \`ExitReason\`) remain open and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming error handling now ensures dispatched tools produce terminal `tool_call` and `tool_result` events before the run ends, improving event completeness and UI consistency.

* **Removed Features**
  * Removed the `ExitProtocolViolation` exit reason.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->