### PR TITLE
API layer improvements: typed stream errors, idle watchdog, turn retry, cache telemetry

### DIFF
--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1689,7 +1689,11 @@ func runInteractive() error {
 	}
 
 	// Wire cross-session memory and summarizer.
-	summarizer := agent.NewLLMSummarizer(p, cfg.Provider.Model)
+	summaryModel := cfg.Provider.SummaryModel
+	if summaryModel == "" {
+		summaryModel = cfg.Provider.Model
+	}
+	summarizer := agent.NewLLMSummarizer(p, summaryModel)
 	opts = append(opts, agent.WithSummarizer(summarizer))
 	opts = append(opts, agent.WithMemoryStore(&storeMemoryAdapter{store: s}))
 
@@ -2183,7 +2187,11 @@ func runHeadless() error {
 	}
 
 	// Wire cross-session memory and summarizer.
-	headlessSummarizer := agent.NewLLMSummarizer(p, cfg.Provider.Model)
+	headlessSummaryModel := cfg.Provider.SummaryModel
+	if headlessSummaryModel == "" {
+		headlessSummaryModel = cfg.Provider.Model
+	}
+	headlessSummarizer := agent.NewLLMSummarizer(p, headlessSummaryModel)
 	opts = append(opts, agent.WithSummarizer(headlessSummarizer))
 	opts = append(opts, agent.WithMemoryStore(&storeMemoryAdapter{store: s}))
 

--- a/docs/superpowers/plans/2026-04-13-api-layer-improvements.md
+++ b/docs/superpowers/plans/2026-04-13-api-layer-improvements.md
@@ -1,0 +1,1965 @@
+# API Layer Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close eleven gaps between Claude Code's production-proven API layer design (as documented in Chapter 4) and Rubichan's current `internal/provider/` + `internal/agent/` implementation.
+
+**Architecture:** Three dependency chains executed in order — Group A (five independent fixes touching one file each), Group B (streaming-resilience chain requiring ordered composition: watchdog → turn-retry → stop_reason → non-stream fallback), Group C (cache architecture: loud PromptBuilder API → session latches). Each task is independently committable and leaves tests green.
+
+**Tech Stack:** Go 1.22, `bufio.Scanner`, `bytes.Buffer`, `sync.Mutex`, `github.com/google/uuid`, `github.com/julianshen/rubichan/internal/provider`, `github.com/julianshen/rubichan/internal/agent`, `github.com/julianshen/rubichan/pkg/agentsdk`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `internal/provider/provider_error.go` | Modify | Add `RequestID string` field to `ProviderError` |
+| `internal/provider/anthropic/provider.go` | Modify | Emit `ErrStreamError` from scanner, add `x-client-request-id`, decode cache tokens |
+| `internal/provider/ssecompat/processor.go` | Modify | Emit `ErrStreamError` from scanner (consistent with anthropic) |
+| `internal/provider/streamwatchdog.go` | **Create** | `WatchdogConfig`, `watchedStream()` helper |
+| `internal/provider/anthropic/provider_test.go` | Modify | Watchdog and `ErrStreamError` tests |
+| `internal/provider/ssecompat/processor_test.go` | Modify | `ErrStreamError` test |
+| `pkg/agentsdk/types.go` | Modify | Add `CacheCreationTokens`, `CacheReadTokens`, `StopReason` to `StreamEvent` |
+| `internal/agent/turnretry.go` | **Create** | `TurnRetryConfig`, `TurnRetry` wrapper function |
+| `internal/agent/turnretry_test.go` | **Create** | Unit tests for turn retry logic |
+| `internal/agent/prompt.go` | Modify | `AddCacheableSection()` / `AddDynamicSection_UNCACHED()` typed API |
+| `internal/agent/prompt_test.go` | Modify | Cache-stability test |
+| `internal/agent/sessionlatches.go` | **Create** | `sessionLatches` one-way ratchet |
+| `internal/agent/sessionlatches_test.go` | **Create** | Latch ratchet tests |
+| `internal/agent/agent.go` | Modify | Wire latches, fix `loadSessionHistory` orphan repair, widen output cap, use `SummaryModel` |
+| `internal/agent/orphan_test.go` | Modify | `TestLoadSessionHistory_SynthesizesOrphans` |
+| `internal/config/config.go` | Modify | Add `SummaryModel string` to `ProviderConfig` |
+| `internal/config/config_test.go` | Modify | `SummaryModel` default/load test |
+
+---
+
+## Group A — Independent Easy Wins (Tasks 1, 2, 7, 8, 11)
+
+These five tasks have no inter-dependencies. They can be done in any order, each committed separately.
+
+---
+
+### Task 1: Emit `ErrStreamError` from scanner errors
+
+**Problem:** Both `anthropic/provider.go` (line 147) and `ssecompat/processor.go` (line 197–202) emit raw `error` events with a plain `error`. The `ProviderError.ErrStreamError` kind already exists but is never constructed — callers cannot distinguish a stream tear from a JSON parse error without string inspection.
+
+**Files:**
+- Modify: `internal/provider/anthropic/provider.go:147-152`
+- Modify: `internal/provider/ssecompat/processor.go:197-202`
+- Modify: `internal/provider/anthropic/provider_test.go`
+- Modify: `internal/provider/ssecompat/processor_test.go`
+
+- [ ] **Step 1: Write failing test in `anthropic/provider_test.go`**
+
+```go
+// In TestProcessStream_ScannerError (new test)
+func TestProcessStream_ScannerError(t *testing.T) {
+    // Use an io.Reader that returns an error mid-stream.
+    pr, pw := io.Pipe()
+    pw.CloseWithError(errors.New("connection reset by peer"))
+
+    p := New("http://localhost", "test-key")
+    ch := make(chan provider.StreamEvent)
+    go p.processStream(context.Background(), io.NopCloser(pr), ch)
+
+    var events []provider.StreamEvent
+    for e := range ch {
+        events = append(events, e)
+    }
+
+    require.Len(t, events, 1)
+    assert.Equal(t, agentsdk.EventError, events[0].Type)
+
+    var pe *provider.ProviderError
+    require.ErrorAs(t, events[0].Error, &pe)
+    assert.Equal(t, provider.ErrStreamError, pe.Kind)
+    assert.Equal(t, "anthropic", pe.Provider)
+    assert.True(t, pe.IsRetryable())
+}
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+go test ./internal/provider/anthropic/... -run TestProcessStream_ScannerError -v
+```
+Expected: `FAIL` — `ErrorAs` fails because the current code emits a plain `error`, not a `*ProviderError`.
+
+- [ ] **Step 3: Update `processStream` in `anthropic/provider.go`**
+
+Replace lines 147–152:
+```go
+// Before:
+if err := scanner.Err(); err != nil {
+    select {
+    case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: err}:
+    case <-ctx.Done():
+    }
+}
+
+// After:
+if err := scanner.Err(); err != nil {
+    streamErr := &provider.ProviderError{
+        Kind:      provider.ErrStreamError,
+        Provider:  "anthropic",
+        Message:   err.Error(),
+        Retryable: true,
+    }
+    select {
+    case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: streamErr}:
+    case <-ctx.Done():
+    }
+}
+```
+
+- [ ] **Step 4: Write failing test in `ssecompat/processor_test.go`**
+
+```go
+func TestProcessSSE_ScannerError(t *testing.T) {
+    pr, pw := io.Pipe()
+    pw.CloseWithError(errors.New("EOF mid-stream"))
+
+    ch := make(chan provider.StreamEvent, 4)
+    ssecompat.ProcessSSE(context.Background(), io.NopCloser(pr), ch, "openai-compat")
+
+    var events []provider.StreamEvent
+    for e := range ch {
+        events = append(events, e)
+    }
+
+    require.Len(t, events, 1)
+    assert.Equal(t, agentsdk.EventError, events[0].Type)
+    var pe *provider.ProviderError
+    require.ErrorAs(t, events[0].Error, &pe)
+    assert.Equal(t, provider.ErrStreamError, pe.Kind)
+}
+```
+
+- [ ] **Step 5: Run test to confirm it fails**
+
+```bash
+go test ./internal/provider/ssecompat/... -run TestProcessSSE_ScannerError -v
+```
+Expected: `FAIL`.
+
+- [ ] **Step 6: Update scanner error in `ssecompat/processor.go`**
+
+Replace lines 197–202:
+```go
+// Before:
+if err := scanner.Err(); err != nil {
+    select {
+    case ch <- provider.StreamEvent{Type: "error", Error: err}:
+    case <-ctx.Done():
+    }
+}
+
+// After:
+if err := scanner.Err(); err != nil {
+    streamErr := &provider.ProviderError{
+        Kind:      provider.ErrStreamError,
+        Provider:  providerName, // pass as parameter (see note below)
+        Message:   err.Error(),
+        Retryable: true,
+    }
+    select {
+    case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: streamErr}:
+    case <-ctx.Done():
+    }
+}
+```
+
+Note: `ProcessSSE` currently takes `(ctx, body, ch)`. Add a `providerName string` parameter so the error carries the right `Provider` field. Update the single call site in `internal/provider/openai/provider.go` (or wherever `ProcessSSE` is called) to pass the provider name string.
+
+- [ ] **Step 7: Run all tests to confirm green**
+
+```bash
+go test ./internal/provider/... -v 2>&1 | tail -20
+```
+Expected: all `PASS`.
+
+- [ ] **Step 8: Lint and format**
+
+```bash
+golangci-lint run ./internal/provider/... && gofmt -l ./internal/provider/
+```
+Expected: no output.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/provider/anthropic/provider.go internal/provider/ssecompat/processor.go \
+        internal/provider/anthropic/provider_test.go internal/provider/ssecompat/processor_test.go
+git commit -m "[BEHAVIORAL] Emit typed ErrStreamError from SSE scanner failures in anthropic and ssecompat providers"
+```
+
+---
+
+### Task 2: Cache token telemetry in StreamEvent
+
+**Problem:** `StreamEvent` carries `InputTokens`/`OutputTokens` but drops `cache_creation_input_tokens` and `cache_read_input_tokens` that Anthropic sends in `message_start`. These two fields are the only way to measure cache hit rate and cost savings — without them the system is flying blind on its most important cost lever.
+
+**Files:**
+- Modify: `pkg/agentsdk/types.go`
+- Modify: `internal/provider/anthropic/provider.go:177-199`
+- Modify: `internal/provider/anthropic/provider_test.go`
+
+- [ ] **Step 1: Write failing test for cache token decoding**
+
+```go
+// In anthropic/provider_test.go — TestHandleMessageStart_CacheTokens
+func TestHandleMessageStart_CacheTokens(t *testing.T) {
+    p := New("http://localhost", "test-key")
+    data := `{"message":{"id":"msg_01","model":"claude-sonnet-4-5","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":2000,"cache_read_input_tokens":48000}}}`
+    
+    evt := p.handleMessageStart(data)
+    require.NotNil(t, evt)
+    assert.Equal(t, "message_start", evt.Type)
+    assert.Equal(t, 2000, evt.CacheCreationTokens)
+    assert.Equal(t, 48000, evt.CacheReadTokens)
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+go test ./internal/provider/anthropic/... -run TestHandleMessageStart_CacheTokens -v
+```
+Expected: compile error — `evt.CacheCreationTokens` undefined.
+
+- [ ] **Step 3: Add fields to `StreamEvent` in `pkg/agentsdk/types.go`**
+
+```go
+// StreamEvent represents a single event in a streaming response.
+type StreamEvent struct {
+    Type                string
+    Text                string
+    ToolUse             *ToolUseBlock
+    Error               error
+    InputTokens         int
+    OutputTokens        int
+    CacheCreationTokens int // tokens written to cache (billed at higher rate)
+    CacheReadTokens     int // tokens read from cache (billed at lower rate)
+    StopReason          string // populated on stop event: "end_turn", "max_tokens", "tool_use", etc.
+    Model               string // populated on message_start
+    MessageID           string // populated on message_start
+}
+```
+
+- [ ] **Step 4: Update `handleMessageStart` to decode cache token fields**
+
+In `anthropic/provider.go`, update the parse struct and the returned event:
+```go
+func (p *Provider) handleMessageStart(data string) *provider.StreamEvent {
+    var parsed struct {
+        Message struct {
+            ID    string `json:"id"`
+            Model string `json:"model"`
+            Usage struct {
+                InputTokens              int `json:"input_tokens"`
+                OutputTokens             int `json:"output_tokens"`
+                CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+                CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+            } `json:"usage"`
+        } `json:"message"`
+    }
+
+    if err := json.NewDecoder(strings.NewReader(data)).Decode(&parsed); err != nil {
+        return &provider.StreamEvent{Type: agentsdk.EventError, Error: fmt.Errorf("parsing message_start: %w", err)}
+    }
+
+    return &provider.StreamEvent{
+        Type:                "message_start",
+        Model:               parsed.Message.Model,
+        MessageID:           parsed.Message.ID,
+        InputTokens:         parsed.Message.Usage.InputTokens,
+        OutputTokens:        parsed.Message.Usage.OutputTokens,
+        CacheCreationTokens: parsed.Message.Usage.CacheCreationInputTokens,
+        CacheReadTokens:     parsed.Message.Usage.CacheReadInputTokens,
+    }
+}
+```
+
+- [ ] **Step 5: Run test to confirm green**
+
+```bash
+go test ./internal/provider/anthropic/... -run TestHandleMessageStart_CacheTokens -v
+```
+Expected: `PASS`.
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+go test ./... 2>&1 | tail -20
+```
+Expected: all `PASS`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/agentsdk/types.go internal/provider/anthropic/provider.go internal/provider/anthropic/provider_test.go
+git commit -m "[BEHAVIORAL] Add CacheCreationTokens, CacheReadTokens, StopReason to StreamEvent; decode cache fields from Anthropic message_start"
+```
+
+---
+
+### Task 7: `x-client-request-id` correlation header
+
+**Problem:** When the Anthropic API times out or drops a connection, `ProviderError` carries no request correlation ID. The API team cannot correlate client timeouts with server-side logs without a client-generated ID that was sent in the request.
+
+**Files:**
+- Modify: `internal/provider/provider_error.go`
+- Modify: `internal/provider/anthropic/provider.go`
+- Modify: `internal/provider/anthropic/provider_test.go`
+
+Note: `github.com/google/uuid` — check if already in `go.mod`. If not, run `go get github.com/google/uuid` and commit the `go.mod`/`go.sum` update as a separate structural commit first.
+
+- [ ] **Step 1: Check if uuid is already available**
+
+```bash
+grep uuid /Users/julianshen/prj/rubichan/go.mod
+```
+If not present: `go get github.com/google/uuid` and commit `go.mod`/`go.sum` with `[STRUCTURAL] Add github.com/google/uuid dependency`.
+
+- [ ] **Step 2: Write failing test**
+
+```go
+// TestStream_SetsRequestIDHeader
+func TestStream_SetsRequestIDHeader(t *testing.T) {
+    var capturedHeader string
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        capturedHeader = r.Header.Get("x-client-request-id")
+        w.Header().Set("Content-Type", "text/event-stream")
+        fmt.Fprintln(w, "event: message_stop\ndata: {}\n")
+    }))
+    defer srv.Close()
+
+    p := New(srv.URL, "test-key")
+    req := provider.CompletionRequest{Model: "claude-sonnet-4-5", MaxTokens: 100,
+        Messages: []provider.Message{{Role: "user", Content: []provider.ContentBlock{{Type: "text", Text: "hi"}}}}}
+    ch, err := p.Stream(context.Background(), req)
+    require.NoError(t, err)
+    for range ch {} // drain
+
+    assert.NotEmpty(t, capturedHeader, "x-client-request-id header must be set")
+    _, uuidErr := uuid.Parse(capturedHeader)
+    assert.NoError(t, uuidErr, "x-client-request-id must be a valid UUID")
+}
+```
+
+- [ ] **Step 3: Run to confirm failure**
+
+```bash
+go test ./internal/provider/anthropic/... -run TestStream_SetsRequestIDHeader -v
+```
+Expected: `FAIL` — `capturedHeader` is empty.
+
+- [ ] **Step 4: Add `RequestID` to `ProviderError`**
+
+In `internal/provider/provider_error.go`, add to the `ProviderError` struct:
+```go
+// RequestID is the client-generated UUID sent as x-client-request-id.
+// Present on stream errors so the API team can correlate server-side logs.
+RequestID string
+```
+
+- [ ] **Step 5: Update `Stream()` in `anthropic/provider.go`**
+
+```go
+import "github.com/google/uuid"
+
+func (p *Provider) Stream(ctx context.Context, req provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
+    body, err := p.transformer.ToProviderJSON(req)
+    if err != nil {
+        return nil, fmt.Errorf("building request body: %w", err)
+    }
+
+    httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/v1/messages", bytes.NewReader(body))
+    if err != nil {
+        return nil, fmt.Errorf("creating request: %w", err)
+    }
+
+    requestID := uuid.New().String()
+    httpReq.Header.Set("Content-Type", "application/json")
+    httpReq.Header.Set("x-api-key", p.apiKey)
+    httpReq.Header.Set("anthropic-version", "2023-06-01")
+    httpReq.Header.Set("x-client-request-id", requestID) // add this line
+
+    // ... rest unchanged, but update ClassifyAPIErrorWithResponse call:
+    return nil, provider.ClassifyAPIErrorWithResponse(resp.StatusCode, respBody, httpReq, "anthropic", resp.Header)
+    // Note: if ClassifyAPIErrorWithResponse returns a *ProviderError, set .RequestID = requestID on it
+```
+
+Update the error classification call site to attach the request ID:
+```go
+if resp.StatusCode != http.StatusOK {
+    defer resp.Body.Close()
+    respBody, _ := io.ReadAll(resp.Body)
+    provider.LogResponse(p.debugLogger, resp.StatusCode, resp.Header, respBody)
+    pe := provider.ClassifyAPIErrorWithResponse(resp.StatusCode, respBody, httpReq, "anthropic", resp.Header)
+    if provErr, ok := pe.(*provider.ProviderError); ok {
+        provErr.RequestID = requestID
+    }
+    return nil, pe
+}
+```
+
+Also thread `requestID` into `processStream` so stall errors can carry it:
+```go
+go p.processStream(ctx, resp.Body, ch, requestID)
+```
+
+Update `processStream` signature:
+```go
+func (p *Provider) processStream(ctx context.Context, body io.ReadCloser, ch chan<- provider.StreamEvent, requestID string) {
+```
+
+In the scanner error block, include `RequestID`:
+```go
+streamErr := &provider.ProviderError{
+    Kind:      provider.ErrStreamError,
+    Provider:  "anthropic",
+    Message:   err.Error(),
+    Retryable: true,
+    RequestID: requestID,
+}
+```
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+go test ./internal/provider/... -v 2>&1 | tail -20
+```
+Expected: all `PASS`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/provider/provider_error.go internal/provider/anthropic/provider.go internal/provider/anthropic/provider_test.go
+git commit -m "[BEHAVIORAL] Add x-client-request-id request header and RequestID field to ProviderError for timeout correlation"
+```
+
+---
+
+### Task 8: Orphan repair on session load
+
+**Problem:** `loadSessionHistory` (agent.go:796) loads messages from the persistence store but never calls `synthesizeMissingToolResults`. If a previous session died mid-stream after emitting `tool_use` blocks but before executing them, the next session resumes with an invalid conversation (orphaned tool_use blocks with no matching tool_result), causing a 400 API error on the first turn.
+
+**Files:**
+- Modify: `internal/agent/agent.go:817`
+- Modify: `internal/agent/orphan_test.go` (or create if absent)
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// TestLoadSessionHistory_SynthesizesOrphans
+// Verify that loading a session with an orphaned tool_use block
+// auto-seals it so the first API call does not fail with 400.
+func TestLoadSessionHistory_SynthesizesOrphans(t *testing.T) {
+    store := newInMemoryStore() // use the test helper already in agent_test.go
+    sessionID := "sess-orphan"
+
+    // Persist an assistant message with a tool_use that was never answered.
+    store.SaveMessage(sessionID, store_pkg.Message{
+        Role: "assistant",
+        Content: []provider.ContentBlock{
+            {Type: "text", Text: "I will call a tool"},
+            {Type: "tool_use", ID: "tool_001", Name: "read_file", Input: json.RawMessage(`{"path":"/tmp/f"}`)},
+        },
+    })
+
+    conv := NewConversation("system prompt")
+    // loadSessionHistory is unexported; test via ResumeSession or expose for testing.
+    // Use the exported ResumeSession path that calls loadSessionHistory internally.
+    sess := session.Session{ID: sessionID, SystemPrompt: "system prompt"}
+    // Inject store into agent, call Resume.
+    a := newTestAgent(t, store)
+    err := a.ResumeSession(sess)
+    require.NoError(t, err)
+
+    msgs := a.conversation.Messages()
+    // The last message must be a user message containing a tool_result for tool_001.
+    last := msgs[len(msgs)-1]
+    require.Equal(t, "user", last.Role)
+    require.Len(t, last.Content, 1)
+    assert.Equal(t, "tool_result", last.Content[0].Type)
+    assert.Equal(t, "tool_001", last.Content[0].ToolUseID)
+    assert.True(t, last.Content[0].IsError)
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+go test ./internal/agent/... -run TestLoadSessionHistory_SynthesizesOrphans -v
+```
+Expected: `FAIL` — no tool_result is synthesized; the last message is still the assistant message.
+
+- [ ] **Step 3: Add orphan repair in `loadSessionHistory`**
+
+In `agent.go`, update both load paths to call `synthesizeMissingToolResults` after loading:
+
+```go
+func (a *Agent) loadSessionHistory(conv *Conversation, sessionID string) error {
+    snapMsgs, snapErr := a.store.GetSnapshot(sessionID)
+    if snapErr == nil && snapMsgs != nil {
+        conv.LoadFromMessages(snapMsgs)
+        synthesizeMissingToolResults(conv, "loaded from snapshot")
+        return nil
+    }
+    if snapErr != nil {
+        log.Printf("warning: snapshot load failed for session %s, falling back to full history: %v", sessionID, snapErr)
+    }
+
+    msgs, err := a.store.GetMessages(sessionID)
+    if err != nil {
+        return fmt.Errorf("load messages: %w", err)
+    }
+    providerMsgs := make([]provider.Message, len(msgs))
+    for i, m := range msgs {
+        providerMsgs[i] = provider.Message{
+            Role:    m.Role,
+            Content: m.Content,
+        }
+    }
+    conv.LoadFromMessages(providerMsgs)
+    synthesizeMissingToolResults(conv, "loaded from message history")
+    return nil
+}
+```
+
+Also add `orphanReasonLoad` constant in `orphan.go`:
+```go
+const orphanReasonLoad = "loaded from persisted session"
+```
+
+Use `orphanReasonLoad` in the two new call sites above.
+
+- [ ] **Step 4: Run test to confirm green**
+
+```bash
+go test ./internal/agent/... -run TestLoadSessionHistory_SynthesizesOrphans -v
+```
+Expected: `PASS`.
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+go test ./... 2>&1 | tail -20
+```
+Expected: all `PASS`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/agent/agent.go internal/agent/orphan.go internal/agent/orphan_test.go
+git commit -m "[BEHAVIORAL] Repair orphaned tool_use blocks when loading session history to prevent 400 errors on resume"
+```
+
+---
+
+### Task 11: Small-model config for summarization
+
+**Problem:** `LLMSummarizer` uses the agent's main provider and model (e.g. `claude-opus-4-6`) for conversation compaction — an expensive internal operation that does not need reasoning capability. Claude Code routes these through a lighter "Haiku path." Rubichan needs a config field to specify a cheaper model for summarization/compaction.
+
+**Files:**
+- Modify: `internal/config/config.go:201-208`
+- Modify: `internal/agent/agent.go` (New() function, where LLMSummarizer is constructed)
+- Modify: `internal/config/config_test.go`
+
+- [ ] **Step 1: Write failing test for config loading**
+
+```go
+// TestProviderConfig_SummaryModel
+func TestProviderConfig_SummaryModel(t *testing.T) {
+    tomlStr := `
+[provider]
+default = "anthropic"
+model = "claude-opus-4-6"
+summary_model = "claude-haiku-4-5-20251001"
+`
+    cfg, err := config.LoadFromBytes([]byte(tomlStr))
+    require.NoError(t, err)
+    assert.Equal(t, "claude-haiku-4-5-20251001", cfg.Provider.SummaryModel)
+}
+```
+
+Note: `LoadFromBytes` may need to be added as a test helper if not present; alternatively use `Load` with a temp file.
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+go test ./internal/config/... -run TestProviderConfig_SummaryModel -v
+```
+Expected: compile error or `SummaryModel` is empty string.
+
+- [ ] **Step 3: Add `SummaryModel` to `ProviderConfig`**
+
+In `internal/config/config.go`, update `ProviderConfig`:
+```go
+type ProviderConfig struct {
+    Default      string                   `toml:"default"`
+    Model        string                   `toml:"model"`
+    SummaryModel string                   `toml:"summary_model"` // model for summarization/compaction (optional; falls back to Model)
+    Anthropic    AnthropicProviderConfig  `toml:"anthropic"`
+    OpenAI       []OpenAICompatibleConfig `toml:"openai_compatible"`
+    Ollama       OllamaProviderConfig     `toml:"ollama"`
+    Zai          ZaiProviderConfig        `toml:"zai"`
+}
+```
+
+- [ ] **Step 4: Wire `SummaryModel` into summarizer construction**
+
+In `agent.go`, find where `NewLLMSummarizer` is called (search for `NewLLMSummarizer`). Update the call to use `cfg.Provider.SummaryModel` with fallback:
+
+```go
+summaryModel := cfg.Provider.SummaryModel
+if summaryModel == "" {
+    summaryModel = cfg.Provider.Model
+}
+summarizer := NewLLMSummarizer(mainProvider, summaryModel)
+```
+
+- [ ] **Step 5: Run test to confirm green**
+
+```bash
+go test ./internal/config/... -run TestProviderConfig_SummaryModel -v
+```
+Expected: `PASS`.
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+go test ./... 2>&1 | tail -20
+```
+Expected: all `PASS`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/config/config.go internal/agent/agent.go internal/config/config_test.go
+git commit -m "[BEHAVIORAL] Add summary_model config field to route summarization/compaction to a lighter model"
+```
+
+---
+
+## Group B — Streaming Resilience Chain (Tasks 3 → 4 → 9 → 10)
+
+These tasks must be done in order: the watchdog (Task 3) enables typed stall errors that the turn retry (Task 4) can catch; `stop_reason` detection (Task 9) needs the retry infrastructure from Task 4; the non-streaming fallback (Task 10) extends the retry logic from Task 4.
+
+---
+
+### Task 3: Stream idle watchdog
+
+**Problem:** `bufio.Scanner.Scan()` blocks indefinitely if the TCP connection goes idle. `ResponseHeaderTimeout: 30s` only covers the initial headers — once HTTP 200 arrives, streaming can stall forever. Production environments with corporate proxies, NAT timeouts, or overloaded API servers hit this regularly.
+
+**Design:** A goroutine-based watchdog that runs the scanner in a goroutine and uses `select` with two timers: a warn timer (45s from last chunk) and a kill timer (90s from last chunk). Both timers reset on every received chunk. On kill, close the body to unblock the scanner goroutine.
+
+**Files:**
+- Create: `internal/provider/streamwatchdog.go`
+- Create: `internal/provider/streamwatchdog_test.go`
+- Modify: `internal/provider/anthropic/provider.go` (use `watchedStream`)
+- Modify: `internal/provider/ssecompat/processor.go` (use `watchedStream`)
+
+- [ ] **Step 1: Write failing test for stall detection**
+
+Create `internal/provider/streamwatchdog_test.go`:
+```go
+package provider_test
+
+import (
+    "context"
+    "io"
+    "testing"
+    "time"
+
+    "github.com/julianshen/rubichan/internal/provider"
+    "github.com/julianshen/rubichan/pkg/agentsdk"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestWatchdogKillsStaleStream(t *testing.T) {
+    // A pipe that sends one line then hangs forever.
+    pr, pw := io.Pipe()
+    go func() {
+        pw.Write([]byte("event: message_stop\ndata: {}\n\n"))
+        // Hang — never write more, never close.
+        time.Sleep(10 * time.Second)
+        pw.Close()
+    }()
+
+    cfg := provider.WatchdogConfig{
+        WarnAfter: 50 * time.Millisecond,
+        KillAfter: 100 * time.Millisecond,
+    }
+
+    rawCh := make(chan string, 8)
+    var warnFired bool
+    onWarn := func() { warnFired = true }
+
+    outCh := provider.WatchedChannel(context.Background(), rawCh, cfg, onWarn)
+
+    // Feed one item then stop feeding.
+    rawCh <- "line1"
+
+    // Drain until we get a stall error.
+    var lastErr error
+    for evt := range outCh {
+        lastErr = evt.StallError
+        if lastErr != nil {
+            break
+        }
+    }
+
+    require.NotNil(t, lastErr)
+    var pe *provider.ProviderError
+    require.ErrorAs(t, lastErr, &pe)
+    assert.Equal(t, provider.ErrStreamError, pe.Kind)
+    assert.True(t, pe.Retryable)
+    assert.True(t, warnFired)
+}
+```
+
+Note: The above tests a channel-based watchdog. The actual implementation is a function `WatchedChannel` that wraps an input `chan string` (the raw SSE scanner loop) with watchdog timers. Alternatively, design as a body-wrapping function if that fits better (see Step 3 for chosen design).
+
+- [ ] **Step 2: Run to confirm compile failure**
+
+```bash
+go test ./internal/provider/... -run TestWatchdogKillsStaleStream -v
+```
+Expected: `cannot use provider.WatchedChannel` — function does not exist.
+
+- [ ] **Step 3: Implement `internal/provider/streamwatchdog.go`**
+
+```go
+package provider
+
+import (
+    "context"
+    "io"
+    "time"
+)
+
+// WatchdogConfig configures the stream idle watchdog timers.
+type WatchdogConfig struct {
+    // WarnAfter is the idle duration before the onWarn callback fires.
+    // Defaults to 45 seconds if zero.
+    WarnAfter time.Duration
+    // KillAfter is the idle duration before the stream is aborted.
+    // Defaults to 90 seconds if zero.
+    KillAfter time.Duration
+}
+
+func (c WatchdogConfig) warnAfter() time.Duration {
+    if c.WarnAfter <= 0 {
+        return 45 * time.Second
+    }
+    return c.WarnAfter
+}
+
+func (c WatchdogConfig) killAfter() time.Duration {
+    if c.KillAfter <= 0 {
+        return 90 * time.Second
+    }
+    return c.KillAfter
+}
+
+// WatchBody wraps body with an idle watchdog. If no bytes arrive for
+// KillAfter, it closes body (unblocking any goroutine blocked on Read)
+// and invokes onKill. If no bytes arrive for WarnAfter, onWarn is called.
+// Both callbacks reset when bytes arrive.
+//
+// The returned io.ReadCloser must be used in place of body. Closing the
+// returned reader cancels the watchdog.
+func WatchBody(body io.ReadCloser, cfg WatchdogConfig, onWarn func(), onKill func()) io.ReadCloser {
+    pr, pw := io.Pipe()
+    warnTimer := time.NewTimer(cfg.warnAfter())
+    killTimer := time.NewTimer(cfg.killAfter())
+
+    go func() {
+        defer pw.Close()
+        defer warnTimer.Stop()
+        defer killTimer.Stop()
+
+        buf := make([]byte, 4096)
+        for {
+            n, err := body.Read(buf)
+            if n > 0 {
+                // Reset timers on activity.
+                if !warnTimer.Stop() {
+                    select {
+                    case <-warnTimer.C:
+                    default:
+                    }
+                }
+                if !killTimer.Stop() {
+                    select {
+                    case <-killTimer.C:
+                    default:
+                    }
+                }
+                warnTimer.Reset(cfg.warnAfter())
+                killTimer.Reset(cfg.killAfter())
+
+                if _, werr := pw.Write(buf[:n]); werr != nil {
+                    body.Close()
+                    return
+                }
+            }
+            if err != nil {
+                if err != io.EOF {
+                    pw.CloseWithError(err)
+                }
+                body.Close()
+                return
+            }
+
+            // Non-blocking check for timer fires after receiving data.
+            select {
+            case <-warnTimer.C:
+                if onWarn != nil {
+                    onWarn()
+                }
+                warnTimer.Reset(cfg.killAfter() - cfg.warnAfter())
+            case <-killTimer.C:
+                if onKill != nil {
+                    onKill()
+                }
+                body.Close()
+                pw.CloseWithError(&ProviderError{
+                    Kind:      ErrStreamError,
+                    Message:   "stream stalled: no data received for " + cfg.killAfter().String(),
+                    Retryable: true,
+                })
+                return
+            default:
+            }
+        }
+    }()
+
+    // Concurrently watch timers (handle the stall when Read is blocked).
+    go func() {
+        select {
+        case <-warnTimer.C:
+            if onWarn != nil {
+                onWarn()
+            }
+        }
+        select {
+        case <-killTimer.C:
+            if onKill != nil {
+                onKill()
+            }
+            body.Close()
+            pw.CloseWithError(&ProviderError{
+                Kind:      ErrStreamError,
+                Message:   "stream stalled: no data received for " + cfg.killAfter().String(),
+                Retryable: true,
+            })
+        }
+    }()
+
+    return pr
+}
+```
+
+Note: The above is a starting-point sketch. The tricky part is that `body.Read()` blocks, so the watchdog goroutine must be separate from the reader goroutine. The design is: one goroutine does `io.Copy`-style reading from `body` into the pipe, and a second goroutine fires the kill timer and closes `body`, which unblocks the first goroutine's `Read` with an error. Adjust the implementation to ensure exactly-once closure and no goroutine leaks. The test uses short timers (50ms/100ms) to make it fast.
+
+**Implementation guidance for the two-goroutine pattern:**
+
+```go
+func WatchBody(body io.ReadCloser, cfg WatchdogConfig, onWarn, onKill func()) io.ReadCloser {
+    pr, pw := io.Pipe()
+    done := make(chan struct{})
+
+    // Goroutine 1: timer watchdog
+    go func() {
+        warn := time.NewTimer(cfg.warnAfter())
+        kill := time.NewTimer(cfg.killAfter())
+        defer warn.Stop()
+        defer kill.Stop()
+        for {
+            select {
+            case <-done:
+                return
+            case <-warn.C:
+                if onWarn != nil { onWarn() }
+            case <-kill.C:
+                if onKill != nil { onKill() }
+                body.Close() // unblocks Read in goroutine 2
+                pw.CloseWithError(&ProviderError{
+                    Kind: ErrStreamError, Message: "stream stalled", Retryable: true,
+                })
+                return
+            }
+        }
+    }()
+
+    // Goroutine 2: pump bytes from body to pw, resetting timers on activity
+    // (timers are reset by closing and re-sending on the done channel — 
+    // simpler: use an activity channel)
+    go func() {
+        defer close(done)
+        defer body.Close()
+        buf := make([]byte, 32*1024)
+        for {
+            n, err := body.Read(buf)
+            if n > 0 {
+                // signal activity — restart watchdog via channel
+                // ... (see note below)
+                pw.Write(buf[:n])
+            }
+            if err != nil {
+                if err != io.EOF { pw.CloseWithError(err) } else { pw.Close() }
+                return
+            }
+        }
+    }()
+
+    return pr
+}
+```
+
+The cleanest pattern for resettable timers: send on an `activity chan struct{}` from goroutine 2, and goroutine 1 resets both timers on each receive. This avoids the race in `timer.Stop()+timer.Reset()`.
+
+- [ ] **Step 4: Wire `WatchBody` into `anthropic/provider.go`**
+
+In `processStream`, wrap `body` before creating the scanner:
+
+```go
+func (p *Provider) processStream(ctx context.Context, body io.ReadCloser, ch chan<- provider.StreamEvent, requestID string) {
+    defer close(ch)
+
+    onWarn := func() {
+        if p.debugLogger != nil {
+            p.debugLogger("[DEBUG] anthropic: stream idle for 45s (request %s), still waiting", requestID)
+        }
+    }
+
+    watched := provider.WatchBody(body, provider.WatchdogConfig{}, onWarn, nil)
+    defer watched.Close()
+
+    state := newStreamState()
+    scanner := newSSEScanner(watched) // pass watched instead of body
+    // ... rest of processStream unchanged
+```
+
+- [ ] **Step 5: Wire `WatchBody` into `ssecompat/processor.go`**
+
+Apply the same pattern at the top of the SSE processing goroutine in `ProcessSSE`.
+
+- [ ] **Step 6: Run watchdog test**
+
+```bash
+go test ./internal/provider/... -run TestWatchdogKills -v -timeout 10s
+```
+Expected: `PASS` within ~200ms.
+
+- [ ] **Step 7: Run all tests**
+
+```bash
+go test ./... -timeout 120s 2>&1 | tail -20
+```
+Expected: all `PASS`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/provider/streamwatchdog.go internal/provider/streamwatchdog_test.go \
+        internal/provider/anthropic/provider.go internal/provider/ssecompat/processor.go
+git commit -m "[BEHAVIORAL] Add stream idle watchdog (45s warn / 90s kill) to prevent indefinite stall on dead TCP connections"
+```
+
+---
+
+### Task 4: Turn-level retry wrapper
+
+**Problem:** `DoWithRetry` in `internal/provider/retry.go` only retries the HTTP POST — if the stream delivers HTTP 200 then dies, there is no retry. The agent loop at `agent.go:1289` calls `provider.Stream()`, and on any error it emits an error turn event and exits. There is no turn-level retry for transient stream failures or rate limits that surface mid-stream.
+
+**Files:**
+- Create: `internal/agent/turnretry.go`
+- Create: `internal/agent/turnretry_test.go`
+- Modify: `internal/agent/agent.go` (wire in the new wrapper around the stream+consume block)
+
+- [ ] **Step 1: Write failing test for turn retry**
+
+Create `internal/agent/turnretry_test.go`:
+```go
+package agent
+
+import (
+    "context"
+    "errors"
+    "testing"
+    "time"
+
+    "github.com/julianshen/rubichan/internal/provider"
+    "github.com/julianshen/rubichan/pkg/agentsdk"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestTurnRetry_RetriesOnStreamError(t *testing.T) {
+    attempts := 0
+    streamFn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+        attempts++
+        if attempts < 3 {
+            return nil, &provider.ProviderError{
+                Kind:      provider.ErrStreamError,
+                Message:   "transient failure",
+                Retryable: true,
+            }
+        }
+        ch := make(chan provider.StreamEvent, 2)
+        ch <- provider.StreamEvent{Type: agentsdk.EventStop}
+        close(ch)
+        return ch, nil
+    }
+
+    cfg := TurnRetryConfig{MaxAttempts: 3, BaseDelay: time.Millisecond, MaxDelay: 10 * time.Millisecond}
+    result, err := TurnRetry(context.Background(), cfg, streamFn)
+    require.NoError(t, err)
+    assert.Equal(t, 3, attempts)
+    assert.NotNil(t, result)
+}
+
+func TestTurnRetry_DoesNotRetryNonRetryable(t *testing.T) {
+    attempts := 0
+    streamFn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+        attempts++
+        return nil, &provider.ProviderError{
+            Kind:    provider.ErrAuthFailed,
+            Message: "invalid api key",
+        }
+    }
+
+    cfg := TurnRetryConfig{MaxAttempts: 3, BaseDelay: time.Millisecond}
+    _, err := TurnRetry(context.Background(), cfg, streamFn)
+    require.Error(t, err)
+    assert.Equal(t, 1, attempts, "must not retry non-retryable errors")
+}
+
+func TestTurnRetry_DoesNotRetryWhenToolsInflight(t *testing.T) {
+    attempts := 0
+    ch := make(chan provider.StreamEvent, 4)
+    ch <- provider.StreamEvent{Type: agentsdk.EventToolUse, ToolUse: &provider.ToolUseBlock{ID: "t1", Name: "foo"}}
+    ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: &provider.ProviderError{Kind: provider.ErrStreamError, Retryable: true}}
+    close(ch)
+
+    streamFn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+        attempts++
+        return ch, nil
+    }
+
+    cfg := TurnRetryConfig{MaxAttempts: 3, BaseDelay: time.Millisecond}
+    _, err := TurnRetry(context.Background(), cfg, streamFn)
+    require.Error(t, err)
+    assert.Equal(t, 1, attempts, "must not retry when tools are in flight")
+}
+```
+
+- [ ] **Step 2: Run to confirm compile failure**
+
+```bash
+go test ./internal/agent/... -run TestTurnRetry -v
+```
+Expected: `cannot find package` or undefined `TurnRetry`.
+
+- [ ] **Step 3: Implement `internal/agent/turnretry.go`**
+
+```go
+package agent
+
+import (
+    "context"
+    "time"
+
+    "github.com/julianshen/rubichan/internal/provider"
+    "github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// TurnRetryConfig configures turn-level retry behavior.
+type TurnRetryConfig struct {
+    // MaxAttempts is the maximum number of total attempts (including the first).
+    // Defaults to 3 if zero.
+    MaxAttempts int
+    // BaseDelay is the initial backoff delay before the second attempt.
+    BaseDelay time.Duration
+    // MaxDelay caps the exponential backoff.
+    MaxDelay time.Duration
+}
+
+func (c TurnRetryConfig) maxAttempts() int {
+    if c.MaxAttempts <= 0 {
+        return 3
+    }
+    return c.MaxAttempts
+}
+
+func (c TurnRetryConfig) baseDelay() time.Duration {
+    if c.BaseDelay <= 0 {
+        return 2 * time.Second
+    }
+    return c.BaseDelay
+}
+
+func (c TurnRetryConfig) maxDelay() time.Duration {
+    if c.MaxDelay <= 0 {
+        return 30 * time.Second
+    }
+    return c.MaxDelay
+}
+
+// TurnRetryResult carries the stream channel from the successful attempt
+// and a record of which events were already consumed before success.
+type TurnRetryResult struct {
+    // Ch is the open channel from the successful attempt.
+    Ch <-chan provider.StreamEvent
+    // Attempt is the 1-based attempt number that succeeded.
+    Attempt int
+}
+
+// streamFunc is the function type that TurnRetry calls per attempt.
+// It must return a fresh channel each call.
+type streamFunc func(ctx context.Context) (<-chan provider.StreamEvent, error)
+
+// TurnRetry calls fn up to cfg.MaxAttempts times. It retries if and only if:
+//  1. The error (from fn or from an error event on the channel) is retryable, AND
+//  2. No tool_use event has been received on the channel yet (tools-in-flight guard).
+//
+// Returns the open channel from the successful attempt, or the last error.
+func TurnRetry(ctx context.Context, cfg TurnRetryConfig, fn streamFunc) (*TurnRetryResult, error) {
+    delay := cfg.baseDelay()
+    var lastErr error
+
+    for attempt := 1; attempt <= cfg.maxAttempts(); attempt++ {
+        if attempt > 1 {
+            select {
+            case <-ctx.Done():
+                return nil, ctx.Err()
+            case <-time.After(delay):
+            }
+            delay *= 2
+            if delay > cfg.maxDelay() {
+                delay = cfg.maxDelay()
+            }
+        }
+
+        ch, err := fn(ctx)
+        if err != nil {
+            lastErr = err
+            if !isRetryableError(err) || attempt == cfg.maxAttempts() {
+                return nil, lastErr
+            }
+            continue
+        }
+
+        // Scan the channel for errors or tool_use events.
+        // If we see a retryable error before any tool_use, we can retry.
+        // If we see a tool_use first, we cannot retry (tools are in flight).
+        result, retryable, scanErr := scanForRetry(ctx, ch)
+        if scanErr == nil {
+            // Stream completed cleanly — return whatever result we got.
+            return &TurnRetryResult{Ch: result, Attempt: attempt}, nil
+        }
+        lastErr = scanErr
+        if !retryable || attempt == cfg.maxAttempts() {
+            return nil, lastErr
+        }
+    }
+    return nil, lastErr
+}
+
+// scanForRetry reads from ch. Returns:
+//   - (bufferedCh, nil, nil) on clean completion
+//   - (nil, true, err) on retryable error before any tool_use
+//   - (nil, false, err) on non-retryable error, or error after tool_use
+func scanForRetry(ctx context.Context, ch <-chan provider.StreamEvent) (<-chan provider.StreamEvent, bool, error) {
+    var buffered []provider.StreamEvent
+    toolSeen := false
+
+    for {
+        select {
+        case <-ctx.Done():
+            return nil, false, ctx.Err()
+        case evt, ok := <-ch:
+            if !ok {
+                // Channel closed cleanly. Return a closed channel of buffered events.
+                out := make(chan provider.StreamEvent, len(buffered)+1)
+                for _, e := range buffered {
+                    out <- e
+                }
+                close(out)
+                return out, false, nil
+            }
+            if evt.Type == agentsdk.EventToolUse {
+                toolSeen = true
+            }
+            if evt.Type == agentsdk.EventError && evt.Error != nil {
+                return nil, !toolSeen && isRetryableError(evt.Error), evt.Error
+            }
+            buffered = append(buffered, evt)
+        }
+    }
+}
+
+func isRetryableError(err error) bool {
+    var pe *provider.ProviderError
+    if errors.As(err, &pe) {
+        return pe.IsRetryable()
+    }
+    return false
+}
+```
+
+- [ ] **Step 4: Run tests to confirm green**
+
+```bash
+go test ./internal/agent/... -run TestTurnRetry -v
+```
+Expected: all `PASS`.
+
+- [ ] **Step 5: Wire `TurnRetry` into `agent.go`**
+
+Find the `provider.Stream()` call (around line 1289). Wrap it:
+
+```go
+retryCfg := TurnRetryConfig{} // uses defaults: 3 attempts, 2s base delay
+retryResult, streamErr := TurnRetry(ctx, retryCfg, func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+    return a.provider.Stream(ctx, req)
+})
+if streamErr != nil {
+    // existing error handling path
+    ...
+}
+streamCh := retryResult.Ch
+// Replace: `stream, err := a.provider.Stream(ctx, req)` → use `streamCh` below
+```
+
+Note: The stream-consuming loop below the call site must use `streamCh` instead of the original `stream` variable. The agent emits a `TurnEvent{Type: "retrying", ...}` on retry attempts (add this to `scanForRetry` via an optional callback parameter if needed, or wire a channel for retry events).
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+go test ./... 2>&1 | tail -20
+```
+Expected: all `PASS`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/agent/turnretry.go internal/agent/turnretry_test.go internal/agent/agent.go
+git commit -m "[BEHAVIORAL] Add turn-level retry wrapper with tools-in-flight guard for transient stream failures"
+```
+
+---
+
+### Task 9: `stop_reason: max_tokens` detection and retry
+
+**Problem:** When the model hits the output token cap mid-response, it emits `stop_reason: "max_tokens"`. Currently the `StreamEvent` has no `StopReason` field (added in Task 2) and `convertSSEEvent` ignores `message_delta` events, making the cap invisible. The agent should detect this and retry the turn with a higher cap.
+
+**Depends on:** Task 2 (StopReason field), Task 4 (TurnRetry infrastructure).
+
+**Files:**
+- Modify: `internal/provider/anthropic/provider.go:160-175` (handle `message_delta`)
+- Modify: `internal/agent/agent.go` (detect `stop_reason: "max_tokens"`)
+- Modify: `internal/provider/anthropic/provider_test.go`
+
+- [ ] **Step 1: Write failing test for `message_delta` handling**
+
+```go
+func TestConvertSSEEvent_MessageDelta_StopReason(t *testing.T) {
+    p := New("http://localhost", "test-key")
+    state := newStreamState()
+    data := `{"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":8192}}`
+    evt, _ := p.convertSSEEvent(state, sseEvent{Event: "message_delta", Data: data})
+
+    require.NotNil(t, evt)
+    assert.Equal(t, agentsdk.EventStop, evt.Type)
+    assert.Equal(t, "max_tokens", evt.StopReason)
+    assert.Equal(t, 8192, evt.OutputTokens)
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+go test ./internal/provider/anthropic/... -run TestConvertSSEEvent_MessageDelta -v
+```
+Expected: `FAIL` — `message_delta` returns `nil`.
+
+- [ ] **Step 3: Handle `message_delta` in `convertSSEEvent`**
+
+Add a case to the switch in `convertSSEEvent`:
+```go
+case "message_delta":
+    return p.handleMessageDelta(evt.Data), nil
+```
+
+Implement `handleMessageDelta`:
+```go
+func (p *Provider) handleMessageDelta(data string) *provider.StreamEvent {
+    var parsed struct {
+        Delta struct {
+            StopReason string `json:"stop_reason"`
+        } `json:"delta"`
+        Usage struct {
+            OutputTokens int `json:"output_tokens"`
+        } `json:"usage"`
+    }
+    if err := json.NewDecoder(strings.NewReader(data)).Decode(&parsed); err != nil {
+        if p.debugLogger != nil {
+            p.debugLogger("[DEBUG] anthropic: parsing message_delta: %v", err)
+        }
+        return nil
+    }
+    if parsed.Delta.StopReason == "" {
+        return nil
+    }
+    return &provider.StreamEvent{
+        Type:         agentsdk.EventStop,
+        StopReason:   parsed.Delta.StopReason,
+        OutputTokens: parsed.Usage.OutputTokens,
+    }
+}
+```
+
+Note: `provider.StreamEvent` now has `StopReason string` from Task 2. If Task 2 was not done first, add it now.
+
+- [ ] **Step 4: Detect `max_tokens` in the agent loop**
+
+In `agent.go`, where the stream is consumed, track the stop reason:
+
+```go
+var stopReason string
+for evt := range streamCh {
+    switch evt.Type {
+    case agentsdk.EventStop:
+        stopReason = evt.StopReason
+    // ... existing cases
+    }
+}
+
+// After the stream loop, if truncated and no tools dispatched:
+if stopReason == "max_tokens" && len(dispatchedToolIDs) == 0 {
+    // Retry with a wider cap. The turn retry infrastructure handles the
+    // actual retry; here we update the request's MaxTokens before the
+    // next attempt.
+    // Wire this into TurnRetry by returning a special sentinel error
+    // that the retry wrapper recognizes as "retry with wider cap".
+    // Simplest approach: a WidenedCapError type.
+}
+```
+
+Simplest implementation: after `stop_reason == "max_tokens"`, treat it as a retryable `ErrStreamError` for the turn retry and update the `CompletionRequest.MaxTokens` to `16384` in the retry `fn` closure.
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+go test ./... 2>&1 | tail -20
+```
+Expected: all `PASS`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/provider/anthropic/provider.go internal/provider/anthropic/provider_test.go internal/agent/agent.go
+git commit -m "[BEHAVIORAL] Handle message_delta stop_reason; retry turn with wider token cap on max_tokens truncation"
+```
+
+---
+
+### Task 10: Non-streaming fallback
+
+**Problem:** Some corporate proxies return HTTP 200 with a non-SSE body (full JSON), or truncate the SSE stream mid-response. When streaming fails, a synchronous `messages.create()` call (non-streaming) is the correct fallback — it produces the complete response in one JSON payload and avoids the proxy entirely.
+
+**Depends on:** Task 4 (TurnRetry — the fallback is triggered as a retry attempt with streaming disabled).
+
+**Files:**
+- Create: `internal/provider/anthropic/nonstream.go`
+- Create: `internal/provider/anthropic/nonstream_test.go`
+- Modify: `internal/provider/provider.go` (add `NonStream` to the interface, or as optional interface)
+- Modify: `internal/agent/turnretry.go` (add non-stream path as last resort)
+
+- [ ] **Step 1: Write failing test for non-stream response**
+
+Create `internal/provider/anthropic/nonstream_test.go`:
+```go
+func TestNonStream_ReturnsCompleteResponse(t *testing.T) {
+    responseJSON := `{
+        "id": "msg_01",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5",
+        "content": [{"type": "text", "text": "Hello!"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5}
+    }`
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // Verify stream=false was sent.
+        var body map[string]interface{}
+        json.NewDecoder(r.Body).Decode(&body)
+        assert.Equal(t, false, body["stream"])
+        w.Header().Set("Content-Type", "application/json")
+        w.Write([]byte(responseJSON))
+    }))
+    defer srv.Close()
+
+    p := New(srv.URL, "test-key")
+    req := provider.CompletionRequest{
+        Model:     "claude-sonnet-4-5",
+        MaxTokens: 100,
+        Messages:  []provider.Message{{Role: "user", Content: []provider.ContentBlock{{Type: "text", Text: "hi"}}}},
+    }
+    events, err := p.NonStream(context.Background(), req)
+    require.NoError(t, err)
+
+    // Should produce: message_start, text_delta, content_block_stop (or similar), stop
+    var texts []string
+    for _, e := range events {
+        if e.Type == "text_delta" {
+            texts = append(texts, e.Text)
+        }
+    }
+    assert.Equal(t, []string{"Hello!"}, texts)
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+go test ./internal/provider/anthropic/... -run TestNonStream -v
+```
+Expected: undefined `p.NonStream`.
+
+- [ ] **Step 3: Implement `internal/provider/anthropic/nonstream.go`**
+
+```go
+package anthropic
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/http"
+    "strings"
+
+    "github.com/julianshen/rubichan/internal/provider"
+    "github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// NonStream sends req with stream=false and converts the full JSON response
+// into a slice of StreamEvents equivalent to what streaming would have produced.
+// Used as a fallback when streaming fails due to proxy issues.
+func (p *Provider) NonStream(ctx context.Context, req provider.CompletionRequest) ([]provider.StreamEvent, error) {
+    body, err := p.transformer.ToProviderJSON(req)
+    if err != nil {
+        return nil, fmt.Errorf("building request body: %w", err)
+    }
+
+    // Inject stream:false. The transformer sets stream:true by default.
+    var raw map[string]json.RawMessage
+    if err := json.Unmarshal(body, &raw); err != nil {
+        return nil, fmt.Errorf("patching stream flag: %w", err)
+    }
+    raw["stream"] = json.RawMessage(`false`)
+    body, err = json.Marshal(raw)
+    if err != nil {
+        return nil, fmt.Errorf("re-marshaling request: %w", err)
+    }
+
+    httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/v1/messages", bytes.NewReader(body))
+    if err != nil {
+        return nil, fmt.Errorf("creating request: %w", err)
+    }
+    httpReq.Header.Set("Content-Type", "application/json")
+    httpReq.Header.Set("x-api-key", p.apiKey)
+    httpReq.Header.Set("anthropic-version", "2023-06-01")
+
+    resp, err := p.client.Do(httpReq)
+    if err != nil {
+        return nil, fmt.Errorf("sending request: %w", err)
+    }
+    defer resp.Body.Close()
+
+    respBody, err := io.ReadAll(resp.Body)
+    if err != nil {
+        return nil, fmt.Errorf("reading response: %w", err)
+    }
+
+    if resp.StatusCode != http.StatusOK {
+        return nil, provider.ClassifyAPIErrorWithResponse(resp.StatusCode, respBody, httpReq, "anthropic", resp.Header)
+    }
+
+    return parseNonStreamResponse(respBody)
+}
+
+// parseNonStreamResponse converts a full Anthropic message JSON response
+// into a StreamEvent slice that mirrors what processStream would have emitted.
+func parseNonStreamResponse(data []byte) ([]provider.StreamEvent, error) {
+    var msg struct {
+        ID         string `json:"id"`
+        Model      string `json:"model"`
+        StopReason string `json:"stop_reason"`
+        Content    []struct {
+            Type  string          `json:"type"`
+            Text  string          `json:"text"`
+            ID    string          `json:"id"`
+            Name  string          `json:"name"`
+            Input json.RawMessage `json:"input"`
+        } `json:"content"`
+        Usage struct {
+            InputTokens              int `json:"input_tokens"`
+            OutputTokens             int `json:"output_tokens"`
+            CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+            CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+        } `json:"usage"`
+    }
+    if err := json.Unmarshal(data, &msg); err != nil {
+        return nil, fmt.Errorf("parsing non-stream response: %w", err)
+    }
+
+    var events []provider.StreamEvent
+    events = append(events, provider.StreamEvent{
+        Type:                "message_start",
+        MessageID:           msg.ID,
+        Model:               msg.Model,
+        InputTokens:         msg.Usage.InputTokens,
+        OutputTokens:        msg.Usage.OutputTokens,
+        CacheCreationTokens: msg.Usage.CacheCreationInputTokens,
+        CacheReadTokens:     msg.Usage.CacheReadInputTokens,
+    })
+
+    for _, block := range msg.Content {
+        switch block.Type {
+        case "text":
+            if block.Text != "" {
+                events = append(events, provider.StreamEvent{Type: "text_delta", Text: block.Text})
+            }
+        case "tool_use":
+            input := block.Input
+            if len(input) == 0 {
+                input = json.RawMessage(`{}`)
+            }
+            events = append(events, provider.StreamEvent{
+                Type: agentsdk.EventToolUse,
+                ToolUse: &provider.ToolUseBlock{
+                    ID:    block.ID,
+                    Name:  block.Name,
+                    Input: input,
+                },
+            })
+            events = append(events, provider.StreamEvent{Type: agentsdk.EventContentBlockStop})
+        }
+    }
+
+    events = append(events, provider.StreamEvent{
+        Type:       agentsdk.EventStop,
+        StopReason: msg.StopReason,
+    })
+    return events, nil
+}
+```
+
+- [ ] **Step 4: Add `NonStreamProvider` optional interface**
+
+In `internal/provider/provider.go` (or a new file), add:
+```go
+// NonStreamProvider is an optional interface for providers that support
+// synchronous (non-streaming) completion as a fallback.
+type NonStreamProvider interface {
+    LLMProvider
+    NonStream(ctx context.Context, req CompletionRequest) ([]StreamEvent, error)
+}
+```
+
+- [ ] **Step 5: Use non-stream as final fallback in turn retry**
+
+In `turnretry.go`, after exhausting streaming retries, try non-stream once:
+```go
+// In TurnRetry, before the final error return:
+if nsp, ok := provider.(provider.NonStreamProvider); ok {
+    events, err := nsp.NonStream(ctx, req)
+    if err == nil {
+        ch := make(chan provider.StreamEvent, len(events))
+        for _, e := range events {
+            ch <- e
+        }
+        close(ch)
+        return &TurnRetryResult{Ch: ch, Attempt: attempt}, nil
+    }
+}
+```
+
+Note: `TurnRetry` currently takes a `streamFunc`. To pass the provider and request for the non-stream path, either add them to `TurnRetryConfig` or pass them as separate parameters. The cleanest approach: add an optional `FallbackProvider provider.NonStreamProvider` and `FallbackReq provider.CompletionRequest` to `TurnRetryConfig`. If set, try non-stream once after all streaming attempts fail.
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+go test ./... 2>&1 | tail -20
+```
+Expected: all `PASS`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/provider/anthropic/nonstream.go internal/provider/anthropic/nonstream_test.go \
+        internal/provider/provider.go internal/agent/turnretry.go
+git commit -m "[BEHAVIORAL] Add non-streaming fallback path for proxy environments that corrupt SSE streams"
+```
+
+---
+
+## Group C — Cache Architecture (Tasks 5 → 6)
+
+Task 6 (session latches) enforces the invariant that Task 5's loud API makes visible. Do them in order.
+
+---
+
+### Task 5: Loud PromptBuilder API
+
+**Problem:** `PromptBuilder.AddSection(PromptSection{Cacheable: true})` is easy to misuse. A developer adding a runtime-conditional section can silently set `Cacheable: true` and fragment the global cache (the 2^N problem from Chapter 4). The API should make the safe path easy and the dangerous path loud.
+
+**Design:** Replace the generic `AddSection(PromptSection)` with two typed methods: `AddCacheableSection(name, content string)` (safe, no branching allowed) and `AddDynamicSection_UNCACHED(name, content, reason string)` (loud, requires documented justification). The `_UNCACHED` suffix and the required `reason` parameter create both naming friction and mandatory documentation.
+
+**Files:**
+- Modify: `internal/agent/prompt.go`
+- Modify: `internal/agent/prompt_test.go`
+- Modify: `internal/agent/agent.go` (all `AddSection` call sites)
+
+- [ ] **Step 1: Survey all `AddSection` call sites**
+
+```bash
+grep -n "AddSection\|PromptSection" internal/agent/agent.go internal/agent/prompt.go
+```
+Note the line numbers — you will update each call site in Step 5.
+
+- [ ] **Step 2: Write tests for new API**
+
+In `internal/agent/prompt_test.go`, add:
+```go
+func TestPromptBuilder_TypedAPI_CacheableFirst(t *testing.T) {
+    pb := NewPromptBuilder()
+    pb.AddDynamicSection_UNCACHED("user context", "session: abc123", "contains session-specific data")
+    pb.AddCacheableSection("instructions", "You are a helpful assistant.")
+    pb.AddCacheableSection("tools", "Available tools: ...")
+
+    prompt, breakpoints := pb.Build()
+
+    // Cacheable sections must come before dynamic sections.
+    instrIdx := strings.Index(prompt, "You are a helpful assistant")
+    sessionIdx := strings.Index(prompt, "session: abc123")
+    assert.True(t, instrIdx < sessionIdx, "cacheable content must precede dynamic content")
+
+    // Exactly one breakpoint, placed after the cacheable sections.
+    require.Len(t, breakpoints, 1)
+    assert.True(t, breakpoints[0] < sessionIdx)
+}
+
+func TestPromptBuilder_CacheStability(t *testing.T) {
+    // The byte offset of the cache breakpoint must not change between calls
+    // when only the dynamic section changes — this is the invariant that
+    // prevents cache busting.
+    makePB := func(sessionData string) *PromptBuilder {
+        pb := NewPromptBuilder()
+        pb.AddCacheableSection("system", "static instructions")
+        pb.AddDynamicSection_UNCACHED("session", sessionData, "per-session data")
+        return pb
+    }
+
+    _, bp1 := makePB("session: aaa").Build()
+    _, bp2 := makePB("session: bbb bbb bbb").Build()
+
+    require.Len(t, bp1, 1)
+    require.Len(t, bp2, 1)
+    assert.Equal(t, bp1[0], bp2[0], "breakpoint byte offset must be stable across dynamic content changes")
+}
+```
+
+- [ ] **Step 3: Run tests to confirm failure**
+
+```bash
+go test ./internal/agent/... -run TestPromptBuilder_TypedAPI -v
+```
+Expected: undefined `AddCacheableSection` / `AddDynamicSection_UNCACHED`.
+
+- [ ] **Step 4: Update `prompt.go` with new typed API**
+
+```go
+// AddCacheableSection appends a section that is identical across sessions
+// and users. Cacheable sections are placed before dynamic sections at Build time.
+// IMPORTANT: do not call this with runtime-conditional content — each unique
+// value doubles the number of global cache entries (the 2^N problem).
+func (pb *PromptBuilder) AddCacheableSection(name, content string) {
+    pb.sections = append(pb.sections, PromptSection{Name: name, Content: content, Cacheable: true})
+}
+
+// AddDynamicSection_UNCACHED appends a section that varies per session or user.
+// Dynamic sections are placed after the cache boundary, so they do not
+// fragment the global prompt cache.
+//
+// reason must document WHY this section cannot be cached — it appears in
+// code review and serves as mandatory documentation for the cache-breaking decision.
+// Example reasons: "contains session ID", "user-specific tool list", "runtime feature flag".
+func (pb *PromptBuilder) AddDynamicSection_UNCACHED(name, content, reason string) {
+    _ = reason // required for documentation; not used at runtime
+    pb.sections = append(pb.sections, PromptSection{Name: name, Content: content, Cacheable: false})
+}
+
+// AddSection appends a section. Deprecated: use AddCacheableSection or
+// AddDynamicSection_UNCACHED to make caching intent explicit.
+// Kept for backward compatibility during migration.
+func (pb *PromptBuilder) AddSection(s PromptSection) {
+    pb.sections = append(pb.sections, s)
+}
+```
+
+- [ ] **Step 5: Update all `AddSection` call sites in `agent.go`**
+
+Run the grep from Step 1. For each call site, replace with the appropriate typed method:
+- Static content (tool descriptions, base instructions, persona): `AddCacheableSection`
+- Session-specific content (session ID, user context, dynamic tool list): `AddDynamicSection_UNCACHED(name, content, "reason here")`
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+go test ./internal/agent/... -v 2>&1 | tail -20
+```
+Expected: all `PASS`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/agent/prompt.go internal/agent/agent.go internal/agent/prompt_test.go
+git commit -m "[BEHAVIORAL] Add typed PromptBuilder API (AddCacheableSection / AddDynamicSection_UNCACHED) to enforce cache boundary documentation"
+```
+
+---
+
+### Task 6: Session latches for capability stability
+
+**Problem:** The agent reads `a.capabilities` directly each turn (set once at construction via `WithCapabilities`). If capabilities could ever change mid-session (e.g. from a config reload or future dynamic detection), the resulting change in tool hint inclusion or reasoning effort would silently change the system prompt's dynamic section on a turn boundary, busting the session cache and costing ~50-70K tokens of reprocessing.
+
+**Design:** A `sessionLatches` struct with one-way ratchet methods. Once a latch is set to `true` (or to a non-empty string), it stays that way for the session. This ensures the cache key for the dynamic prompt section is stable even if the underlying capability detection changes.
+
+**Files:**
+- Create: `internal/agent/sessionlatches.go`
+- Create: `internal/agent/sessionlatches_test.go`
+- Modify: `internal/agent/agent.go`
+
+- [ ] **Step 1: Write failing test for latch behavior**
+
+Create `internal/agent/sessionlatches_test.go`:
+```go
+package agent
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestSessionLatches_BoolRatchet(t *testing.T) {
+    l := newSessionLatches()
+
+    // Initially false — latch off.
+    assert.False(t, l.latchToolHint(false))
+
+    // Flip to true — latches on.
+    assert.True(t, l.latchToolHint(true))
+
+    // Cannot be unlatched — subsequent false is ignored.
+    assert.True(t, l.latchToolHint(false))
+    assert.True(t, l.latchToolHint(false))
+}
+
+func TestSessionLatches_StringRatchet(t *testing.T) {
+    l := newSessionLatches()
+
+    // Empty string — not latched.
+    assert.Equal(t, "", l.latchReasoningEffort(""))
+
+    // Set to "high" — latches.
+    assert.Equal(t, "high", l.latchReasoningEffort("high"))
+
+    // Cannot change to "low" once latched.
+    assert.Equal(t, "high", l.latchReasoningEffort("low"))
+    assert.Equal(t, "high", l.latchReasoningEffort(""))
+}
+
+func TestSessionLatches_ConcurrentAccess(t *testing.T) {
+    l := newSessionLatches()
+    done := make(chan struct{})
+    for i := 0; i < 100; i++ {
+        go func() {
+            l.latchToolHint(i%2 == 0)
+            done <- struct{}{}
+        }()
+    }
+    for i := 0; i < 100; i++ {
+        <-done
+    }
+    // No race — test passes if -race does not fire.
+}
+```
+
+- [ ] **Step 2: Run to confirm compile failure**
+
+```bash
+go test ./internal/agent/... -run TestSessionLatches -v -race
+```
+Expected: undefined `newSessionLatches`.
+
+- [ ] **Step 3: Implement `internal/agent/sessionlatches.go`**
+
+```go
+package agent
+
+import "sync"
+
+// sessionLatches holds per-session boolean and string latches that follow
+// a one-way ratchet pattern: once a latch is set, it cannot be unset for
+// the lifetime of the session. This prevents mid-session capability changes
+// from altering the system prompt's dynamic section, which would bust the
+// session prompt cache.
+//
+// See: Chapter 4 — "Sticky Latches in Action" for the design rationale.
+type sessionLatches struct {
+    mu sync.Mutex
+
+    // toolHintEnabled is true if the tool discovery hint section has ever
+    // been included in the system prompt for this session.
+    toolHintEnabled bool
+    toolHintSet     bool
+
+    // reasoningEffort is the reasoning effort level ("low", "medium", "high")
+    // that was first used in this session. Empty means not yet set.
+    reasoningEffort string
+}
+
+func newSessionLatches() *sessionLatches {
+    return &sessionLatches{}
+}
+
+// latchToolHint returns the effective value for the tool hint inclusion flag.
+// Once set to true, it stays true regardless of subsequent calls.
+func (l *sessionLatches) latchToolHint(want bool) bool {
+    l.mu.Lock()
+    defer l.mu.Unlock()
+    if !l.toolHintSet {
+        l.toolHintSet = true
+        l.toolHintEnabled = want
+    } else if want {
+        l.toolHintEnabled = true // one-way ratchet: can only flip to true
+    }
+    return l.toolHintEnabled
+}
+
+// latchReasoningEffort returns the effective reasoning effort for this session.
+// Once set to a non-empty string, it stays at that value regardless of subsequent calls.
+func (l *sessionLatches) latchReasoningEffort(want string) string {
+    l.mu.Lock()
+    defer l.mu.Unlock()
+    if l.reasoningEffort == "" && want != "" {
+        l.reasoningEffort = want
+    }
+    return l.reasoningEffort
+}
+```
+
+- [ ] **Step 4: Add `sessionLatches` to `Agent` struct and wire into prompt construction**
+
+In `agent.go`, add to the `Agent` struct:
+```go
+latches *sessionLatches
+```
+
+In `New()` (or wherever the agent is constructed), initialize:
+```go
+a.latches = newSessionLatches()
+```
+
+In the turn loop, where `NeedsToolDiscoveryHint` and `ReasoningEffort` are read from `a.capabilities`, replace with latch reads:
+
+```go
+// Before (direct capability read):
+if a.capabilities.NeedsToolDiscoveryHint { ... }
+reasoningEffort := a.capabilities.ReasoningEffort
+
+// After (latch-stabilized):
+includeToolHint := a.latches.latchToolHint(a.capabilities.NeedsToolDiscoveryHint)
+if includeToolHint { ... }
+reasoningEffort := a.latches.latchReasoningEffort(a.capabilities.ReasoningEffort)
+```
+
+- [ ] **Step 5: Run all tests with race detector**
+
+```bash
+go test ./internal/agent/... -race 2>&1 | tail -20
+```
+Expected: all `PASS`, no races reported.
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+go test ./... 2>&1 | tail -20
+```
+Expected: all `PASS`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/agent/sessionlatches.go internal/agent/sessionlatches_test.go internal/agent/agent.go
+git commit -m "[BEHAVIORAL] Add sessionLatches one-way ratchet to prevent mid-session capability changes from busting prompt cache"
+```
+
+---
+
+## Self-Review
+
+### 1. Spec coverage (11 items vs plan tasks)
+
+| Gap | Task | Status |
+|-----|------|--------|
+| ErrStreamError never emitted | Task 1 | ✓ |
+| Cache token telemetry missing | Task 2 | ✓ |
+| No stream idle watchdog | Task 3 | ✓ |
+| No turn-level retry | Task 4 | ✓ |
+| No loud PromptBuilder naming | Task 5 | ✓ |
+| No session latches | Task 6 | ✓ |
+| No x-client-request-id | Task 7 | ✓ |
+| Orphan repair missing on load | Task 8 | ✓ |
+| stop_reason max_tokens invisible | Task 9 | ✓ |
+| No non-streaming fallback | Task 10 | ✓ |
+| No small-model config | Task 11 | ✓ |
+
+### 2. Placeholder scan
+
+- All code steps contain complete, runnable code.
+- All test steps contain complete test function bodies.
+- All commands include expected output.
+- No "TBD", "TODO", or "similar to Task N" references.
+
+### 3. Type consistency
+
+- `provider.StreamEvent.CacheCreationTokens` / `CacheReadTokens` / `StopReason` — added in Task 2, used in Tasks 3, 9, 10. ✓
+- `provider.ProviderError.RequestID` — added in Task 7, used in Task 7 only. ✓
+- `provider.WatchdogConfig` / `WatchBody` — defined in Task 3, used in anthropic and ssecompat. ✓
+- `TurnRetryConfig` / `TurnRetry` / `TurnRetryResult` — defined in Task 4, extended in Tasks 9 and 10. ✓
+- `AddCacheableSection` / `AddDynamicSection_UNCACHED` — defined in Task 5, call sites updated in same task. ✓
+- `sessionLatches` / `latchToolHint` / `latchReasoningEffort` — defined in Task 6, used in same task. ✓
+- `orphanReasonLoad` — added in Task 8's orphan.go change. ✓
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-13-api-layer-improvements.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -347,6 +347,7 @@ type Agent struct {
 	acpServer         *acp.Server             // ACP server instance (if enabled)
 	acpRegistry       *acp.CapabilityRegistry // Capability registry for ACP
 	useACP            bool                    // Enable ACP server
+	latches           *sessionLatches         // one-way ratchets for session-stable capability values
 }
 
 const maxUIRequestInputBytes = 2048
@@ -368,6 +369,7 @@ func New(p provider.LLMProvider, t *tools.Registry, approve ApprovalFunc, cfg *c
 		scratchpad:   NewScratchpad(),
 		progress:     NewProgressTracker(),
 		capabilities: agentsdk.DefaultCapabilities(),
+		latches:      newSessionLatches(),
 	}
 	for _, opt := range opts {
 		opt(a)
@@ -1220,7 +1222,11 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		}
 
 		// Append tool discovery hint for models that benefit from explicit guidance.
-		if a.capabilities.NeedsToolDiscoveryHint {
+		// The latch freezes this decision at the first turn so a mid-session
+		// capability change cannot alter the system prompt's dynamic section,
+		// which would invalidate the provider's session prompt cache.
+		needsToolHint := a.latches.latchToolHint(a.capabilities.NeedsToolDiscoveryHint)
+		if needsToolHint {
 			toolHint := a.deferral.ToolSummary(activeTools)
 			systemPrompt = systemPrompt + "\n\n" + toolHint
 		}
@@ -1256,6 +1262,10 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			MaxTokens:        4096,
 			CacheBreakpoints: cacheBreakpoints,
 		}
+		// Latch ReasoningEffort so a mid-session capability change cannot
+		// alter the value passed to the provider. The latch is set on the
+		// first non-empty value; empty means "use provider default."
+		req.Capabilities.ReasoningEffort = a.latches.latchReasoningEffort(a.capabilities.ReasoningEffort)
 
 		if a.rateLimiter != nil {
 			if !a.rateLimiter.AllowNow() {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1080,22 +1080,14 @@ func (a *Agent) buildSystemPromptWithFragments(ctx context.Context, lastUserMess
 			pb.AddSection(section)
 		}
 	} else {
-		pb.AddSection(PromptSection{
-			Name:      "",
-			Content:   baseSystemPrompt,
-			Cacheable: true,
-		})
+		pb.AddCacheableSection("", baseSystemPrompt)
 	}
 
 	// Scratchpad — dynamic, changes as user adds notes.
 	if a.scratchpad != nil {
 		rendered := a.scratchpad.Render()
 		if rendered != "" {
-			pb.AddSection(PromptSection{
-				Name:      "Scratchpad",
-				Content:   rendered,
-				Cacheable: false,
-			})
+			pb.AddDynamicSection_UNCACHED("Scratchpad", rendered, "user-editable notes change across turns")
 		}
 	}
 
@@ -1103,11 +1095,7 @@ func (a *Agent) buildSystemPromptWithFragments(ctx context.Context, lastUserMess
 	if a.progress != nil {
 		rendered := a.progress.Render()
 		if rendered != "" {
-			pb.AddSection(PromptSection{
-				Name:      "Progress",
-				Content:   rendered,
-				Cacheable: false,
-			})
+			pb.AddDynamicSection_UNCACHED("Progress", rendered, "accumulates tool results at runtime and changes each turn")
 		}
 	}
 
@@ -1118,11 +1106,7 @@ func (a *Agent) buildSystemPromptWithFragments(ctx context.Context, lastUserMess
 		if err == nil && len(entities) > 0 {
 			knowledge := renderKnowledgeSection(entities)
 			if knowledge != "" {
-				pb.AddSection(PromptSection{
-					Name:      "Project Knowledge",
-					Content:   knowledge,
-					Cacheable: false,
-				})
+				pb.AddDynamicSection_UNCACHED("Project Knowledge", knowledge, "selected per-query from knowledge graph based on user message content")
 			}
 			// Record that these entities were selected and injected into the prompt.
 			// Errors are silently discarded to ensure metrics recording never blocks prompt building.
@@ -1133,11 +1117,7 @@ func (a *Agent) buildSystemPromptWithFragments(ctx context.Context, lastUserMess
 	// Skill prompt fragments — use budgeted selection to respect context budget.
 	if a.skillRuntime != nil {
 		for _, f := range builtFragments {
-			pb.AddSection(PromptSection{
-				Name:      f.SkillName,
-				Content:   f.Prompt,
-				Cacheable: false,
-			})
+			pb.AddDynamicSection_UNCACHED(f.SkillName, f.Prompt, "skill-injected prompt varies by active skill set and runtime context")
 		}
 	}
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1427,7 +1427,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		}
 
 		// Warn if the model hit the output token cap so operators know to raise MaxOutputTokens.
-		if stopReason == "max_tokens" {
+		if stopReason == agentsdk.StopReasonMaxTokens {
 			a.logger.Warn("response truncated by output token limit (consider increasing max_output_tokens in config)")
 		}
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1288,7 +1288,16 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			}
 		}
 
-		stream, err := a.provider.Stream(ctx, req)
+		retryCfg := TurnRetryConfig{} // use defaults: 3 attempts, 2s base delay, 30s max delay
+		onRetry := func(attempt int, delay time.Duration, cause error) {
+			a.emit(ctx, ch, TurnEvent{
+				Type:  "retrying",
+				Error: fmt.Errorf("attempt %d after %s: %w", attempt, delay, cause),
+			})
+		}
+		stream, err := TurnRetry(ctx, retryCfg, func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+			return a.provider.Stream(ctx, req)
+		}, onRetry)
 		if err != nil {
 			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream: %w", err)})
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError))

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -797,6 +797,7 @@ func (a *Agent) loadSessionHistory(conv *Conversation, sessionID string) error {
 	snapMsgs, snapErr := a.store.GetSnapshot(sessionID)
 	if snapErr == nil && snapMsgs != nil {
 		conv.LoadFromMessages(snapMsgs)
+		synthesizeMissingToolResults(conv, orphanReasonLoad)
 		return nil
 	}
 	if snapErr != nil {
@@ -815,6 +816,7 @@ func (a *Agent) loadSessionHistory(conv *Conversation, sessionID string) error {
 		}
 	}
 	conv.LoadFromMessages(providerMsgs)
+	synthesizeMissingToolResults(conv, orphanReasonLoad)
 	return nil
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1312,6 +1312,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		var currentTool *provider.ToolUseBlock
 		var toolInputBuf string
 		var thinkingBuf string
+		var stopReason string
 
 		// Streaming dispatch: concurrency-safe tools run in the
 		// background as their tool_use blocks finalize during the stream,
@@ -1428,8 +1429,16 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 				a.emit(ctx, ch, TurnEvent{Type: "error", Error: event.Error})
 
 			case "stop":
-				// Will be handled after the loop
+				// Capture stop reason for post-loop detection (e.g. max_tokens truncation).
+				if event.StopReason != "" {
+					stopReason = event.StopReason
+				}
 			}
+		}
+
+		// Warn if the model hit the output token cap so operators know to raise MaxOutputTokens.
+		if stopReason == "max_tokens" {
+			a.logger.Warn("response truncated by output token limit (consider increasing max_output_tokens in config)")
 		}
 
 		// Capture accumulated text before finalizing, for text-based tool extraction.

--- a/internal/agent/orphan.go
+++ b/internal/agent/orphan.go
@@ -10,6 +10,7 @@ const (
 	orphanReasonStreamError = "stream error"
 	orphanReasonToolCancel  = "cancelled during tool execution"
 	orphanReasonPanic       = "agent panic"
+	orphanReasonLoad        = "loaded from persisted session"
 )
 
 // emptyModelResponseText is the placeholder inserted when the model

--- a/internal/agent/orphan_test.go
+++ b/internal/agent/orphan_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/store"
 	"github.com/julianshen/rubichan/internal/tools"
 	"github.com/julianshen/rubichan/pkg/agentsdk"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSynthesizeMissingToolResultsFillsOrphans(t *testing.T) {
@@ -217,5 +219,67 @@ func TestRunLoopToolCancelLeavesNoOrphans(t *testing.T) {
 		if !answered[id] {
 			t.Fatalf("orphan tool_use %q has no matching tool_result; sweeper not wired", id)
 		}
+	}
+}
+
+// TestLoadSessionHistory_SynthesizesOrphans verifies that loadSessionHistory
+// calls synthesizeMissingToolResults so that a persisted session whose last
+// assistant message contains unanswered tool_use blocks is repaired on resume.
+// Without the fix a subsequent API call would fail with a 400 protocol error.
+func TestLoadSessionHistory_SynthesizesOrphans(t *testing.T) {
+	t.Parallel()
+
+	s, err := store.NewStore(":memory:")
+	require.NoError(t, err)
+	defer s.Close()
+
+	const sessionID = "sess-orphan"
+	require.NoError(t, s.CreateSession(store.Session{
+		ID:           sessionID,
+		Model:        "gpt-4",
+		SystemPrompt: "You are helpful.",
+	}))
+
+	// Persist a user message followed by an assistant message whose
+	// tool_use block has no matching tool_result — simulating a session
+	// that died between emitting tool_use and executing the tool.
+	require.NoError(t, s.AppendMessage(sessionID, "user", []provider.ContentBlock{
+		{Type: "text", Text: "Run the tool please"},
+	}))
+	require.NoError(t, s.AppendMessage(sessionID, "assistant", []provider.ContentBlock{
+		{Type: "text", Text: "Sure, calling the tool now."},
+		{Type: "tool_use", ID: "orphan_call_1", Name: "read_file", Input: json.RawMessage(`{"path":"file.go"}`)},
+	}))
+
+	cfg := &config.Config{
+		Provider: config.ProviderConfig{Model: "gpt-4"},
+		Agent:    config.AgentConfig{MaxTurns: 5, ContextBudget: 100000},
+	}
+	mp := &mockProvider{events: []provider.StreamEvent{{Type: "stop"}}}
+
+	a := New(mp, tools.NewRegistry(), autoApprove, cfg, WithStore(s))
+
+	err = a.ResumeSession(context.Background(), sessionID)
+	require.NoError(t, err)
+
+	// After load, the orphaned tool_use must have been sealed with a
+	// synthetic error tool_result so the conversation is protocol-valid.
+	msgs := a.conversation.Messages()
+	var found bool
+	for _, m := range msgs {
+		for _, b := range m.Content {
+			if b.Type == "tool_result" && b.ToolUseID == "orphan_call_1" {
+				found = true
+				if !b.IsError {
+					t.Errorf("synthesized tool_result should have IsError=true")
+				}
+				if !strings.Contains(b.Text, orphanReasonLoad) {
+					t.Errorf("synthesized content missing load reason: %q", b.Text)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no tool_result found for orphan_call_1 after session load; orphan repair not wired into loadSessionHistory")
 	}
 }

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -25,6 +25,33 @@ func (pb *PromptBuilder) AddSection(s PromptSection) {
 	pb.sections = append(pb.sections, s)
 }
 
+// AddCacheableSection appends a section whose content is identical across
+// sessions, users, and organizations. Cacheable sections are placed before
+// the cache boundary at Build time so they can be served from the global
+// provider cache.
+//
+// IMPORTANT: do not call this with runtime-conditional content. Each unique
+// value fragments the global cache — three boolean conditionals create eight
+// variants, five create thirty-two. Use AddDynamicSection_UNCACHED for
+// anything that varies per session, user, or feature flag.
+func (pb *PromptBuilder) AddCacheableSection(name, content string) {
+	pb.sections = append(pb.sections, PromptSection{Name: name, Content: content, Cacheable: true})
+}
+
+// AddDynamicSection_UNCACHED appends a section whose content varies per
+// session, user, or runtime condition. Dynamic sections are placed after
+// the cache boundary so they do not fragment the global prompt cache.
+//
+// The reason parameter documents WHY this section cannot be cached. It is
+// not used at runtime — its purpose is mandatory documentation. Reviewers
+// see the reason in code review, and grep across the codebase surfaces
+// every cache-breaking decision. Example reasons: "contains session ID",
+// "runtime feature flag", "user-specific tool inventory".
+func (pb *PromptBuilder) AddDynamicSection_UNCACHED(name, content, reason string) {
+	_ = reason // documentation-only; unused at runtime by design
+	pb.sections = append(pb.sections, PromptSection{Name: name, Content: content, Cacheable: false})
+}
+
 // Build returns the assembled prompt string and cache breakpoint byte offsets.
 // Cacheable sections are placed first. A single breakpoint is inserted after
 // the last cacheable section (only if both cacheable and dynamic sections exist).

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -48,7 +48,6 @@ func (pb *PromptBuilder) AddCacheableSection(name, content string) {
 // every cache-breaking decision. Example reasons: "contains session ID",
 // "runtime feature flag", "user-specific tool inventory".
 func (pb *PromptBuilder) AddDynamicSection_UNCACHED(name, content, reason string) {
-	_ = reason // documentation-only; unused at runtime by design
 	pb.sections = append(pb.sections, PromptSection{Name: name, Content: content, Cacheable: false})
 }
 

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPromptBuilderEmptyBuild(t *testing.T) {
@@ -52,4 +53,44 @@ func TestPromptBuilderAllDynamicNoBreakpoint(t *testing.T) {
 
 	_, breakpoints := pb.Build()
 	assert.Empty(t, breakpoints, "no breakpoint when all sections dynamic")
+}
+
+func TestPromptBuilder_TypedAPI_CacheableFirst(t *testing.T) {
+	pb := NewPromptBuilder()
+	pb.AddDynamicSection_UNCACHED("user-ctx", "session: abc123", "contains session-specific data")
+	pb.AddCacheableSection("instructions", "You are a helpful assistant.")
+	pb.AddCacheableSection("tools", "Available tools: ...")
+
+	prompt, breakpoints := pb.Build()
+
+	instrIdx := strings.Index(prompt, "You are a helpful assistant")
+	toolsIdx := strings.Index(prompt, "Available tools")
+	sessionIdx := strings.Index(prompt, "session: abc123")
+
+	require.NotEqual(t, -1, instrIdx)
+	require.NotEqual(t, -1, toolsIdx)
+	require.NotEqual(t, -1, sessionIdx)
+	assert.True(t, instrIdx < sessionIdx, "cacheable content must precede dynamic content")
+	assert.True(t, toolsIdx < sessionIdx, "cacheable content must precede dynamic content")
+
+	require.Len(t, breakpoints, 1, "expect exactly one breakpoint between cacheable and dynamic")
+	assert.True(t, breakpoints[0] < sessionIdx)
+	assert.True(t, breakpoints[0] > toolsIdx)
+}
+
+func TestPromptBuilder_CacheStability(t *testing.T) {
+	// The breakpoint byte offset must be stable across dynamic content changes.
+	makePrompt := func(sessionData string) (string, []int) {
+		pb := NewPromptBuilder()
+		pb.AddCacheableSection("system", "static instructions")
+		pb.AddDynamicSection_UNCACHED("session", sessionData, "per-session data")
+		return pb.Build()
+	}
+
+	_, bp1 := makePrompt("session: aaa")
+	_, bp2 := makePrompt("session: bbb bbb bbb bbb bbb")
+
+	require.Len(t, bp1, 1)
+	require.Len(t, bp2, 1)
+	assert.Equal(t, bp1[0], bp2[0], "breakpoint byte offset must be stable across dynamic content changes")
 }

--- a/internal/agent/sessionlatches.go
+++ b/internal/agent/sessionlatches.go
@@ -7,9 +7,7 @@ import "sync"
 // value wins, subsequent calls return the stored value regardless of
 // what was passed. This prevents mid-session capability changes from
 // altering the system prompt's dynamic section, which would invalidate
-// the provider's session prompt cache.
-//
-// See: Chapter 4 — "The Sticky Latches in Action" for the design rationale.
+// ~50-70K tokens of the provider's session prompt cache.
 type sessionLatches struct {
 	mu sync.Mutex
 

--- a/internal/agent/sessionlatches.go
+++ b/internal/agent/sessionlatches.go
@@ -1,0 +1,54 @@
+package agent
+
+import "sync"
+
+// sessionLatches freezes capability values for the lifetime of an agent
+// session. Each latch follows a one-way ratchet: the first non-empty
+// value wins, subsequent calls return the stored value regardless of
+// what was passed. This prevents mid-session capability changes from
+// altering the system prompt's dynamic section, which would invalidate
+// the provider's session prompt cache.
+//
+// See: Chapter 4 — "The Sticky Latches in Action" for the design rationale.
+type sessionLatches struct {
+	mu sync.Mutex
+
+	// toolHintSet is true once latchToolHint has been called at least once.
+	// toolHintEnabled is the stored value.
+	toolHintSet     bool
+	toolHintEnabled bool
+
+	// reasoningEffort is empty until the first non-empty value is latched.
+	reasoningEffort string
+}
+
+// newSessionLatches returns a sessionLatches with all latches unset.
+func newSessionLatches() *sessionLatches {
+	return &sessionLatches{}
+}
+
+// latchToolHint records the tool-discovery-hint preference on the first
+// call and returns that value on all subsequent calls. The first call's
+// argument is the latched value.
+func (l *sessionLatches) latchToolHint(want bool) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.toolHintSet {
+		l.toolHintSet = true
+		l.toolHintEnabled = want
+	}
+	return l.toolHintEnabled
+}
+
+// latchReasoningEffort records the reasoning effort level on the first
+// non-empty call and returns that value on all subsequent calls. Empty
+// strings never latch — callers can pass "" to mean "use whatever is
+// already latched, or empty if nothing has been latched yet."
+func (l *sessionLatches) latchReasoningEffort(want string) string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.reasoningEffort == "" && want != "" {
+		l.reasoningEffort = want
+	}
+	return l.reasoningEffort
+}

--- a/internal/agent/sessionlatches_test.go
+++ b/internal/agent/sessionlatches_test.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSessionLatches_BoolRatchet_LatchesOnFirstCall(t *testing.T) {
+	l := newSessionLatches()
+
+	// First call with false latches false.
+	assert.False(t, l.latchToolHint(false))
+	// Subsequent calls — even with true — return the latched false.
+	assert.False(t, l.latchToolHint(true))
+	assert.False(t, l.latchToolHint(true))
+}
+
+func TestSessionLatches_BoolRatchet_TrueStaysTrue(t *testing.T) {
+	l := newSessionLatches()
+
+	// First call with true latches true.
+	assert.True(t, l.latchToolHint(true))
+	// Subsequent calls with false return true (ratchet cannot reverse).
+	assert.True(t, l.latchToolHint(false))
+	assert.True(t, l.latchToolHint(false))
+}
+
+func TestSessionLatches_StringRatchet_EmptyDoesNotLatch(t *testing.T) {
+	l := newSessionLatches()
+
+	// Empty call returns empty, nothing latched.
+	assert.Equal(t, "", l.latchReasoningEffort(""))
+
+	// First non-empty call latches.
+	assert.Equal(t, "high", l.latchReasoningEffort("high"))
+
+	// Subsequent calls — any value, empty or not — return the latched value.
+	assert.Equal(t, "high", l.latchReasoningEffort("low"))
+	assert.Equal(t, "high", l.latchReasoningEffort(""))
+	assert.Equal(t, "high", l.latchReasoningEffort("medium"))
+}
+
+func TestSessionLatches_ConcurrentAccess(t *testing.T) {
+	l := newSessionLatches()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			l.latchToolHint(n%2 == 0)
+			l.latchReasoningEffort("high")
+		}(i)
+	}
+	wg.Wait()
+	// After the race, the values are stable (whatever was latched first wins).
+	// We can't predict which, but repeated reads must return the same value.
+	first := l.latchToolHint(true)
+	assert.Equal(t, first, l.latchToolHint(false))
+	assert.Equal(t, "high", l.latchReasoningEffort(""))
+}

--- a/internal/agent/turnretry.go
+++ b/internal/agent/turnretry.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/julianshen/rubichan/internal/provider"
+)
+
+// TurnRetryConfig configures turn-level retry behavior.
+type TurnRetryConfig struct {
+	// MaxAttempts is the maximum number of total attempts (including the first).
+	// Defaults to 3 if zero.
+	MaxAttempts int
+	// BaseDelay is the initial backoff delay before the second attempt.
+	// Defaults to 2 seconds if zero.
+	BaseDelay time.Duration
+	// MaxDelay caps the exponential backoff. Defaults to 30 seconds if zero.
+	MaxDelay time.Duration
+}
+
+func (c TurnRetryConfig) maxAttempts() int {
+	if c.MaxAttempts <= 0 {
+		return 3
+	}
+	return c.MaxAttempts
+}
+
+func (c TurnRetryConfig) baseDelay() time.Duration {
+	if c.BaseDelay <= 0 {
+		return 2 * time.Second
+	}
+	return c.BaseDelay
+}
+
+func (c TurnRetryConfig) maxDelay() time.Duration {
+	if c.MaxDelay <= 0 {
+		return 30 * time.Second
+	}
+	return c.MaxDelay
+}
+
+// StreamFunc opens a new stream and returns its event channel.
+// TurnRetry calls this once per attempt.
+type StreamFunc func(ctx context.Context) (<-chan provider.StreamEvent, error)
+
+// OnRetry is called before each retry attempt (not before the first attempt).
+// Use it to emit telemetry events.
+type OnRetry func(attempt int, delay time.Duration, cause error)
+
+// TurnRetry calls fn up to cfg.MaxAttempts times. It retries only when fn
+// itself returns a *provider.ProviderError whose IsRetryable() returns true.
+// Mid-stream errors (errors emitted on the channel after fn returns) are NOT
+// retried — by the time they appear, the caller may already have consumed
+// partial events, so replay is unsafe.
+//
+// Returns the channel from the successful attempt, or the last error.
+func TurnRetry(ctx context.Context, cfg TurnRetryConfig, fn StreamFunc, onRetry OnRetry) (<-chan provider.StreamEvent, error) {
+	delay := cfg.baseDelay()
+	var lastErr error
+
+	for attempt := 1; attempt <= cfg.maxAttempts(); attempt++ {
+		if attempt > 1 {
+			if onRetry != nil {
+				onRetry(attempt, delay, lastErr)
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+			delay *= 2
+			if delay > cfg.maxDelay() {
+				delay = cfg.maxDelay()
+			}
+		}
+
+		ch, err := fn(ctx)
+		if err == nil {
+			return ch, nil
+		}
+		lastErr = err
+
+		if !isRetryableProviderError(err) || attempt == cfg.maxAttempts() {
+			return nil, lastErr
+		}
+	}
+	return nil, lastErr
+}
+
+func isRetryableProviderError(err error) bool {
+	var pe *provider.ProviderError
+	if errors.As(err, &pe) {
+		return pe.IsRetryable()
+	}
+	return false
+}

--- a/internal/agent/turnretry_test.go
+++ b/internal/agent/turnretry_test.go
@@ -1,0 +1,127 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTurnRetry_SucceedsFirstAttempt(t *testing.T) {
+	called := 0
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		called++
+		ch := make(chan provider.StreamEvent, 1)
+		ch <- provider.StreamEvent{Type: agentsdk.EventStop}
+		close(ch)
+		return ch, nil
+	}
+
+	ch, err := TurnRetry(context.Background(), TurnRetryConfig{BaseDelay: time.Millisecond}, fn, nil)
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+	assert.Equal(t, 1, called)
+}
+
+func TestTurnRetry_RetriesOnRetryableError(t *testing.T) {
+	var attempts int32
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 3 {
+			return nil, &provider.ProviderError{
+				Kind:    provider.ErrRateLimited,
+				Message: "slow down",
+			}
+		}
+		ch := make(chan provider.StreamEvent, 1)
+		ch <- provider.StreamEvent{Type: agentsdk.EventStop}
+		close(ch)
+		return ch, nil
+	}
+
+	cfg := TurnRetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   time.Millisecond,
+		MaxDelay:    10 * time.Millisecond,
+	}
+	var retryCalls []int
+	onRetry := func(attempt int, delay time.Duration, cause error) {
+		retryCalls = append(retryCalls, attempt)
+	}
+
+	ch, err := TurnRetry(context.Background(), cfg, fn, onRetry)
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+	assert.Equal(t, []int{2, 3}, retryCalls)
+}
+
+func TestTurnRetry_DoesNotRetryNonRetryable(t *testing.T) {
+	var attempts int32
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, &provider.ProviderError{
+			Kind:    provider.ErrAuthFailed,
+			Message: "bad api key",
+		}
+	}
+
+	_, err := TurnRetry(context.Background(), TurnRetryConfig{BaseDelay: time.Millisecond}, fn, nil)
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts))
+}
+
+func TestTurnRetry_DoesNotRetryPlainError(t *testing.T) {
+	var attempts int32
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, errors.New("network refused")
+	}
+
+	_, err := TurnRetry(context.Background(), TurnRetryConfig{BaseDelay: time.Millisecond}, fn, nil)
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts), "plain errors must not be retried")
+}
+
+func TestTurnRetry_ExhaustsAttempts(t *testing.T) {
+	var attempts int32
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, &provider.ProviderError{
+			Kind:    provider.ErrServerError,
+			Message: "upstream down",
+		}
+	}
+
+	cfg := TurnRetryConfig{MaxAttempts: 3, BaseDelay: time.Millisecond, MaxDelay: 5 * time.Millisecond}
+	_, err := TurnRetry(context.Background(), cfg, fn, nil)
+	require.Error(t, err)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+	var pe *provider.ProviderError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, provider.ErrServerError, pe.Kind)
+}
+
+func TestTurnRetry_RespectsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var attempts int32
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			cancel() // cancel between first failure and retry delay
+		}
+		return nil, &provider.ProviderError{Kind: provider.ErrRateLimited, Message: "429"}
+	}
+
+	cfg := TurnRetryConfig{MaxAttempts: 3, BaseDelay: 100 * time.Millisecond}
+	_, err := TurnRetry(ctx, cfg, fn, nil)
+	require.Error(t, err)
+	// After cancel during delay, the err should be ctx.Err(), not the retry error.
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/internal/agent/turnretry_test.go
+++ b/internal/agent/turnretry_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"errors"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -30,10 +29,10 @@ func TestTurnRetry_SucceedsFirstAttempt(t *testing.T) {
 }
 
 func TestTurnRetry_RetriesOnRetryableError(t *testing.T) {
-	var attempts int32
+	attempts := 0
 	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
-		n := atomic.AddInt32(&attempts, 1)
-		if n < 3 {
+		attempts++
+		if attempts < 3 {
 			return nil, &provider.ProviderError{
 				Kind:    provider.ErrRateLimited,
 				Message: "slow down",
@@ -58,14 +57,14 @@ func TestTurnRetry_RetriesOnRetryableError(t *testing.T) {
 	ch, err := TurnRetry(context.Background(), cfg, fn, onRetry)
 	require.NoError(t, err)
 	require.NotNil(t, ch)
-	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+	assert.Equal(t, 3, attempts)
 	assert.Equal(t, []int{2, 3}, retryCalls)
 }
 
 func TestTurnRetry_DoesNotRetryNonRetryable(t *testing.T) {
-	var attempts int32
+	attempts := 0
 	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
-		atomic.AddInt32(&attempts, 1)
+		attempts++
 		return nil, &provider.ProviderError{
 			Kind:    provider.ErrAuthFailed,
 			Message: "bad api key",
@@ -74,25 +73,25 @@ func TestTurnRetry_DoesNotRetryNonRetryable(t *testing.T) {
 
 	_, err := TurnRetry(context.Background(), TurnRetryConfig{BaseDelay: time.Millisecond}, fn, nil)
 	require.Error(t, err)
-	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts))
+	assert.Equal(t, 1, attempts)
 }
 
 func TestTurnRetry_DoesNotRetryPlainError(t *testing.T) {
-	var attempts int32
+	attempts := 0
 	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
-		atomic.AddInt32(&attempts, 1)
+		attempts++
 		return nil, errors.New("network refused")
 	}
 
 	_, err := TurnRetry(context.Background(), TurnRetryConfig{BaseDelay: time.Millisecond}, fn, nil)
 	require.Error(t, err)
-	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts), "plain errors must not be retried")
+	assert.Equal(t, 1, attempts, "plain errors must not be retried")
 }
 
 func TestTurnRetry_ExhaustsAttempts(t *testing.T) {
-	var attempts int32
+	attempts := 0
 	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
-		atomic.AddInt32(&attempts, 1)
+		attempts++
 		return nil, &provider.ProviderError{
 			Kind:    provider.ErrServerError,
 			Message: "upstream down",
@@ -102,7 +101,7 @@ func TestTurnRetry_ExhaustsAttempts(t *testing.T) {
 	cfg := TurnRetryConfig{MaxAttempts: 3, BaseDelay: time.Millisecond, MaxDelay: 5 * time.Millisecond}
 	_, err := TurnRetry(context.Background(), cfg, fn, nil)
 	require.Error(t, err)
-	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+	assert.Equal(t, 3, attempts)
 	var pe *provider.ProviderError
 	require.ErrorAs(t, err, &pe)
 	assert.Equal(t, provider.ErrServerError, pe.Kind)
@@ -110,10 +109,10 @@ func TestTurnRetry_ExhaustsAttempts(t *testing.T) {
 
 func TestTurnRetry_RespectsContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	var attempts int32
+	attempts := 0
 	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
-		n := atomic.AddInt32(&attempts, 1)
-		if n == 1 {
+		attempts++
+		if attempts == 1 {
 			cancel() // cancel between first failure and retry delay
 		}
 		return nil, &provider.ProviderError{Kind: provider.ErrRateLimited, Message: "429"}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -199,12 +199,13 @@ type SecurityConfig struct {
 
 // ProviderConfig holds settings for AI provider selection and configuration.
 type ProviderConfig struct {
-	Default   string                   `toml:"default"`
-	Model     string                   `toml:"model"`
-	Anthropic AnthropicProviderConfig  `toml:"anthropic"`
-	OpenAI    []OpenAICompatibleConfig `toml:"openai_compatible"`
-	Ollama    OllamaProviderConfig     `toml:"ollama"`
-	Zai       ZaiProviderConfig        `toml:"zai"`
+	Default      string                   `toml:"default"`
+	Model        string                   `toml:"model"`
+	SummaryModel string                   `toml:"summary_model"` // model for summarization/compaction; falls back to Model if empty
+	Anthropic    AnthropicProviderConfig  `toml:"anthropic"`
+	OpenAI       []OpenAICompatibleConfig `toml:"openai_compatible"`
+	Ollama       OllamaProviderConfig     `toml:"ollama"`
+	Zai          ZaiProviderConfig        `toml:"zai"`
 }
 
 // AnthropicProviderConfig holds Anthropic-specific provider settings.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -825,3 +825,29 @@ func TestSandboxConfigValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestProviderConfig_SummaryModel(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "config.toml")
+	content := `
+[provider]
+default = "anthropic"
+model = "claude-opus-4-6"
+summary_model = "claude-haiku-4-5-20251001"
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-6", cfg.Provider.Model)
+	assert.Equal(t, "claude-haiku-4-5-20251001", cfg.Provider.SummaryModel)
+}
+
+func TestProviderConfig_SummaryModel_EmptyByDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	assert.Equal(t, "", cfg.Provider.SummaryModel, "SummaryModel should default to empty (caller falls back to Model)")
+}

--- a/internal/provider/anthropic/nonstream.go
+++ b/internal/provider/anthropic/nonstream.go
@@ -1,0 +1,154 @@
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// NonStream sends req with stream=false and converts the full JSON response
+// into a slice of StreamEvents equivalent to what streaming would have produced.
+// Intended as a fallback for proxy environments that corrupt SSE streams
+// (HTTP 200 with non-SSE body, or mid-stream truncation).
+func (p *Provider) NonStream(ctx context.Context, req provider.CompletionRequest) ([]provider.StreamEvent, error) {
+	body, err := p.transformer.ToProviderJSON(req)
+	if err != nil {
+		return nil, fmt.Errorf("building request body: %w", err)
+	}
+
+	// Inject stream:false. The transformer sets stream:true by default.
+	body, err = overrideStreamFlag(body, false)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	requestID := uuid.New().String()
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-api-key", p.apiKey)
+	httpReq.Header.Set("anthropic-version", "2023-06-01")
+	httpReq.Header.Set("x-client-request-id", requestID)
+
+	provider.LogRequest(p.debugLogger, httpReq, body)
+
+	resp, err := provider.DoWithRetry(ctx, p.client, httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	provider.LogResponse(p.debugLogger, resp.StatusCode, resp.Header, respBody)
+
+	if resp.StatusCode != http.StatusOK {
+		classified := provider.ClassifyAPIErrorWithResponse(resp.StatusCode, respBody, httpReq, "anthropic", resp.Header)
+		if classified != nil {
+			classified.RequestID = requestID
+		}
+		return nil, classified
+	}
+
+	events, err := parseNonStreamResponse(respBody)
+	if err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+// overrideStreamFlag rewrites the stream field in a request body JSON object.
+// The transformer emits stream:true by default; this flips it for NonStream.
+func overrideStreamFlag(body []byte, stream bool) ([]byte, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("patching stream flag: %w", err)
+	}
+	if stream {
+		raw["stream"] = json.RawMessage(`true`)
+	} else {
+		raw["stream"] = json.RawMessage(`false`)
+	}
+	return json.Marshal(raw)
+}
+
+// parseNonStreamResponse converts a full Anthropic message JSON response
+// into a StreamEvent slice mirroring what processStream would have emitted.
+// Event order: message_start, then one text_delta per text block OR
+// tool_use+content_block_stop per tool block, then a final stop event.
+func parseNonStreamResponse(data []byte) ([]provider.StreamEvent, error) {
+	var msg struct {
+		ID         string `json:"id"`
+		Model      string `json:"model"`
+		StopReason string `json:"stop_reason"`
+		Content    []struct {
+			Type  string          `json:"type"`
+			Text  string          `json:"text"`
+			ID    string          `json:"id"`
+			Name  string          `json:"name"`
+			Input json.RawMessage `json:"input"`
+		} `json:"content"`
+		Usage struct {
+			InputTokens              int `json:"input_tokens"`
+			OutputTokens             int `json:"output_tokens"`
+			CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+			CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return nil, fmt.Errorf("parsing non-stream response: %w", err)
+	}
+
+	events := make([]provider.StreamEvent, 0, 2+2*len(msg.Content))
+	events = append(events, provider.StreamEvent{
+		Type:                "message_start",
+		MessageID:           msg.ID,
+		Model:               msg.Model,
+		InputTokens:         msg.Usage.InputTokens,
+		OutputTokens:        msg.Usage.OutputTokens,
+		CacheCreationTokens: msg.Usage.CacheCreationInputTokens,
+		CacheReadTokens:     msg.Usage.CacheReadInputTokens,
+	})
+
+	for _, block := range msg.Content {
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				events = append(events, provider.StreamEvent{Type: "text_delta", Text: block.Text})
+			}
+		case "tool_use":
+			input := block.Input
+			if len(input) == 0 {
+				input = json.RawMessage(`{}`)
+			}
+			events = append(events, provider.StreamEvent{
+				Type: agentsdk.EventToolUse,
+				ToolUse: &provider.ToolUseBlock{
+					ID:    block.ID,
+					Name:  block.Name,
+					Input: input,
+				},
+			})
+			events = append(events, provider.StreamEvent{Type: agentsdk.EventContentBlockStop})
+		}
+	}
+
+	events = append(events, provider.StreamEvent{
+		Type:       agentsdk.EventStop,
+		StopReason: msg.StopReason,
+	})
+	return events, nil
+}

--- a/internal/provider/anthropic/nonstream_test.go
+++ b/internal/provider/anthropic/nonstream_test.go
@@ -1,0 +1,148 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNonStream_TextResponse(t *testing.T) {
+	responseJSON := `{
+        "id": "msg_01",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5",
+        "content": [{"type": "text", "text": "Hello world!"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+    }`
+
+	var capturedStream bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]interface{}
+		_ = json.Unmarshal(body, &parsed)
+		if s, ok := parsed["stream"].(bool); ok {
+			capturedStream = s
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, responseJSON)
+	}))
+	defer srv.Close()
+
+	p := New(srv.URL, "test-key")
+	req := provider.CompletionRequest{
+		Model:     "claude-sonnet-4-5",
+		MaxTokens: 100,
+		Messages:  []provider.Message{{Role: "user", Content: []provider.ContentBlock{{Type: "text", Text: "hi"}}}},
+	}
+	events, err := p.NonStream(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.False(t, capturedStream, "stream flag must be false")
+
+	// Expect: message_start, text_delta, stop
+	require.Len(t, events, 3)
+	assert.Equal(t, "message_start", events[0].Type)
+	assert.Equal(t, "msg_01", events[0].MessageID)
+	assert.Equal(t, 10, events[0].InputTokens)
+	assert.Equal(t, 5, events[0].OutputTokens)
+
+	assert.Equal(t, "text_delta", events[1].Type)
+	assert.Equal(t, "Hello world!", events[1].Text)
+
+	assert.Equal(t, agentsdk.EventStop, events[2].Type)
+	assert.Equal(t, "end_turn", events[2].StopReason)
+}
+
+func TestNonStream_ToolUseResponse(t *testing.T) {
+	responseJSON := `{
+        "id": "msg_02",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5",
+        "content": [
+            {"type": "text", "text": "Let me check that."},
+            {"type": "tool_use", "id": "tool_abc", "name": "read_file", "input": {"path": "/tmp/f"}}
+        ],
+        "stop_reason": "tool_use",
+        "usage": {"input_tokens": 20, "output_tokens": 15}
+    }`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, responseJSON)
+	}))
+	defer srv.Close()
+
+	p := New(srv.URL, "test-key")
+	req := provider.CompletionRequest{
+		Model:     "claude-sonnet-4-5",
+		MaxTokens: 100,
+		Messages:  []provider.Message{{Role: "user", Content: []provider.ContentBlock{{Type: "text", Text: "hi"}}}},
+	}
+	events, err := p.NonStream(context.Background(), req)
+	require.NoError(t, err)
+
+	// Expect: message_start, text_delta, tool_use, content_block_stop, stop
+	require.Len(t, events, 5)
+	assert.Equal(t, "message_start", events[0].Type)
+	assert.Equal(t, "text_delta", events[1].Type)
+	assert.Equal(t, "Let me check that.", events[1].Text)
+	assert.Equal(t, agentsdk.EventToolUse, events[2].Type)
+	require.NotNil(t, events[2].ToolUse)
+	assert.Equal(t, "tool_abc", events[2].ToolUse.ID)
+	assert.Equal(t, "read_file", events[2].ToolUse.Name)
+	assert.Equal(t, `{"path":"/tmp/f"}`, strings.ReplaceAll(string(events[2].ToolUse.Input), " ", ""))
+	assert.Equal(t, agentsdk.EventContentBlockStop, events[3].Type)
+	assert.Equal(t, agentsdk.EventStop, events[4].Type)
+	assert.Equal(t, "tool_use", events[4].StopReason)
+}
+
+func TestNonStream_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Header().Set("Retry-After", "5")
+		fmt.Fprint(w, `{"error":{"type":"rate_limit_error","message":"slow down"}}`)
+	}))
+	defer srv.Close()
+
+	p := New(srv.URL, "test-key")
+	req := provider.CompletionRequest{
+		Model:     "claude-sonnet-4-5",
+		MaxTokens: 100,
+		Messages:  []provider.Message{{Role: "user", Content: []provider.ContentBlock{{Type: "text", Text: "hi"}}}},
+	}
+	_, err := p.NonStream(context.Background(), req)
+	require.Error(t, err)
+
+	var pe *provider.ProviderError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, provider.ErrRateLimited, pe.Kind)
+	assert.NotEmpty(t, pe.RequestID, "RequestID must be populated on HTTP errors")
+}
+
+func TestParseNonStreamResponse_EmptyInputToolUse(t *testing.T) {
+	data := []byte(`{
+        "id": "msg_03",
+        "model": "m",
+        "stop_reason": "tool_use",
+        "content": [{"type": "tool_use", "id": "t1", "name": "noop"}],
+        "usage": {"input_tokens": 1, "output_tokens": 1}
+    }`)
+	events, err := parseNonStreamResponse(data)
+	require.NoError(t, err)
+	// message_start, tool_use, content_block_stop, stop
+	require.Len(t, events, 4)
+	require.NotNil(t, events[1].ToolUse)
+	assert.JSONEq(t, `{}`, string(events[1].ToolUse.Input), "empty input must default to {}")
+}

--- a/internal/provider/anthropic/nonstream_test.go
+++ b/internal/provider/anthropic/nonstream_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/pkg/agentsdk"
@@ -110,8 +111,11 @@ func TestNonStream_ToolUseResponse(t *testing.T) {
 
 func TestNonStream_HTTPError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusTooManyRequests)
+		// Headers must be set BEFORE WriteHeader — anything set after is
+		// silently dropped by net/http. The Retry-After check below
+		// verifies the response actually round-trips the hint.
 		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
 		fmt.Fprint(w, `{"error":{"type":"rate_limit_error","message":"slow down"}}`)
 	}))
 	defer srv.Close()
@@ -129,6 +133,8 @@ func TestNonStream_HTTPError(t *testing.T) {
 	require.ErrorAs(t, err, &pe)
 	assert.Equal(t, provider.ErrRateLimited, pe.Kind)
 	assert.NotEmpty(t, pe.RequestID, "RequestID must be populated on HTTP errors")
+	assert.Equal(t, 5*time.Second, pe.RetryAfter,
+		"Retry-After header must be parsed when set before WriteHeader")
 }
 
 func TestParseNonStreamResponse_EmptyInputToolUse(t *testing.T) {

--- a/internal/provider/anthropic/provider.go
+++ b/internal/provider/anthropic/provider.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
@@ -61,9 +62,11 @@ func (p *Provider) Stream(ctx context.Context, req provider.CompletionRequest) (
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
+	requestID := uuid.New().String()
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("x-api-key", p.apiKey)
 	httpReq.Header.Set("anthropic-version", "2023-06-01")
+	httpReq.Header.Set("x-client-request-id", requestID)
 
 	provider.LogRequest(p.debugLogger, httpReq, body)
 
@@ -76,7 +79,9 @@ func (p *Provider) Stream(ctx context.Context, req provider.CompletionRequest) (
 		defer resp.Body.Close()
 		respBody, _ := io.ReadAll(resp.Body)
 		provider.LogResponse(p.debugLogger, resp.StatusCode, resp.Header, respBody)
-		return nil, provider.ClassifyAPIErrorWithResponse(resp.StatusCode, respBody, httpReq, "anthropic", resp.Header)
+		classified := provider.ClassifyAPIErrorWithResponse(resp.StatusCode, respBody, httpReq, "anthropic", resp.Header)
+		classified.RequestID = requestID
+		return nil, classified
 	}
 
 	if p.debugLogger != nil {
@@ -84,7 +89,7 @@ func (p *Provider) Stream(ctx context.Context, req provider.CompletionRequest) (
 	}
 
 	ch := make(chan provider.StreamEvent)
-	go p.processStream(ctx, resp.Body, ch)
+	go p.processStream(ctx, resp.Body, ch, requestID)
 
 	return ch, nil
 }
@@ -111,7 +116,7 @@ func newStreamState() *streamState {
 
 // processStream reads SSE events from the response body and sends StreamEvents
 // to the channel as they arrive. It closes both the body and the channel when done.
-func (p *Provider) processStream(ctx context.Context, body io.ReadCloser, ch chan<- provider.StreamEvent) {
+func (p *Provider) processStream(ctx context.Context, body io.ReadCloser, ch chan<- provider.StreamEvent, requestID string) {
 	defer close(ch)
 	defer body.Close()
 
@@ -150,6 +155,7 @@ func (p *Provider) processStream(ctx context.Context, body io.ReadCloser, ch cha
 			Provider:  "anthropic",
 			Message:   err.Error(),
 			Retryable: true,
+			RequestID: requestID,
 		}
 		select {
 		case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: streamErr}:

--- a/internal/provider/anthropic/provider.go
+++ b/internal/provider/anthropic/provider.go
@@ -204,6 +204,8 @@ func (p *Provider) convertSSEEvent(state *streamState, evt sseEvent) (first, sec
 		return p.handleContentBlockDelta(state, evt.Data), nil
 	case "content_block_stop":
 		return p.handleContentBlockStop(state, evt.Data)
+	case "message_delta":
+		return p.handleMessageDelta(evt.Data), nil
 	case "message_stop":
 		return &provider.StreamEvent{Type: agentsdk.EventStop}, nil
 	default:
@@ -237,6 +239,31 @@ func (p *Provider) handleMessageStart(data string) *provider.StreamEvent {
 		OutputTokens:        parsed.Message.Usage.OutputTokens,
 		CacheCreationTokens: parsed.Message.Usage.CacheCreationInputTokens,
 		CacheReadTokens:     parsed.Message.Usage.CacheReadInputTokens,
+	}
+}
+
+func (p *Provider) handleMessageDelta(data string) *provider.StreamEvent {
+	var parsed struct {
+		Delta struct {
+			StopReason string `json:"stop_reason"`
+		} `json:"delta"`
+		Usage struct {
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.NewDecoder(strings.NewReader(data)).Decode(&parsed); err != nil {
+		if p.debugLogger != nil {
+			p.debugLogger("[DEBUG] anthropic: parsing message_delta: %v", err)
+		}
+		return nil
+	}
+	if parsed.Delta.StopReason == "" {
+		return nil
+	}
+	return &provider.StreamEvent{
+		Type:         agentsdk.EventStop,
+		StopReason:   parsed.Delta.StopReason,
+		OutputTokens: parsed.Usage.OutputTokens,
 	}
 }
 

--- a/internal/provider/anthropic/provider.go
+++ b/internal/provider/anthropic/provider.go
@@ -186,8 +186,10 @@ func (p *Provider) handleMessageStart(data string) *provider.StreamEvent {
 			ID    string `json:"id"`
 			Model string `json:"model"`
 			Usage struct {
-				InputTokens  int `json:"input_tokens"`
-				OutputTokens int `json:"output_tokens"`
+				InputTokens              int `json:"input_tokens"`
+				OutputTokens             int `json:"output_tokens"`
+				CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+				CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 			} `json:"usage"`
 		} `json:"message"`
 	}
@@ -197,11 +199,13 @@ func (p *Provider) handleMessageStart(data string) *provider.StreamEvent {
 	}
 
 	return &provider.StreamEvent{
-		Type:         "message_start",
-		Model:        parsed.Message.Model,
-		MessageID:    parsed.Message.ID,
-		InputTokens:  parsed.Message.Usage.InputTokens,
-		OutputTokens: parsed.Message.Usage.OutputTokens,
+		Type:                "message_start",
+		Model:               parsed.Message.Model,
+		MessageID:           parsed.Message.ID,
+		InputTokens:         parsed.Message.Usage.InputTokens,
+		OutputTokens:        parsed.Message.Usage.OutputTokens,
+		CacheCreationTokens: parsed.Message.Usage.CacheCreationInputTokens,
+		CacheReadTokens:     parsed.Message.Usage.CacheReadInputTokens,
 	}
 }
 

--- a/internal/provider/anthropic/provider.go
+++ b/internal/provider/anthropic/provider.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -115,14 +116,28 @@ func newStreamState() *streamState {
 }
 
 // processStream reads SSE events from the response body and sends StreamEvents
-// to the channel as they arrive. It closes both the body and the channel when done.
+// to the channel as they arrive. It closes the channel when done; the watchdog
+// pump goroutine owns closing body.
 func (p *Provider) processStream(ctx context.Context, body io.ReadCloser, ch chan<- provider.StreamEvent, requestID string) {
 	defer close(ch)
-	defer body.Close()
+
+	onWarn := func() {
+		if p.debugLogger != nil {
+			p.debugLogger("[DEBUG] anthropic: stream idle for 45s (request %s), still waiting", requestID)
+		}
+	}
+	onKill := func() {
+		if p.debugLogger != nil {
+			p.debugLogger("[DEBUG] anthropic: stream killed after 90s idle (request %s)", requestID)
+		}
+	}
+
+	watched := provider.WatchBody(body, provider.WatchdogConfig{}, onWarn, onKill)
+	defer watched.Close()
 
 	state := newStreamState()
 
-	scanner := newSSEScanner(body)
+	scanner := newSSEScanner(watched)
 	for scanner.Next() {
 		if ctx.Err() != nil {
 			select {
@@ -150,12 +165,22 @@ func (p *Provider) processStream(ctx context.Context, body io.ReadCloser, ch cha
 	}
 
 	if err := scanner.Err(); err != nil {
-		streamErr := &provider.ProviderError{
-			Kind:      provider.ErrStreamError,
-			Provider:  "anthropic",
-			Message:   err.Error(),
-			Retryable: true,
-			RequestID: requestID,
+		var streamErr *provider.ProviderError
+		if !errors.As(err, &streamErr) {
+			streamErr = &provider.ProviderError{
+				Kind:      provider.ErrStreamError,
+				Provider:  "anthropic",
+				Message:   err.Error(),
+				Retryable: true,
+				RequestID: requestID,
+			}
+		} else {
+			if streamErr.Provider == "" {
+				streamErr.Provider = "anthropic"
+			}
+			if streamErr.RequestID == "" {
+				streamErr.RequestID = requestID
+			}
 		}
 		select {
 		case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: streamErr}:

--- a/internal/provider/anthropic/provider.go
+++ b/internal/provider/anthropic/provider.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -165,25 +164,8 @@ func (p *Provider) processStream(ctx context.Context, body io.ReadCloser, ch cha
 	}
 
 	if err := scanner.Err(); err != nil {
-		var streamErr *provider.ProviderError
-		if !errors.As(err, &streamErr) {
-			streamErr = &provider.ProviderError{
-				Kind:      provider.ErrStreamError,
-				Provider:  "anthropic",
-				Message:   err.Error(),
-				Retryable: true,
-				RequestID: requestID,
-			}
-		} else {
-			if streamErr.Provider == "" {
-				streamErr.Provider = "anthropic"
-			}
-			if streamErr.RequestID == "" {
-				streamErr.RequestID = requestID
-			}
-		}
 		select {
-		case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: streamErr}:
+		case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: provider.WrapScannerError(err, "anthropic", requestID)}:
 		case <-ctx.Done():
 		}
 	}

--- a/internal/provider/anthropic/provider.go
+++ b/internal/provider/anthropic/provider.go
@@ -145,8 +145,14 @@ func (p *Provider) processStream(ctx context.Context, body io.ReadCloser, ch cha
 	}
 
 	if err := scanner.Err(); err != nil {
+		streamErr := &provider.ProviderError{
+			Kind:      provider.ErrStreamError,
+			Provider:  "anthropic",
+			Message:   err.Error(),
+			Retryable: true,
+		}
 		select {
-		case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: err}:
+		case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: streamErr}:
 		case <-ctx.Done():
 		}
 	}

--- a/internal/provider/anthropic/provider.go
+++ b/internal/provider/anthropic/provider.go
@@ -108,6 +108,10 @@ type pendingToolBlock struct {
 // inside processStream's goroutine so there is no cross-request sharing.
 type streamState struct {
 	pendingTools map[int]*pendingToolBlock
+	// stopEmitted gates the terminal EventStop so that the typical
+	// message_delta (carrying stop_reason) + message_stop pair does not
+	// produce two terminal events to the agent loop.
+	stopEmitted bool
 }
 
 func newStreamState() *streamState {
@@ -164,6 +168,18 @@ func (p *Provider) processStream(ctx context.Context, body io.ReadCloser, ch cha
 	}
 
 	if err := scanner.Err(); err != nil {
+		// Prefer context cancellation over reclassifying a network-level
+		// read failure as a retryable ErrStreamError. When the caller
+		// cancels mid-stream the HTTP transport typically tears down
+		// the body with a low-level error; wrapping that as retryable
+		// would make TurnRetry re-run a user-cancelled operation.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			select {
+			case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: ctxErr}:
+			default:
+			}
+			return
+		}
 		select {
 		case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: provider.WrapScannerError(err, "anthropic", requestID)}:
 		case <-ctx.Done():
@@ -187,8 +203,15 @@ func (p *Provider) convertSSEEvent(state *streamState, evt sseEvent) (first, sec
 	case "content_block_stop":
 		return p.handleContentBlockStop(state, evt.Data)
 	case "message_delta":
-		return p.handleMessageDelta(evt.Data), nil
+		return p.handleMessageDelta(state, evt.Data), nil
 	case "message_stop":
+		// message_stop typically follows a message_delta that already
+		// carried stop_reason. Suppress the duplicate terminal event so
+		// downstream finalization runs exactly once per turn.
+		if state.stopEmitted {
+			return nil, nil
+		}
+		state.stopEmitted = true
 		return &provider.StreamEvent{Type: agentsdk.EventStop}, nil
 	default:
 		return nil, nil
@@ -224,7 +247,7 @@ func (p *Provider) handleMessageStart(data string) *provider.StreamEvent {
 	}
 }
 
-func (p *Provider) handleMessageDelta(data string) *provider.StreamEvent {
+func (p *Provider) handleMessageDelta(state *streamState, data string) *provider.StreamEvent {
 	var parsed struct {
 		Delta struct {
 			StopReason string `json:"stop_reason"`
@@ -239,9 +262,10 @@ func (p *Provider) handleMessageDelta(data string) *provider.StreamEvent {
 		}
 		return nil
 	}
-	if parsed.Delta.StopReason == "" {
+	if parsed.Delta.StopReason == "" || state.stopEmitted {
 		return nil
 	}
+	state.stopEmitted = true
 	return &provider.StreamEvent{
 		Type:         agentsdk.EventStop,
 		StopReason:   parsed.Delta.StopReason,

--- a/internal/provider/anthropic/provider_test.go
+++ b/internal/provider/anthropic/provider_test.go
@@ -1064,6 +1064,45 @@ func TestProcessStream_ScannerError(t *testing.T) {
 	assert.Equal(t, "test-request-id", pe.RequestID)
 }
 
+// When ctx is canceled while the scanner is blocked reading the body, the
+// underlying transport typically returns a network-level error from
+// scanner.Err(). processStream must prefer the context error over reclassifying
+// the read failure as a retryable ErrStreamError — a user cancellation is not
+// retryable.
+func TestProcessStream_ContextCancelledPrefersCtxErr(t *testing.T) {
+	pr, pw := io.Pipe()
+	// Simulate a network-level error from the read side (as if Transport
+	// closed the body after ctx cancellation).
+	pw.CloseWithError(errors.New("connection reset by peer"))
+
+	p := New("http://localhost", "test-key")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before processStream inspects scanner.Err()
+
+	ch := make(chan provider.StreamEvent)
+	go p.processStream(ctx, io.NopCloser(pr), ch, "test-request-id")
+
+	var events []provider.StreamEvent
+	for e := range ch {
+		events = append(events, e)
+	}
+
+	require.Len(t, events, 1)
+	assert.Equal(t, agentsdk.EventError, events[0].Type)
+
+	// The emitted error must be context.Canceled (or a ProviderError that
+	// is NOT retryable), not a retryable ErrStreamError — otherwise
+	// TurnRetry will incorrectly retry a user-cancelled operation.
+	if errors.Is(events[0].Error, context.Canceled) {
+		return
+	}
+	var pe *provider.ProviderError
+	require.ErrorAs(t, events[0].Error, &pe,
+		"expected context.Canceled or a ProviderError, got %T", events[0].Error)
+	assert.False(t, pe.IsRetryable(),
+		"ctx-cancelled scanner error must not be marked retryable")
+}
+
 func TestStream_SetsRequestIDHeader(t *testing.T) {
 	var capturedHeader string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1113,6 +1152,39 @@ func TestConvertSSEEvent_MessageDelta_EndTurn(t *testing.T) {
 	require.NotNil(t, first)
 	assert.Equal(t, agentsdk.EventStop, first.Type)
 	assert.Equal(t, "end_turn", first.StopReason)
+}
+
+// Normal Anthropic streams emit message_delta (with stop_reason) immediately
+// followed by message_stop. Both must not produce terminal EventStop events;
+// otherwise downstream agent-loop finalization runs twice.
+func TestConvertSSEEvent_MessageStop_GatedAfterMessageDelta(t *testing.T) {
+	p := New("http://localhost", "test-key")
+	state := newStreamState()
+
+	// message_delta fires first and emits EventStop with the real stop_reason.
+	deltaData := `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}`
+	first, second := p.convertSSEEvent(state, sseEvent{Event: "message_delta", Data: deltaData})
+	require.NotNil(t, first)
+	require.Nil(t, second)
+	assert.Equal(t, agentsdk.EventStop, first.Type)
+	assert.Equal(t, "end_turn", first.StopReason)
+
+	// message_stop arriving after the delta-stop must be suppressed.
+	stopFirst, stopSecond := p.convertSSEEvent(state, sseEvent{Event: "message_stop", Data: `{"type":"message_stop"}`})
+	assert.Nil(t, stopFirst, "message_stop after message_delta must not emit a second EventStop")
+	assert.Nil(t, stopSecond)
+}
+
+// When message_delta never carries stop_reason (older providers, edge cases),
+// message_stop must still emit the terminal event so the agent loop completes.
+func TestConvertSSEEvent_MessageStop_EmitsWhenNoDeltaStop(t *testing.T) {
+	p := New("http://localhost", "test-key")
+	state := newStreamState()
+
+	first, second := p.convertSSEEvent(state, sseEvent{Event: "message_stop", Data: `{"type":"message_stop"}`})
+	require.NotNil(t, first, "message_stop must emit EventStop when no prior delta-stop")
+	assert.Nil(t, second)
+	assert.Equal(t, agentsdk.EventStop, first.Type)
 }
 
 func TestHandleMessageStart_CacheTokens(t *testing.T) {

--- a/internal/provider/anthropic/provider_test.go
+++ b/internal/provider/anthropic/provider_test.go
@@ -1062,3 +1062,16 @@ func TestProcessStream_ScannerError(t *testing.T) {
 }
 
 func floatPtr(f float64) *float64 { return &f }
+
+func TestHandleMessageStart_CacheTokens(t *testing.T) {
+	p := New("http://localhost", "test-key")
+	data := `{"message":{"id":"msg_01","model":"claude-sonnet-4-5","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":2000,"cache_read_input_tokens":48000}}}`
+
+	evt := p.handleMessageStart(data)
+	require.NotNil(t, evt)
+	assert.Equal(t, "message_start", evt.Type)
+	assert.Equal(t, 100, evt.InputTokens)
+	assert.Equal(t, 50, evt.OutputTokens)
+	assert.Equal(t, 2000, evt.CacheCreationTokens)
+	assert.Equal(t, 48000, evt.CacheReadTokens)
+}

--- a/internal/provider/anthropic/provider_test.go
+++ b/internal/provider/anthropic/provider_test.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/testutil"
 	"github.com/julianshen/rubichan/pkg/agentsdk"
@@ -1044,7 +1046,7 @@ func TestProcessStream_ScannerError(t *testing.T) {
 
 	p := New("http://localhost", "test-key")
 	ch := make(chan provider.StreamEvent)
-	go p.processStream(context.Background(), io.NopCloser(pr), ch)
+	go p.processStream(context.Background(), io.NopCloser(pr), ch, "test-request-id")
 
 	var events []provider.StreamEvent
 	for e := range ch {
@@ -1059,6 +1061,32 @@ func TestProcessStream_ScannerError(t *testing.T) {
 	assert.Equal(t, provider.ErrStreamError, pe.Kind)
 	assert.Equal(t, "anthropic", pe.Provider)
 	assert.True(t, pe.IsRetryable())
+	assert.Equal(t, "test-request-id", pe.RequestID)
+}
+
+func TestStream_SetsRequestIDHeader(t *testing.T) {
+	var capturedHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header.Get("x-client-request-id")
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "event: message_stop\ndata: {}\n\n")
+	}))
+	defer srv.Close()
+
+	p := New(srv.URL, "test-key")
+	req := provider.CompletionRequest{
+		Model:     "claude-sonnet-4-5",
+		MaxTokens: 100,
+		Messages:  []provider.Message{{Role: "user", Content: []provider.ContentBlock{{Type: "text", Text: "hi"}}}},
+	}
+	ch, err := p.Stream(context.Background(), req)
+	require.NoError(t, err)
+	for range ch { // drain
+	}
+
+	assert.NotEmpty(t, capturedHeader, "x-client-request-id header must be set")
+	_, parseErr := uuid.Parse(capturedHeader)
+	assert.NoError(t, parseErr, "x-client-request-id must be a valid UUID")
 }
 
 func floatPtr(f float64) *float64 { return &f }

--- a/internal/provider/anthropic/provider_test.go
+++ b/internal/provider/anthropic/provider_test.go
@@ -1091,6 +1091,30 @@ func TestStream_SetsRequestIDHeader(t *testing.T) {
 
 func floatPtr(f float64) *float64 { return &f }
 
+func TestConvertSSEEvent_MessageDelta_StopReason(t *testing.T) {
+	p := New("http://localhost", "test-key")
+	state := newStreamState()
+	data := `{"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"output_tokens":8192}}`
+
+	first, second := p.convertSSEEvent(state, sseEvent{Event: "message_delta", Data: data})
+	require.NotNil(t, first)
+	require.Nil(t, second)
+	assert.Equal(t, agentsdk.EventStop, first.Type)
+	assert.Equal(t, "max_tokens", first.StopReason)
+	assert.Equal(t, 8192, first.OutputTokens)
+}
+
+func TestConvertSSEEvent_MessageDelta_EndTurn(t *testing.T) {
+	p := New("http://localhost", "test-key")
+	state := newStreamState()
+	data := `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":150}}`
+
+	first, _ := p.convertSSEEvent(state, sseEvent{Event: "message_delta", Data: data})
+	require.NotNil(t, first)
+	assert.Equal(t, agentsdk.EventStop, first.Type)
+	assert.Equal(t, "end_turn", first.StopReason)
+}
+
 func TestHandleMessageStart_CacheTokens(t *testing.T) {
 	p := New("http://localhost", "test-key")
 	data := `{"message":{"id":"msg_01","model":"claude-sonnet-4-5","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":2000,"cache_read_input_tokens":48000}}}`

--- a/internal/provider/anthropic/provider_test.go
+++ b/internal/provider/anthropic/provider_test.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/testutil"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1034,6 +1036,29 @@ func TestTransformerStripsEmptyTextViaNormalization(t *testing.T) {
 	var blocks []map[string]any
 	require.NoError(t, json.Unmarshal(parsed.Messages[0].Content, &blocks))
 	assert.Len(t, blocks, 2, "empty text block should be removed by normalization")
+}
+
+func TestProcessStream_ScannerError(t *testing.T) {
+	pr, pw := io.Pipe()
+	pw.CloseWithError(errors.New("connection reset by peer"))
+
+	p := New("http://localhost", "test-key")
+	ch := make(chan provider.StreamEvent)
+	go p.processStream(context.Background(), io.NopCloser(pr), ch)
+
+	var events []provider.StreamEvent
+	for e := range ch {
+		events = append(events, e)
+	}
+
+	require.Len(t, events, 1)
+	assert.Equal(t, agentsdk.EventError, events[0].Type)
+
+	var pe *provider.ProviderError
+	require.ErrorAs(t, events[0].Error, &pe)
+	assert.Equal(t, provider.ErrStreamError, pe.Kind)
+	assert.Equal(t, "anthropic", pe.Provider)
+	assert.True(t, pe.IsRetryable())
 }
 
 func floatPtr(f float64) *float64 { return &f }

--- a/internal/provider/openai/provider.go
+++ b/internal/provider/openai/provider.go
@@ -90,7 +90,7 @@ func (p *Provider) Stream(ctx context.Context, req provider.CompletionRequest) (
 	}
 
 	ch := make(chan provider.StreamEvent)
-	go ssecompat.ProcessSSE(ctx, resp.Body, ch)
+	go ssecompat.ProcessSSE(ctx, resp.Body, ch, "openai")
 
 	return ch, nil
 }

--- a/internal/provider/provider_error.go
+++ b/internal/provider/provider_error.go
@@ -78,6 +78,11 @@ type ProviderError struct {
 	// Retryable is an explicit override for the retry decision.
 	// When true, IsRetryable returns true regardless of Kind.
 	Retryable bool
+	// RequestID is the client-generated UUID sent as x-client-request-id for
+	// request correlation. Present on stream errors and HTTP errors that were
+	// classified after the header was sent. Empty when the error originated
+	// before the request was built.
+	RequestID string
 }
 
 // Error implements the error interface.

--- a/internal/provider/scannererror.go
+++ b/internal/provider/scannererror.go
@@ -1,0 +1,26 @@
+package provider
+
+import "errors"
+
+// WrapScannerError converts an SSE scanner error into a typed *ProviderError.
+// If err is already a *ProviderError, its Provider and RequestID fields are
+// backfilled when empty so upstream watchdog errors keep their original kind
+// and metadata. Otherwise a fresh ErrStreamError is constructed.
+func WrapScannerError(err error, providerName, requestID string) *ProviderError {
+	var pe *ProviderError
+	if errors.As(err, &pe) {
+		if pe.Provider == "" {
+			pe.Provider = providerName
+		}
+		if pe.RequestID == "" {
+			pe.RequestID = requestID
+		}
+		return pe
+	}
+	return &ProviderError{
+		Kind:      ErrStreamError,
+		Provider:  providerName,
+		Message:   err.Error(),
+		RequestID: requestID,
+	}
+}

--- a/internal/provider/ssecompat/processor.go
+++ b/internal/provider/ssecompat/processor.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
 // chatChunk represents a single SSE chunk from an OpenAI-compatible API.
@@ -115,7 +116,9 @@ func (a *ToolCallAccumulator) Flush(ctx context.Context, ch chan<- provider.Stre
 // ProcessSSE reads OpenAI-compatible SSE lines from a reader and sends
 // StreamEvents to the channel. Handles text deltas, tool call accumulation,
 // and [DONE] detection. Closes both the body and the channel when done.
-func ProcessSSE(ctx context.Context, body io.ReadCloser, ch chan<- provider.StreamEvent) {
+// providerName is included in any ProviderError emitted so callers can
+// distinguish which provider encountered the stream failure.
+func ProcessSSE(ctx context.Context, body io.ReadCloser, ch chan<- provider.StreamEvent, providerName string) {
 	defer close(ch)
 	defer body.Close()
 
@@ -195,8 +198,14 @@ func ProcessSSE(ctx context.Context, body io.ReadCloser, ch chan<- provider.Stre
 	}
 
 	if err := scanner.Err(); err != nil {
+		streamErr := &provider.ProviderError{
+			Kind:      provider.ErrStreamError,
+			Provider:  providerName,
+			Message:   err.Error(),
+			Retryable: true,
+		}
 		select {
-		case ch <- provider.StreamEvent{Type: "error", Error: err}:
+		case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: streamErr}:
 		case <-ctx.Done():
 		}
 	}

--- a/internal/provider/ssecompat/processor.go
+++ b/internal/provider/ssecompat/processor.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -202,21 +201,8 @@ func ProcessSSE(ctx context.Context, body io.ReadCloser, ch chan<- provider.Stre
 	}
 
 	if err := scanner.Err(); err != nil {
-		var streamErr *provider.ProviderError
-		if !errors.As(err, &streamErr) {
-			streamErr = &provider.ProviderError{
-				Kind:      provider.ErrStreamError,
-				Provider:  providerName,
-				Message:   err.Error(),
-				Retryable: true,
-			}
-		} else {
-			if streamErr.Provider == "" {
-				streamErr.Provider = providerName
-			}
-		}
 		select {
-		case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: streamErr}:
+		case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: provider.WrapScannerError(err, providerName, "")}:
 		case <-ctx.Done():
 		}
 	}

--- a/internal/provider/ssecompat/processor.go
+++ b/internal/provider/ssecompat/processor.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -115,17 +116,20 @@ func (a *ToolCallAccumulator) Flush(ctx context.Context, ch chan<- provider.Stre
 
 // ProcessSSE reads OpenAI-compatible SSE lines from a reader and sends
 // StreamEvents to the channel. Handles text deltas, tool call accumulation,
-// and [DONE] detection. Closes both the body and the channel when done.
+// and [DONE] detection. Closes the channel when done; the watchdog pump
+// goroutine owns closing body.
 // providerName is included in any ProviderError emitted so callers can
 // distinguish which provider encountered the stream failure.
 func ProcessSSE(ctx context.Context, body io.ReadCloser, ch chan<- provider.StreamEvent, providerName string) {
 	defer close(ch)
-	defer body.Close()
+
+	watched := provider.WatchBody(body, provider.WatchdogConfig{}, nil, nil)
+	defer watched.Close()
 
 	var toolAcc ToolCallAccumulator
 	sentMessageStart := false
 
-	scanner := bufio.NewScanner(body)
+	scanner := bufio.NewScanner(watched)
 	// Increase buffer to 1MB to handle large JSON chunks (reasoning, tool args).
 	const maxScanCapacity = 1024 * 1024
 	scanner.Buffer(make([]byte, 0, maxScanCapacity), maxScanCapacity)
@@ -198,11 +202,18 @@ func ProcessSSE(ctx context.Context, body io.ReadCloser, ch chan<- provider.Stre
 	}
 
 	if err := scanner.Err(); err != nil {
-		streamErr := &provider.ProviderError{
-			Kind:      provider.ErrStreamError,
-			Provider:  providerName,
-			Message:   err.Error(),
-			Retryable: true,
+		var streamErr *provider.ProviderError
+		if !errors.As(err, &streamErr) {
+			streamErr = &provider.ProviderError{
+				Kind:      provider.ErrStreamError,
+				Provider:  providerName,
+				Message:   err.Error(),
+				Retryable: true,
+			}
+		} else {
+			if streamErr.Provider == "" {
+				streamErr.Provider = providerName
+			}
 		}
 		select {
 		case ch <- provider.StreamEvent{Type: agentsdk.EventError, Error: streamErr}:

--- a/internal/provider/ssecompat/processor_test.go
+++ b/internal/provider/ssecompat/processor_test.go
@@ -2,11 +2,13 @@ package ssecompat
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,7 +38,7 @@ func TestProcessSSE_TextDelta(t *testing.T) {
 	)
 
 	ch := make(chan provider.StreamEvent, 16)
-	ProcessSSE(context.Background(), body, ch)
+	ProcessSSE(context.Background(), body, ch, "test")
 	events := collect(ch)
 
 	var texts []string
@@ -55,7 +57,7 @@ func TestProcessSSE_MessageStart(t *testing.T) {
 	)
 
 	ch := make(chan provider.StreamEvent, 16)
-	ProcessSSE(context.Background(), body, ch)
+	ProcessSSE(context.Background(), body, ch, "test")
 	events := collect(ch)
 
 	require.GreaterOrEqual(t, len(events), 1)
@@ -73,7 +75,7 @@ func TestProcessSSE_ToolCallAccumulation(t *testing.T) {
 	)
 
 	ch := make(chan provider.StreamEvent, 16)
-	ProcessSSE(context.Background(), body, ch)
+	ProcessSSE(context.Background(), body, ch, "test")
 	events := collect(ch)
 
 	var toolUses []provider.StreamEvent
@@ -96,7 +98,7 @@ func TestProcessSSE_Done(t *testing.T) {
 	)
 
 	ch := make(chan provider.StreamEvent, 16)
-	ProcessSSE(context.Background(), body, ch)
+	ProcessSSE(context.Background(), body, ch, "test")
 	events := collect(ch)
 
 	require.NotEmpty(t, events, "expected at least one event")
@@ -110,7 +112,7 @@ func TestProcessSSE_ParseError(t *testing.T) {
 	)
 
 	ch := make(chan provider.StreamEvent, 16)
-	ProcessSSE(context.Background(), body, ch)
+	ProcessSSE(context.Background(), body, ch, "test")
 	events := collect(ch)
 
 	var hasError bool
@@ -132,7 +134,7 @@ func TestProcessSSE_ContextCancellation(t *testing.T) {
 	)
 
 	ch := make(chan provider.StreamEvent, 16)
-	ProcessSSE(ctx, body, ch)
+	ProcessSSE(ctx, body, ch, "test")
 	events := collect(ch)
 
 	// Should get an error event from context cancellation, not normal processing.
@@ -155,7 +157,7 @@ func TestProcessSSE_SkipsNonDataLines(t *testing.T) {
 	)
 
 	ch := make(chan provider.StreamEvent, 16)
-	ProcessSSE(context.Background(), body, ch)
+	ProcessSSE(context.Background(), body, ch, "test")
 	events := collect(ch)
 
 	var texts []string
@@ -188,4 +190,32 @@ func TestToolCallAccumulator_MultipleIndexes(t *testing.T) {
 	require.Len(t, toolUses, 2)
 	assert.Equal(t, "c1", toolUses[0].ToolUse.ID)
 	assert.Equal(t, "c2", toolUses[1].ToolUse.ID)
+}
+
+func TestProcessSSE_ScannerError(t *testing.T) {
+	pr, pw := io.Pipe()
+	pw.CloseWithError(errors.New("EOF mid-stream"))
+
+	ch := make(chan provider.StreamEvent, 4)
+	ProcessSSE(context.Background(), io.NopCloser(pr), ch, "openai-compat")
+
+	var events []provider.StreamEvent
+	for e := range ch {
+		events = append(events, e)
+	}
+
+	require.GreaterOrEqual(t, len(events), 1)
+	// Find the error event.
+	var errEvt *provider.StreamEvent
+	for i := range events {
+		if events[i].Type == agentsdk.EventError {
+			errEvt = &events[i]
+			break
+		}
+	}
+	require.NotNil(t, errEvt)
+	var pe *provider.ProviderError
+	require.ErrorAs(t, errEvt.Error, &pe)
+	assert.Equal(t, provider.ErrStreamError, pe.Kind)
+	assert.Equal(t, "openai-compat", pe.Provider)
 }

--- a/internal/provider/ssecompat/processor_test.go
+++ b/internal/provider/ssecompat/processor_test.go
@@ -204,18 +204,12 @@ func TestProcessSSE_ScannerError(t *testing.T) {
 		events = append(events, e)
 	}
 
-	require.GreaterOrEqual(t, len(events), 1)
-	// Find the error event.
-	var errEvt *provider.StreamEvent
-	for i := range events {
-		if events[i].Type == agentsdk.EventError {
-			errEvt = &events[i]
-			break
-		}
-	}
-	require.NotNil(t, errEvt)
+	require.Len(t, events, 1)
+	errEvt := &events[0]
+	require.Equal(t, agentsdk.EventError, errEvt.Type)
 	var pe *provider.ProviderError
 	require.ErrorAs(t, errEvt.Error, &pe)
 	assert.Equal(t, provider.ErrStreamError, pe.Kind)
 	assert.Equal(t, "openai-compat", pe.Provider)
+	assert.True(t, pe.IsRetryable())
 }

--- a/internal/provider/streamwatchdog.go
+++ b/internal/provider/streamwatchdog.go
@@ -93,6 +93,20 @@ func WatchBody(body io.ReadCloser, cfg WatchdogConfig, onWarn, onKill func()) io
 					warnFired = true
 				}
 			case <-killTimer.C:
+				// Select may fire killTimer.C even when an activity
+				// signal arrived simultaneously (Go makes no ordering
+				// promise between ready cases). Drain any pending
+				// activity before killing so a stream that just became
+				// live is not aborted spuriously.
+				select {
+				case <-activity:
+					warnTimer.Stop()
+					warnTimer.Reset(cfg.warnAfter())
+					killTimer.Reset(cfg.killAfter())
+					warnFired = false
+					continue
+				default:
+				}
 				if onKill != nil {
 					onKill()
 				}

--- a/internal/provider/streamwatchdog.go
+++ b/internal/provider/streamwatchdog.go
@@ -1,0 +1,122 @@
+package provider
+
+import (
+	"io"
+	"sync"
+	"time"
+)
+
+// WatchdogConfig configures the stream idle watchdog timers.
+type WatchdogConfig struct {
+	// WarnAfter is the idle duration before onWarn fires. Defaults to 45s if zero.
+	WarnAfter time.Duration
+	// KillAfter is the idle duration before the stream is aborted. Defaults to 90s if zero.
+	KillAfter time.Duration
+}
+
+func (c WatchdogConfig) warnAfter() time.Duration {
+	if c.WarnAfter <= 0 {
+		return 45 * time.Second
+	}
+	return c.WarnAfter
+}
+
+func (c WatchdogConfig) killAfter() time.Duration {
+	if c.KillAfter <= 0 {
+		return 90 * time.Second
+	}
+	return c.KillAfter
+}
+
+// WatchBody wraps body with an idle watchdog. If no bytes arrive for
+// cfg.KillAfter, the underlying body is closed and the returned reader
+// yields an ErrStreamError. If no bytes arrive for cfg.WarnAfter, onWarn
+// fires (purely informational — the stream continues).
+//
+// Both timers reset on any read activity. Callers must use the returned
+// io.ReadCloser in place of body; closing it cancels the watchdog.
+func WatchBody(body io.ReadCloser, cfg WatchdogConfig, onWarn, onKill func()) io.ReadCloser {
+	pr, pw := io.Pipe()
+	activity := make(chan struct{}, 1)
+	done := make(chan struct{})
+	var once sync.Once
+	stop := func() { once.Do(func() { close(done) }) }
+
+	// Pump: copy body -> pipe, signal activity on each read.
+	go func() {
+		defer stop()
+		buf := make([]byte, 32*1024)
+		for {
+			n, rerr := body.Read(buf)
+			if n > 0 {
+				select {
+				case activity <- struct{}{}:
+				default:
+				}
+				if _, werr := pw.Write(buf[:n]); werr != nil {
+					_ = body.Close()
+					return
+				}
+			}
+			if rerr != nil {
+				if rerr == io.EOF {
+					_ = pw.Close()
+				} else {
+					_ = pw.CloseWithError(rerr)
+				}
+				return
+			}
+		}
+	}()
+
+	// Watchdog: timers reset on activity; fire onWarn / onKill on idle.
+	go func() {
+		warnTimer := time.NewTimer(cfg.warnAfter())
+		killTimer := time.NewTimer(cfg.killAfter())
+		defer warnTimer.Stop()
+		defer killTimer.Stop()
+		warnFired := false
+		for {
+			select {
+			case <-done:
+				return
+			case <-activity:
+				// Drain+reset both timers.
+				if !warnTimer.Stop() {
+					select {
+					case <-warnTimer.C:
+					default:
+					}
+				}
+				if !killTimer.Stop() {
+					select {
+					case <-killTimer.C:
+					default:
+					}
+				}
+				warnTimer.Reset(cfg.warnAfter())
+				killTimer.Reset(cfg.killAfter())
+				warnFired = false
+			case <-warnTimer.C:
+				if !warnFired && onWarn != nil {
+					onWarn()
+					warnFired = true
+				}
+			case <-killTimer.C:
+				if onKill != nil {
+					onKill()
+				}
+				_ = body.Close()
+				stallErr := &ProviderError{
+					Kind:      ErrStreamError,
+					Message:   "stream stalled: no data for " + cfg.killAfter().String(),
+					Retryable: true,
+				}
+				_ = pw.CloseWithError(stallErr)
+				return
+			}
+		}
+	}()
+
+	return pr
+}

--- a/internal/provider/streamwatchdog.go
+++ b/internal/provider/streamwatchdog.go
@@ -45,7 +45,7 @@ func WatchBody(body io.ReadCloser, cfg WatchdogConfig, onWarn, onKill func()) io
 	// Pump: copy body -> pipe, signal activity on each read.
 	go func() {
 		defer stop()
-		buf := make([]byte, 32*1024)
+		buf := make([]byte, 4*1024)
 		for {
 			n, rerr := body.Read(buf)
 			if n > 0 {
@@ -81,19 +81,9 @@ func WatchBody(body io.ReadCloser, cfg WatchdogConfig, onWarn, onKill func()) io
 			case <-done:
 				return
 			case <-activity:
-				// Drain+reset both timers.
-				if !warnTimer.Stop() {
-					select {
-					case <-warnTimer.C:
-					default:
-					}
-				}
-				if !killTimer.Stop() {
-					select {
-					case <-killTimer.C:
-					default:
-					}
-				}
+				// Go 1.23+ semantics: Stop then Reset is safe without draining C.
+				warnTimer.Stop()
+				killTimer.Stop()
 				warnTimer.Reset(cfg.warnAfter())
 				killTimer.Reset(cfg.killAfter())
 				warnFired = false
@@ -108,9 +98,8 @@ func WatchBody(body io.ReadCloser, cfg WatchdogConfig, onWarn, onKill func()) io
 				}
 				_ = body.Close()
 				stallErr := &ProviderError{
-					Kind:      ErrStreamError,
-					Message:   "stream stalled: no data for " + cfg.killAfter().String(),
-					Retryable: true,
+					Kind:    ErrStreamError,
+					Message: "stream stalled: no data for " + cfg.killAfter().String(),
 				}
 				_ = pw.CloseWithError(stallErr)
 				return

--- a/internal/provider/streamwatchdog_test.go
+++ b/internal/provider/streamwatchdog_test.go
@@ -1,0 +1,115 @@
+package provider_test
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWatchBody_KillsStaleStream(t *testing.T) {
+	// Source writes one byte then hangs forever.
+	pr, pw := io.Pipe()
+	go func() {
+		_, _ = pw.Write([]byte("x"))
+		// Never write again, never close — simulates a stalled TCP connection.
+		time.Sleep(2 * time.Second) // longer than the test's kill timer
+		pw.Close()
+	}()
+
+	cfg := provider.WatchdogConfig{
+		WarnAfter: 40 * time.Millisecond,
+		KillAfter: 100 * time.Millisecond,
+	}
+	warned := make(chan struct{}, 1)
+	killed := make(chan struct{}, 1)
+	onWarn := func() {
+		select {
+		case warned <- struct{}{}:
+		default:
+		}
+	}
+	onKill := func() {
+		select {
+		case killed <- struct{}{}:
+		default:
+		}
+	}
+
+	watched := provider.WatchBody(pr, cfg, onWarn, onKill)
+	defer watched.Close()
+
+	// Read the one byte that came through.
+	buf := make([]byte, 1)
+	n, err := watched.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	// Next read blocks, then returns ErrStreamError once the kill timer fires.
+	_, err = watched.Read(buf)
+	require.Error(t, err)
+
+	var pe *provider.ProviderError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, provider.ErrStreamError, pe.Kind)
+	assert.True(t, pe.IsRetryable())
+
+	// Both callbacks should have fired.
+	select {
+	case <-warned:
+	case <-time.After(500 * time.Millisecond):
+		t.Error("onWarn was not called")
+	}
+	select {
+	case <-killed:
+	case <-time.After(500 * time.Millisecond):
+		t.Error("onKill was not called")
+	}
+}
+
+func TestWatchBody_ActivityResetsTimers(t *testing.T) {
+	// Source writes a byte every 30ms for 200ms total — total time exceeds
+	// the 100ms kill timer, but activity keeps resetting it.
+	pr, pw := io.Pipe()
+	go func() {
+		defer pw.Close()
+		for i := 0; i < 6; i++ {
+			_, _ = pw.Write([]byte{byte('a' + i)})
+			time.Sleep(30 * time.Millisecond)
+		}
+	}()
+
+	cfg := provider.WatchdogConfig{
+		WarnAfter: 40 * time.Millisecond,
+		KillAfter: 100 * time.Millisecond,
+	}
+	watched := provider.WatchBody(pr, cfg, nil, nil)
+	defer watched.Close()
+
+	// Read all 6 bytes — should succeed without a stall.
+	got, err := io.ReadAll(watched)
+	require.NoError(t, err)
+	assert.Equal(t, "abcdef", string(got))
+}
+
+func TestWatchBody_PassesThroughClean(t *testing.T) {
+	pr, pw := io.Pipe()
+	go func() {
+		defer pw.Close()
+		_, _ = pw.Write([]byte("hello world"))
+	}()
+
+	cfg := provider.WatchdogConfig{
+		WarnAfter: 100 * time.Millisecond,
+		KillAfter: 500 * time.Millisecond,
+	}
+	watched := provider.WatchBody(pr, cfg, nil, nil)
+	defer watched.Close()
+
+	got, err := io.ReadAll(watched)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", string(got))
+}

--- a/internal/provider/zai/provider.go
+++ b/internal/provider/zai/provider.go
@@ -100,7 +100,7 @@ func (p *Provider) Stream(ctx context.Context, req provider.CompletionRequest) (
 	}
 
 	ch := make(chan provider.StreamEvent)
-	go ssecompat.ProcessSSE(ctx, resp.Body, ch)
+	go ssecompat.ProcessSSE(ctx, resp.Body, ch, "zai")
 
 	return ch, nil
 }

--- a/pkg/agentsdk/types.go
+++ b/pkg/agentsdk/types.go
@@ -162,14 +162,17 @@ func (t ToolUseBlock) MarshalJSON() ([]byte, error) {
 
 // StreamEvent represents a single event in a streaming response.
 type StreamEvent struct {
-	Type         string
-	Text         string
-	ToolUse      *ToolUseBlock
-	Error        error
-	InputTokens  int
-	OutputTokens int
-	Model        string // populated on message_start
-	MessageID    string // populated on message_start
+	Type                string
+	Text                string
+	ToolUse             *ToolUseBlock
+	Error               error
+	InputTokens         int
+	OutputTokens        int
+	CacheCreationTokens int    // tokens written to cache on this request (billed at higher rate)
+	CacheReadTokens     int    // tokens read from cache on this request (billed at lower rate)
+	StopReason          string // populated on stop events: "end_turn", "max_tokens", "tool_use", "stop_sequence"
+	Model               string // populated on message_start
+	MessageID           string // populated on message_start
 }
 
 func marshalSafeRawJSON(raw json.RawMessage) json.RawMessage {

--- a/pkg/agentsdk/types.go
+++ b/pkg/agentsdk/types.go
@@ -80,6 +80,15 @@ const (
 	EventError            = "error"
 )
 
+// Stop reason constants. Populated on StreamEvent.StopReason when the
+// provider signals how the model stopped generating.
+const (
+	StopReasonEndTurn      = "end_turn"
+	StopReasonMaxTokens    = "max_tokens"
+	StopReasonToolUse      = "tool_use"
+	StopReasonStopSequence = "stop_sequence"
+)
+
 // CompletionRequest represents a request to an LLM for completion.
 type CompletionRequest struct {
 	Model            string            `json:"model"`


### PR DESCRIPTION
## Summary

Closes eleven gaps between Claude Code's API layer design (Chapter 4) and Rubichan's `internal/provider/` + `internal/agent/` implementation. Thirteen commits organized into three dependency groups.

**Group A — Independent fixes:**
- Typed `ErrStreamError` at SSE scanner failure sites so `errors.As` routes to retry logic (`d85f2c9`, `63a893f`)
- `CacheCreationTokens` / `CacheReadTokens` / `StopReason` fields added to `StreamEvent`; Anthropic cache fields decoded from `message_start` (`1767c83`)
- `x-client-request-id` header injection + `ProviderError.RequestID` for timeout correlation (`54494d1`)
- Orphan `tool_use` repair on session load prevents 400 errors when resuming a session that died mid-turn (`a4a9494`)
- `summary_model` config field routes compaction/summarization to a cheaper model (`f8d6b03`)

**Group B — Streaming resilience:**
- Two-goroutine stream idle watchdog (45s warn / 90s kill) wired into both `anthropic` and `ssecompat` providers; kill emits a typed `ErrStreamError` through the existing scanner-error path (`43c99cb`)
- `TurnRetry` wrapper retries retryable `ProviderError` at the initial `Stream()` call (HTTP 429, 5xx, connection errors) (`662c526`)
- `message_delta` stop_reason decoding + warning log on `max_tokens` truncation (`963096c`)
- Standalone `(*Provider).NonStream` for proxy-corrupted SSE environments; produces a `StreamEvent` slice mirroring the streaming format (`2304d3a`)

**Group C — Cache architecture:**
- Loud `PromptBuilder` API: `AddCacheableSection(name, content)` and `AddDynamicSection_UNCACHED(name, content, reason)`. The suffix + mandatory reason parameter make cache-breaking decisions grep-findable and visible in code review. Five inline call sites converted (`7bd6419`)
- `sessionLatches` one-way ratchet freezes `NeedsToolDiscoveryHint` and `ReasoningEffort` at the first turn so mid-session capability changes cannot invalidate the ~50-70K-token session prompt cache (`31466a5`)

## Scoping reductions made during execution

Three tasks were reduced from their original plan descriptions after implementation revealed correctness issues:

1. **Turn retry** is scoped to initial-Stream errors only. Mid-stream retry would replay already-emitted text_deltas to the UI, creating a doubled-prefix bug.
2. **\`max_tokens\` handling** is detection + log only. Auto-retry with widened token cap has the same replay issue.
3. **NonStream** is a standalone method, not wired into TurnRetry. Integration needs a \`StreamFunc\` contract change worth its own task.

Deferred follow-ons:
- Wire \`NonStream\` into \`TurnRetry\` as a final-attempt fallback
- Extend typed error handling to the context-cancel and JSON-parse branches in \`ssecompat/processor.go\`
- Add \`SupportsNativeToolUse\` to \`sessionLatches\` if capability hot-reload ever ships

## Stats

25 files changed, +3305/-72 lines (~1,500 production, ~1,800 test). Three new abstractions (\`streamwatchdog.go\`, \`turnretry.go\`, \`sessionlatches.go\`) each with single-responsibility boundaries.

## Test plan

- [x] \`go test ./...\` green on full suite
- [x] \`go test ./... -race\` green (verified on agent package)
- [x] \`golangci-lint run\` clean on touched files (pre-existing warnings in unrelated files unchanged)
- [x] \`gofmt -l\` clean
- [ ] Manual smoke test against live Anthropic API (verify \`x-client-request-id\` appears in logs)
- [ ] Manual smoke test: interrupt a long-running session and resume to confirm orphan repair fires
- [ ] Manual verification: set \`summary_model = "claude-haiku-4-5-20251001"\` in config and observe summarization routing

Implementation plan: \`docs/superpowers/plans/2026-04-13-api-layer-improvements.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable summary model per provider (falls back to main model).
  * Non-stream fallback for one provider to return full responses when streaming is unavailable.
  * Turn-level retry with exponential backoff and idle-stream watchdog to improve streaming resilience.
  * Expose cache token counts and explicit stop-reason metadata in stream events.
  * Session latching to stabilize capability/config choices during a session.

* **Bug Fixes**
  * Session load now repairs missing tool results from persisted conversations.

* **Documentation**
  * Added an API-layer improvement plan.

* **Tests**
  * Expanded unit tests covering retries, watchdog, prompt cache behavior, and session recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->