### PR TITLE
[BEHAVIORAL] WS transport: forward ExitReason on done events

### DIFF
--- a/internal/transport/ws/hub.go
+++ b/internal/transport/ws/hub.go
@@ -686,6 +686,8 @@ func (h *Hub) sendEnvelope(c *Client, msgType, sessionID string, payload any) {
 
 // marshalTurnEvent serializes a TurnEvent for wire transmission.
 // The error field is converted to a string since errors aren't JSON-serializable.
+// ExitReason uses the stable lowercase String() form so cross-language
+// consumers don't have to pin the Go enum's integer value.
 type wireTurnEvent struct {
 	Type         string                    `json:"type"`
 	Text         string                    `json:"text,omitempty"`
@@ -699,6 +701,7 @@ type wireTurnEvent struct {
 	InputTokens  int                       `json:"input_tokens,omitempty"`
 	OutputTokens int                       `json:"output_tokens,omitempty"`
 	DiffSummary  string                    `json:"diff_summary,omitempty"`
+	ExitReason   string                    `json:"exit_reason,omitempty"`
 }
 
 type wireToolProgress struct {
@@ -721,6 +724,11 @@ func marshalTurnEvent(evt agentsdk.TurnEvent) (json.RawMessage, error) {
 		InputTokens:  evt.InputTokens,
 		OutputTokens: evt.OutputTokens,
 		DiffSummary:  evt.DiffSummary,
+	}
+	// Only forward ExitReason on done events. Zero value (ExitUnknown)
+	// is a bug signal on a done event but noise on any other event.
+	if evt.Type == "done" && evt.ExitReason != agentsdk.ExitUnknown {
+		w.ExitReason = evt.ExitReason.String()
 	}
 	if evt.Error != nil {
 		w.Error = evt.Error.Error()

--- a/internal/transport/ws/hub_test.go
+++ b/internal/transport/ws/hub_test.go
@@ -249,6 +249,35 @@ func TestHub_MarshalTurnEvent_WithError(t *testing.T) {
 	assert.Contains(t, wire.Error, "assert.AnError")
 }
 
+func TestHub_MarshalTurnEvent_DoneCarriesExitReason(t *testing.T) {
+	// A done TurnEvent must serialize its ExitReason as a stable
+	// lowercase string ("cancelled", "provider_error", ...) so
+	// cross-language wire consumers can switch on it without pinning
+	// the Go enum's integer value.
+	raw, err := marshalTurnEvent(agentsdk.TurnEvent{
+		Type:       "done",
+		ExitReason: agentsdk.ExitProviderError,
+	})
+	require.NoError(t, err)
+
+	var wire wireTurnEvent
+	require.NoError(t, json.Unmarshal(raw, &wire))
+	assert.Equal(t, "done", wire.Type)
+	assert.Equal(t, "provider_error", wire.ExitReason)
+}
+
+func TestHub_MarshalTurnEvent_NonDoneOmitsExitReason(t *testing.T) {
+	// Non-done events should omit ExitReason from the wire entirely
+	// (omitempty) so consumers don't see a spurious "unknown" string
+	// on every text_delta.
+	raw, err := marshalTurnEvent(agentsdk.TurnEvent{
+		Type: "text_delta",
+		Text: "hello",
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "exit_reason")
+}
+
 func TestHub_MarshalTurnEvent_WithToolProgress(t *testing.T) {
 	raw, err := marshalTurnEvent(agentsdk.TurnEvent{
 		Type: "tool_progress",


### PR DESCRIPTION
## Summary

Closes the third known follow-up from PR #231: WS/TUI clients couldn't see the typed \`TurnExitReason\` added to \`done\` events because \`wireTurnEvent\` didn't forward the field.

\`wireTurnEvent\` now carries an \`exit_reason\` field populated from \`TurnExitReason.String()\` so WebSocket consumers can switch on the stable lowercase form (\`\"cancelled\"\`, \`\"provider_error\"\`, \`\"compaction_failed\"\`, \`\"completed\"\`, etc.) without pinning the Go enum's integer value. Only \`done\` events forward the field — zero value (\`ExitUnknown\`) is omitted on non-done events via \`omitempty\` so high-volume text_delta/tool_progress events don't carry spurious fields.

## Test Plan

- [x] \`TestHub_MarshalTurnEvent_DoneCarriesExitReason\` — asserts done event with \`ExitProviderError\` serializes as \`\"exit_reason\":\"provider_error\"\`
- [x] \`TestHub_MarshalTurnEvent_NonDoneOmitsExitReason\` — asserts a text_delta event never emits \`exit_reason\` on the wire
- [x] \`go test -race ./internal/transport/ws/\` passes
- [x] No pre-existing tests regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)