### PR TITLE
Platform CLI fallback clients (gh/glab) — plan PR 4

### DIFF
--- a/internal/platform/cli_exec.go
+++ b/internal/platform/cli_exec.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// ExecFunc is the signature CLI-backed Platform clients use to invoke
+// external binaries (`gh`, `glab`). Tests inject a fake. stdin is optional
+// (nil when the command takes no input).
+type ExecFunc func(ctx context.Context, stdin []byte, name string, args ...string) ([]byte, error)
+
+// defaultExec runs name with args, piping stdin if non-nil, and returns
+// the combined stdout. On failure, stderr is wrapped into the error so
+// callers surface actionable CLI diagnostics.
+func defaultExec(ctx context.Context, stdin []byte, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%s %v: %w (stderr: %s)",
+			name, args, err, bytes.TrimSpace(stderr.Bytes()))
+	}
+	return stdout.Bytes(), nil
+}

--- a/internal/platform/cli_github.go
+++ b/internal/platform/cli_github.go
@@ -1,0 +1,140 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ghReviewComment mirrors the GitHub reviews API comment shape.
+// Exported via JSON struct tags only — consumers build Review values.
+type ghReviewComment struct {
+	Path string `json:"path"`
+	Line int    `json:"line"`
+	Body string `json:"body"`
+	Side string `json:"side"`
+}
+
+type ghReviewPayload struct {
+	Body     string            `json:"body"`
+	Event    string            `json:"event"`
+	Comments []ghReviewComment `json:"comments"`
+}
+
+// CLIGitHubClient implements Platform by shelling out to the `gh` CLI.
+// Used as a fallback when no GITHUB_TOKEN is present but `gh` is installed
+// locally (typically authenticated via `gh auth login`).
+type CLIGitHubClient struct {
+	execFn ExecFunc
+}
+
+// NewCLIGitHubClient returns a CLI-backed GitHub platform client that invokes
+// the real `gh` binary. For tests, use NewCLIGitHubClientWithExec to inject
+// a fake exec function.
+func NewCLIGitHubClient() *CLIGitHubClient {
+	return &CLIGitHubClient{execFn: defaultExec}
+}
+
+// NewCLIGitHubClientWithExec returns a client that calls the provided exec
+// function instead of spawning a real process. Intended for tests.
+func NewCLIGitHubClientWithExec(execFn ExecFunc) *CLIGitHubClient {
+	return &CLIGitHubClient{execFn: execFn}
+}
+
+func (c *CLIGitHubClient) Name() string { return "github" }
+
+func (c *CLIGitHubClient) PostPRComment(ctx context.Context, repo string, prNum int, body string) error {
+	path := fmt.Sprintf("repos/%s/issues/%d/comments", repo, prNum)
+	_, err := c.execFn(ctx, nil,
+		"gh", "api", path, "-X", "POST", "-f", "body="+body)
+	if err != nil {
+		return fmt.Errorf("gh api: posting PR comment: %w", err)
+	}
+	return nil
+}
+
+func (c *CLIGitHubClient) PostPRReview(ctx context.Context, repo string, prNum int, review Review) error {
+	payload := ghReviewPayload{
+		Body:     review.Body,
+		Event:    review.Event,
+		Comments: make([]ghReviewComment, len(review.Comments)),
+	}
+	for i, cmt := range review.Comments {
+		payload.Comments[i] = ghReviewComment{
+			Path: cmt.Path,
+			Line: cmt.Line,
+			Body: cmt.Body,
+			Side: cmt.Side,
+		}
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("gh api: encoding review: %w", err)
+	}
+
+	path := fmt.Sprintf("repos/%s/pulls/%d/reviews", repo, prNum)
+	_, err = c.execFn(ctx, body,
+		"gh", "api", path, "-X", "POST", "--input", "-")
+	if err != nil {
+		return fmt.Errorf("gh api: posting PR review: %w", err)
+	}
+	return nil
+}
+
+func (c *CLIGitHubClient) GetPRDiff(ctx context.Context, repo string, prNum int) (string, error) {
+	out, err := c.execFn(ctx, nil,
+		"gh", "pr", "diff", fmt.Sprintf("%d", prNum), "--repo", repo)
+	if err != nil {
+		return "", fmt.Errorf("gh pr diff: %w", err)
+	}
+	return string(out), nil
+}
+
+func (c *CLIGitHubClient) ListPRFiles(ctx context.Context, repo string, prNum int) ([]PRFile, error) {
+	// --paginate flattens all pages into a single JSON array, matching
+	// what the SDK client returns after its loop-and-append.
+	path := fmt.Sprintf("repos/%s/pulls/%d/files", repo, prNum)
+	out, err := c.execFn(ctx, nil,
+		"gh", "api", path, "--paginate")
+	if err != nil {
+		return nil, fmt.Errorf("gh api: listing PR files: %w", err)
+	}
+
+	var raw []struct {
+		Filename string `json:"filename"`
+		Status   string `json:"status"`
+		Patch    string `json:"patch"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("gh api: parsing PR files JSON: %w", err)
+	}
+	files := make([]PRFile, len(raw))
+	for i, r := range raw {
+		files[i] = PRFile{Filename: r.Filename, Status: r.Status, Patch: r.Patch}
+	}
+	return files, nil
+}
+
+func (c *CLIGitHubClient) UploadSARIF(ctx context.Context, repo string, commitSHA, ref string, sarif []byte) error {
+	// GitHub's code-scanning/sarifs endpoint expects the SARIF to arrive
+	// gzip-compressed and base64-encoded under the "sarif" JSON field.
+	encoded, err := gzipBase64(sarif)
+	if err != nil {
+		return fmt.Errorf("gh api: encoding SARIF: %w", err)
+	}
+	payload, err := json.Marshal(map[string]string{
+		"commit_sha": commitSHA,
+		"ref":        ref,
+		"sarif":      encoded,
+	})
+	if err != nil {
+		return fmt.Errorf("gh api: encoding SARIF payload: %w", err)
+	}
+	path := fmt.Sprintf("repos/%s/code-scanning/sarifs", repo)
+	_, err = c.execFn(ctx, payload,
+		"gh", "api", path, "-X", "POST", "--input", "-")
+	if err != nil {
+		return fmt.Errorf("gh api: uploading SARIF: %w", err)
+	}
+	return nil
+}

--- a/internal/platform/cli_github.go
+++ b/internal/platform/cli_github.go
@@ -44,9 +44,18 @@ func NewCLIGitHubClientWithExec(execFn ExecFunc) *CLIGitHubClient {
 func (c *CLIGitHubClient) Name() string { return "github" }
 
 func (c *CLIGitHubClient) PostPRComment(ctx context.Context, repo string, prNum int, body string) error {
+	// Use --input - with a JSON payload instead of -f body=... because:
+	//   1. `gh api -f body=@foo` treats "@foo" as a file read directive,
+	//      so any review comment starting with @ would silently corrupt.
+	//   2. Large comment bodies can exceed ARG_MAX on the command line.
+	// JSON on stdin sidesteps both.
+	payload, err := json.Marshal(map[string]string{"body": body})
+	if err != nil {
+		return fmt.Errorf("gh api: encoding comment body: %w", err)
+	}
 	path := fmt.Sprintf("repos/%s/issues/%d/comments", repo, prNum)
-	_, err := c.execFn(ctx, nil,
-		"gh", "api", path, "-X", "POST", "-f", "body="+body)
+	_, err = c.execFn(ctx, payload,
+		"gh", "api", path, "-X", "POST", "--input", "-")
 	if err != nil {
 		return fmt.Errorf("gh api: posting PR comment: %w", err)
 	}
@@ -91,26 +100,32 @@ func (c *CLIGitHubClient) GetPRDiff(ctx context.Context, repo string, prNum int)
 }
 
 func (c *CLIGitHubClient) ListPRFiles(ctx context.Context, repo string, prNum int) ([]PRFile, error) {
-	// --paginate flattens all pages into a single JSON array, matching
-	// what the SDK client returns after its loop-and-append.
+	// Important: `gh api --paginate` emits each page as its own JSON
+	// document concatenated without a delimiter — that's NOT a single
+	// valid JSON array and json.Unmarshal will reject it on any PR
+	// large enough to paginate. `--slurp` wraps the pages into an
+	// outer array, producing `[[page1...], [page2...]]` which we then
+	// flatten to a single []PRFile. See cli/cli#10459.
 	path := fmt.Sprintf("repos/%s/pulls/%d/files", repo, prNum)
 	out, err := c.execFn(ctx, nil,
-		"gh", "api", path, "--paginate")
+		"gh", "api", path, "--paginate", "--slurp")
 	if err != nil {
 		return nil, fmt.Errorf("gh api: listing PR files: %w", err)
 	}
 
-	var raw []struct {
+	var pages [][]struct {
 		Filename string `json:"filename"`
 		Status   string `json:"status"`
 		Patch    string `json:"patch"`
 	}
-	if err := json.Unmarshal(out, &raw); err != nil {
+	if err := json.Unmarshal(out, &pages); err != nil {
 		return nil, fmt.Errorf("gh api: parsing PR files JSON: %w", err)
 	}
-	files := make([]PRFile, len(raw))
-	for i, r := range raw {
-		files[i] = PRFile{Filename: r.Filename, Status: r.Status, Patch: r.Patch}
+	var files []PRFile
+	for _, page := range pages {
+		for _, r := range page {
+			files = append(files, PRFile{Filename: r.Filename, Status: r.Status, Patch: r.Patch})
+		}
 	}
 	return files, nil
 }

--- a/internal/platform/cli_github_test.go
+++ b/internal/platform/cli_github_test.go
@@ -1,0 +1,195 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCLIGitHubClientImplementsPlatform(t *testing.T) {
+	var _ Platform = (*CLIGitHubClient)(nil)
+}
+
+// recordedCall captures the arguments of a single exec invocation so
+// tests can inspect how the CLI client built the shell-out.
+type recordedCall struct {
+	Name  string
+	Args  []string
+	Stdin []byte
+}
+
+// fakeExec returns an ExecFunc that records every call it sees and
+// replies with the given stdout/err pair.
+func fakeExec(out []byte, err error, calls *[]recordedCall) ExecFunc {
+	return func(ctx context.Context, stdin []byte, name string, args ...string) ([]byte, error) {
+		*calls = append(*calls, recordedCall{Name: name, Args: append([]string(nil), args...), Stdin: append([]byte(nil), stdin...)})
+		return out, err
+	}
+}
+
+func TestCLIGitHubPostPRComment(t *testing.T) {
+	var calls []recordedCall
+	c := NewCLIGitHubClientWithExec(fakeExec([]byte(`{"id":1}`), nil, &calls))
+
+	err := c.PostPRComment(context.Background(), "octo/hello", 42, "looks good")
+	require.NoError(t, err)
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, "gh", calls[0].Name)
+
+	// Must invoke `gh api repos/octo/hello/issues/42/comments` with
+	// method POST and the body as a form field.
+	joined := strings.Join(calls[0].Args, " ")
+	assert.Contains(t, joined, "api")
+	assert.Contains(t, joined, "repos/octo/hello/issues/42/comments")
+	assert.Contains(t, joined, "-X")
+	assert.Contains(t, joined, "POST")
+	assert.Contains(t, joined, "-f")
+	assert.Contains(t, joined, "body=looks good")
+}
+
+func TestCLIGitHubPostPRReview(t *testing.T) {
+	var calls []recordedCall
+	c := NewCLIGitHubClientWithExec(fakeExec([]byte(`{"id":100}`), nil, &calls))
+
+	review := Review{
+		Body:  "Found 2 issues",
+		Event: EventComment,
+		Comments: []ReviewComment{
+			{Path: "main.go", Line: 42, Body: "nil check missing", Side: SideRight},
+			{Path: "util.go", Line: 7, Body: "extract helper", Side: SideRight},
+		},
+	}
+	err := c.PostPRReview(context.Background(), "octo/hello", 5, review)
+	require.NoError(t, err)
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, "gh", calls[0].Name)
+	joined := strings.Join(calls[0].Args, " ")
+	assert.Contains(t, joined, "api")
+	assert.Contains(t, joined, "repos/octo/hello/pulls/5/reviews")
+	assert.Contains(t, joined, "--input")
+	assert.Contains(t, joined, "-") // stdin marker
+
+	// The review body must arrive as JSON on stdin with fields the GitHub
+	// reviews API expects: body, event, comments[].{path,line,body,side}.
+	require.NotEmpty(t, calls[0].Stdin, "review JSON must be passed via stdin")
+	var payload struct {
+		Body     string `json:"body"`
+		Event    string `json:"event"`
+		Comments []struct {
+			Path string `json:"path"`
+			Line int    `json:"line"`
+			Body string `json:"body"`
+			Side string `json:"side"`
+		} `json:"comments"`
+	}
+	require.NoError(t, json.Unmarshal(calls[0].Stdin, &payload))
+	assert.Equal(t, "Found 2 issues", payload.Body)
+	assert.Equal(t, EventComment, payload.Event)
+	require.Len(t, payload.Comments, 2)
+	assert.Equal(t, "main.go", payload.Comments[0].Path)
+	assert.Equal(t, 42, payload.Comments[0].Line)
+	assert.Equal(t, "nil check missing", payload.Comments[0].Body)
+	assert.Equal(t, SideRight, payload.Comments[0].Side)
+}
+
+func TestCLIGitHubGetPRDiff(t *testing.T) {
+	diff := `diff --git a/main.go b/main.go
+index abc..def 100644
+--- a/main.go
++++ b/main.go
+@@ -1 +1 @@
+-old
++new
+`
+	var calls []recordedCall
+	c := NewCLIGitHubClientWithExec(fakeExec([]byte(diff), nil, &calls))
+
+	got, err := c.GetPRDiff(context.Background(), "octo/hello", 17)
+	require.NoError(t, err)
+	assert.Equal(t, diff, got)
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, "gh", calls[0].Name)
+	joined := strings.Join(calls[0].Args, " ")
+	// `gh pr diff 17 --repo octo/hello` is the documented invocation.
+	assert.Contains(t, joined, "pr")
+	assert.Contains(t, joined, "diff")
+	assert.Contains(t, joined, "17")
+	assert.Contains(t, joined, "--repo")
+	assert.Contains(t, joined, "octo/hello")
+}
+
+func TestCLIGitHubListPRFiles(t *testing.T) {
+	jsonBody := `[
+		{"filename":"a.go","status":"modified","patch":"@@ -1 +1 @@\n-a\n+A"},
+		{"filename":"b.go","status":"added","patch":""}
+	]`
+	var calls []recordedCall
+	c := NewCLIGitHubClientWithExec(fakeExec([]byte(jsonBody), nil, &calls))
+
+	files, err := c.ListPRFiles(context.Background(), "octo/hello", 3)
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+	assert.Equal(t, "a.go", files[0].Filename)
+	assert.Equal(t, "modified", files[0].Status)
+	assert.Equal(t, "b.go", files[1].Filename)
+	assert.Equal(t, "added", files[1].Status)
+
+	require.Len(t, calls, 1)
+	joined := strings.Join(calls[0].Args, " ")
+	assert.Contains(t, joined, "repos/octo/hello/pulls/3/files")
+	assert.Contains(t, joined, "--paginate",
+		"CLI client must request pagination so large PRs return fully")
+}
+
+func TestCLIGitHubUploadSARIF(t *testing.T) {
+	var calls []recordedCall
+	c := NewCLIGitHubClientWithExec(fakeExec([]byte(`{"id":"abc"}`), nil, &calls))
+
+	sarif := []byte(`{"version":"2.1.0","runs":[]}`)
+	err := c.UploadSARIF(context.Background(), "octo/hello", "deadbeef", "refs/heads/main", sarif)
+	require.NoError(t, err)
+
+	require.Len(t, calls, 1)
+	joined := strings.Join(calls[0].Args, " ")
+	assert.Contains(t, joined, "repos/octo/hello/code-scanning/sarifs")
+	assert.Contains(t, joined, "--input")
+
+	// Stdin must be a JSON object with commit_sha, ref and a
+	// gzip+base64 encoded sarif body.
+	var payload struct {
+		CommitSHA string `json:"commit_sha"`
+		Ref       string `json:"ref"`
+		Sarif     string `json:"sarif"`
+	}
+	require.NoError(t, json.Unmarshal(calls[0].Stdin, &payload))
+	assert.Equal(t, "deadbeef", payload.CommitSHA)
+	assert.Equal(t, "refs/heads/main", payload.Ref)
+	assert.NotEmpty(t, payload.Sarif, "SARIF body must be encoded and sent")
+	assert.NotEqual(t, string(sarif), payload.Sarif,
+		"SARIF body must be gzip+base64 encoded, not raw")
+}
+
+// Exec errors from the underlying CLI (nonzero exit, parse failures,
+// auth failures) must propagate to the caller so the operator sees the
+// actual reason instead of a generic wrap.
+func TestCLIGitHubExecFailurePropagates(t *testing.T) {
+	execErr := errors.New("HTTP 403: Not Found (stderr: gh: 403 Forbidden)")
+	var calls []recordedCall
+	c := NewCLIGitHubClientWithExec(fakeExec(nil, execErr, &calls))
+
+	err := c.PostPRComment(context.Background(), "octo/hello", 1, "body")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, execErr,
+		"exec error must be wrapped with %%w so errors.Is finds it")
+	assert.Contains(t, err.Error(), "403 Forbidden",
+		"stderr context must be preserved end-to-end for operator diagnosis")
+	assert.Len(t, calls, 1, "client must attempt the exec even on failure")
+}

--- a/internal/platform/cli_github_test.go
+++ b/internal/platform/cli_github_test.go
@@ -36,21 +36,32 @@ func TestCLIGitHubPostPRComment(t *testing.T) {
 	var calls []recordedCall
 	c := NewCLIGitHubClientWithExec(fakeExec([]byte(`{"id":1}`), nil, &calls))
 
-	err := c.PostPRComment(context.Background(), "octo/hello", 42, "looks good")
+	// Include a body that starts with @ to lock in the `-f body=@foo`
+	// file-read regression: if the client ever reverts to -f the
+	// assertion below fails because the stdin payload won't contain
+	// the literal text.
+	body := "@please-do-not-read-a-file\nlooks good"
+	err := c.PostPRComment(context.Background(), "octo/hello", 42, body)
 	require.NoError(t, err)
 
 	require.Len(t, calls, 1)
 	assert.Equal(t, "gh", calls[0].Name)
 
-	// Must invoke `gh api repos/octo/hello/issues/42/comments` with
-	// method POST and the body as a form field.
 	joined := strings.Join(calls[0].Args, " ")
 	assert.Contains(t, joined, "api")
 	assert.Contains(t, joined, "repos/octo/hello/issues/42/comments")
 	assert.Contains(t, joined, "-X")
 	assert.Contains(t, joined, "POST")
-	assert.Contains(t, joined, "-f")
-	assert.Contains(t, joined, "body=looks good")
+	// Body must travel via --input - (JSON on stdin), not -f body=...
+	assert.Contains(t, joined, "--input")
+	assert.NotContains(t, joined, "-f",
+		"-f is unsafe for bodies starting with @ and can hit ARG_MAX")
+
+	var payload struct {
+		Body string `json:"body"`
+	}
+	require.NoError(t, json.Unmarshal(calls[0].Stdin, &payload))
+	assert.Equal(t, body, payload.Body)
 }
 
 func TestCLIGitHubPostPRReview(t *testing.T) {
@@ -127,26 +138,38 @@ index abc..def 100644
 }
 
 func TestCLIGitHubListPRFiles(t *testing.T) {
+	// `gh api --paginate --slurp` wraps pages in an outer array.
+	// This fixture emulates two pages worth of files to prove the
+	// flatten step actually runs.
 	jsonBody := `[
-		{"filename":"a.go","status":"modified","patch":"@@ -1 +1 @@\n-a\n+A"},
-		{"filename":"b.go","status":"added","patch":""}
+		[
+			{"filename":"a.go","status":"modified","patch":"@@ -1 +1 @@\n-a\n+A"},
+			{"filename":"b.go","status":"added","patch":""}
+		],
+		[
+			{"filename":"c.go","status":"removed","patch":""}
+		]
 	]`
 	var calls []recordedCall
 	c := NewCLIGitHubClientWithExec(fakeExec([]byte(jsonBody), nil, &calls))
 
 	files, err := c.ListPRFiles(context.Background(), "octo/hello", 3)
 	require.NoError(t, err)
-	require.Len(t, files, 2)
+	require.Len(t, files, 3, "pages must be flattened into a single slice")
 	assert.Equal(t, "a.go", files[0].Filename)
 	assert.Equal(t, "modified", files[0].Status)
 	assert.Equal(t, "b.go", files[1].Filename)
 	assert.Equal(t, "added", files[1].Status)
+	assert.Equal(t, "c.go", files[2].Filename)
+	assert.Equal(t, "removed", files[2].Status)
 
 	require.Len(t, calls, 1)
 	joined := strings.Join(calls[0].Args, " ")
 	assert.Contains(t, joined, "repos/octo/hello/pulls/3/files")
 	assert.Contains(t, joined, "--paginate",
 		"CLI client must request pagination so large PRs return fully")
+	assert.Contains(t, joined, "--slurp",
+		"--slurp is required; without it gh emits concatenated per-page JSON that json.Unmarshal rejects")
 }
 
 func TestCLIGitHubUploadSARIF(t *testing.T) {

--- a/internal/platform/cli_gitlab.go
+++ b/internal/platform/cli_gitlab.go
@@ -36,21 +36,28 @@ func NewCLIGitLabClientWithExec(execFn ExecFunc) *CLIGitLabClient {
 func (c *CLIGitLabClient) Name() string { return "gitlab" }
 
 func (c *CLIGitLabClient) PostPRComment(ctx context.Context, repo string, prNum int, body string) error {
+	// Use --input - with a JSON payload rather than -f body=...:
+	//   1. `glab api -f body=@foo` treats @foo as a file read directive.
+	//   2. Large comment bodies can exceed ARG_MAX on the command line.
+	payload, err := json.Marshal(map[string]string{"body": body})
+	if err != nil {
+		return fmt.Errorf("glab api: encoding comment body: %w", err)
+	}
 	path := fmt.Sprintf("projects/%s/merge_requests/%d/notes", glProjectPath(repo), prNum)
-	_, err := c.execFn(ctx, nil,
-		"glab", "api", path, "-X", "POST", "-f", "body="+body)
+	_, err = c.execFn(ctx, payload,
+		"glab", "api", path, "-X", "POST", "--input", "-")
 	if err != nil {
 		return fmt.Errorf("glab api: posting MR note: %w", err)
 	}
 	return nil
 }
 
-// PostPRReview emits the review body as a single MR note and appends each
-// inline comment as an additional note, prefixed with its file/line
-// location. GitLab's Discussions API requires a PositionOptions object
-// with diff SHAs that the CLI cannot easily supply without an additional
-// round-trip; the fallback keeps the information visible without
-// attempting to map it onto diff hunks.
+// PostPRReview emits a single MR note that contains the review body
+// followed by every inline comment fragment, each prefixed with its
+// file/line location. GitLab's Discussions API would allow true inline
+// comments but requires a PositionOptions object with diff SHAs the
+// CLI cannot cheaply supply; this fallback keeps the information
+// visible in one note without mapping it onto diff hunks.
 func (c *CLIGitLabClient) PostPRReview(ctx context.Context, repo string, prNum int, review Review) error {
 	var sb strings.Builder
 	sb.WriteString(review.Body)

--- a/internal/platform/cli_gitlab.go
+++ b/internal/platform/cli_gitlab.go
@@ -1,0 +1,115 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// glProjectPath URL-encodes a "group/project" path for the GitLab REST
+// API, which requires the project to appear as a single encoded segment.
+func glProjectPath(repo string) string {
+	return url.PathEscape(repo)
+}
+
+// CLIGitLabClient implements Platform by shelling out to the `glab` CLI.
+// Used as a fallback when no GITLAB_TOKEN is present but `glab` is
+// installed locally (typically authenticated via `glab auth login`).
+type CLIGitLabClient struct {
+	execFn ExecFunc
+}
+
+// NewCLIGitLabClient returns a CLI-backed GitLab platform client that
+// invokes the real `glab` binary. For tests, use NewCLIGitLabClientWithExec.
+func NewCLIGitLabClient() *CLIGitLabClient {
+	return &CLIGitLabClient{execFn: defaultExec}
+}
+
+// NewCLIGitLabClientWithExec returns a client that calls the provided exec
+// function instead of spawning a real process. Intended for tests.
+func NewCLIGitLabClientWithExec(execFn ExecFunc) *CLIGitLabClient {
+	return &CLIGitLabClient{execFn: execFn}
+}
+
+func (c *CLIGitLabClient) Name() string { return "gitlab" }
+
+func (c *CLIGitLabClient) PostPRComment(ctx context.Context, repo string, prNum int, body string) error {
+	path := fmt.Sprintf("projects/%s/merge_requests/%d/notes", glProjectPath(repo), prNum)
+	_, err := c.execFn(ctx, nil,
+		"glab", "api", path, "-X", "POST", "-f", "body="+body)
+	if err != nil {
+		return fmt.Errorf("glab api: posting MR note: %w", err)
+	}
+	return nil
+}
+
+// PostPRReview emits the review body as a single MR note and appends each
+// inline comment as an additional note, prefixed with its file/line
+// location. GitLab's Discussions API requires a PositionOptions object
+// with diff SHAs that the CLI cannot easily supply without an additional
+// round-trip; the fallback keeps the information visible without
+// attempting to map it onto diff hunks.
+func (c *CLIGitLabClient) PostPRReview(ctx context.Context, repo string, prNum int, review Review) error {
+	var sb strings.Builder
+	sb.WriteString(review.Body)
+	for _, cmt := range review.Comments {
+		sb.WriteString(fmt.Sprintf("\n\n**%s:%d**: %s", cmt.Path, cmt.Line, cmt.Body))
+	}
+	return c.PostPRComment(ctx, repo, prNum, sb.String())
+}
+
+func (c *CLIGitLabClient) GetPRDiff(ctx context.Context, repo string, prNum int) (string, error) {
+	out, err := c.execFn(ctx, nil,
+		"glab", "mr", "diff", fmt.Sprintf("%d", prNum), "--repo", repo)
+	if err != nil {
+		return "", fmt.Errorf("glab mr diff: %w", err)
+	}
+	return string(out), nil
+}
+
+func (c *CLIGitLabClient) ListPRFiles(ctx context.Context, repo string, prNum int) ([]PRFile, error) {
+	// The `changes` endpoint returns the MR with a "changes" array whose
+	// entries carry new_path, new_file/deleted_file/renamed_file flags,
+	// and the raw "diff" text.
+	path := fmt.Sprintf("projects/%s/merge_requests/%d/changes", glProjectPath(repo), prNum)
+	out, err := c.execFn(ctx, nil, "glab", "api", path)
+	if err != nil {
+		return nil, fmt.Errorf("glab api: listing MR changes: %w", err)
+	}
+
+	var resp struct {
+		Changes []struct {
+			NewPath     string `json:"new_path"`
+			NewFile     bool   `json:"new_file"`
+			DeletedFile bool   `json:"deleted_file"`
+			RenamedFile bool   `json:"renamed_file"`
+			Diff        string `json:"diff"`
+		} `json:"changes"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, fmt.Errorf("glab api: parsing MR changes: %w", err)
+	}
+	files := make([]PRFile, 0, len(resp.Changes))
+	for _, ch := range resp.Changes {
+		status := FileStatusModified
+		switch {
+		case ch.NewFile:
+			status = FileStatusAdded
+		case ch.DeletedFile:
+			status = FileStatusRemoved
+		}
+		files = append(files, PRFile{
+			Filename: ch.NewPath,
+			Status:   status,
+			Patch:    ch.Diff,
+		})
+	}
+	return files, nil
+}
+
+func (c *CLIGitLabClient) UploadSARIF(ctx context.Context, repo string, commitSHA, ref string, sarif []byte) error {
+	// GitLab ingests SARIF via CI artifact, not API. No-op.
+	return nil
+}

--- a/internal/platform/cli_gitlab_test.go
+++ b/internal/platform/cli_gitlab_test.go
@@ -1,0 +1,115 @@
+package platform
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCLIGitLabClientImplementsPlatform(t *testing.T) {
+	var _ Platform = (*CLIGitLabClient)(nil)
+}
+
+func TestCLIGitLabPostMRComment(t *testing.T) {
+	var calls []recordedCall
+	c := NewCLIGitLabClientWithExec(fakeExec([]byte(`{"id":7}`), nil, &calls))
+
+	err := c.PostPRComment(context.Background(), "grp/proj", 17, "looks good")
+	require.NoError(t, err)
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, "glab", calls[0].Name)
+
+	joined := strings.Join(calls[0].Args, " ")
+	assert.Contains(t, joined, "api")
+	// The GitLab REST API requires the project path to be URL-encoded.
+	// group/proj → group%2Fproj.
+	assert.Contains(t, joined, "projects/grp%2Fproj/merge_requests/17/notes")
+	assert.Contains(t, joined, "-X")
+	assert.Contains(t, joined, "POST")
+	assert.Contains(t, joined, "-f")
+	assert.Contains(t, joined, "body=looks good")
+}
+
+func TestCLIGitLabGetMRDiff(t *testing.T) {
+	diff := "diff --git a/x b/x\n"
+	var calls []recordedCall
+	c := NewCLIGitLabClientWithExec(fakeExec([]byte(diff), nil, &calls))
+
+	got, err := c.GetPRDiff(context.Background(), "grp/proj", 9)
+	require.NoError(t, err)
+	assert.Equal(t, diff, got)
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, "glab", calls[0].Name)
+	joined := strings.Join(calls[0].Args, " ")
+	assert.Contains(t, joined, "mr")
+	assert.Contains(t, joined, "diff")
+	assert.Contains(t, joined, "9")
+	assert.Contains(t, joined, "--repo")
+	assert.Contains(t, joined, "grp/proj")
+}
+
+func TestCLIGitLabListMRFiles(t *testing.T) {
+	body := `{
+		"changes": [
+			{"new_path":"a.go","new_file":false,"deleted_file":false,"renamed_file":false,"diff":"@@ -1 +1 @@\n-a\n+A"},
+			{"new_path":"b.go","new_file":true,"diff":""},
+			{"new_path":"c.go","deleted_file":true,"diff":""}
+		]
+	}`
+	var calls []recordedCall
+	c := NewCLIGitLabClientWithExec(fakeExec([]byte(body), nil, &calls))
+
+	files, err := c.ListPRFiles(context.Background(), "grp/proj", 4)
+	require.NoError(t, err)
+	require.Len(t, files, 3)
+	assert.Equal(t, "a.go", files[0].Filename)
+	assert.Equal(t, FileStatusModified, files[0].Status)
+	assert.Equal(t, FileStatusAdded, files[1].Status)
+	assert.Equal(t, FileStatusRemoved, files[2].Status)
+
+	require.Len(t, calls, 1)
+	joined := strings.Join(calls[0].Args, " ")
+	assert.Contains(t, joined, "projects/grp%2Fproj/merge_requests/4/changes")
+}
+
+// PostPRReview on GitLab collapses the review body + inline comments
+// into a single MR note, so tests must see the same shell-out pattern
+// as PostPRComment plus a body that contains every inline fragment.
+func TestCLIGitLabPostPRReviewFallsBackToSingleNote(t *testing.T) {
+	var calls []recordedCall
+	c := NewCLIGitLabClientWithExec(fakeExec([]byte(`{"id":42}`), nil, &calls))
+
+	review := Review{
+		Body: "Summary",
+		Comments: []ReviewComment{
+			{Path: "a.go", Line: 10, Body: "fix"},
+			{Path: "b.go", Line: 20, Body: "rename"},
+		},
+	}
+	require.NoError(t, c.PostPRReview(context.Background(), "grp/proj", 6, review))
+
+	require.Len(t, calls, 1)
+	joined := strings.Join(calls[0].Args, " ")
+	assert.Contains(t, joined, "projects/grp%2Fproj/merge_requests/6/notes")
+	// The note body should contain the summary plus each inline snippet.
+	assert.Contains(t, joined, "body=Summary")
+	assert.Contains(t, joined, "a.go:10")
+	assert.Contains(t, joined, "b.go:20")
+}
+
+func TestCLIGitLabUploadSARIFIsNoOp(t *testing.T) {
+	// GitLab ingests SARIF as a CI artifact, not via API. The CLI
+	// fallback must mirror the SDK's no-op behavior so downstream
+	// callers can use either interchangeably.
+	var calls []recordedCall
+	c := NewCLIGitLabClientWithExec(fakeExec(nil, nil, &calls))
+
+	err := c.UploadSARIF(context.Background(), "grp/proj", "sha", "ref", []byte(`{}`))
+	require.NoError(t, err)
+	assert.Len(t, calls, 0, "UploadSARIF must not shell out on GitLab")
+}

--- a/internal/platform/cli_gitlab_test.go
+++ b/internal/platform/cli_gitlab_test.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -17,7 +18,8 @@ func TestCLIGitLabPostMRComment(t *testing.T) {
 	var calls []recordedCall
 	c := NewCLIGitLabClientWithExec(fakeExec([]byte(`{"id":7}`), nil, &calls))
 
-	err := c.PostPRComment(context.Background(), "grp/proj", 17, "looks good")
+	body := "@file-read-guard\nlooks good"
+	err := c.PostPRComment(context.Background(), "grp/proj", 17, body)
 	require.NoError(t, err)
 
 	require.Len(t, calls, 1)
@@ -30,8 +32,15 @@ func TestCLIGitLabPostMRComment(t *testing.T) {
 	assert.Contains(t, joined, "projects/grp%2Fproj/merge_requests/17/notes")
 	assert.Contains(t, joined, "-X")
 	assert.Contains(t, joined, "POST")
-	assert.Contains(t, joined, "-f")
-	assert.Contains(t, joined, "body=looks good")
+	assert.Contains(t, joined, "--input")
+	assert.NotContains(t, joined, "-f",
+		"-f is unsafe for bodies starting with @ and can hit ARG_MAX")
+
+	var payload struct {
+		Body string `json:"body"`
+	}
+	require.NoError(t, json.Unmarshal(calls[0].Stdin, &payload))
+	assert.Equal(t, body, payload.Body)
 }
 
 func TestCLIGitLabGetMRDiff(t *testing.T) {
@@ -78,8 +87,8 @@ func TestCLIGitLabListMRFiles(t *testing.T) {
 }
 
 // PostPRReview on GitLab collapses the review body + inline comments
-// into a single MR note, so tests must see the same shell-out pattern
-// as PostPRComment plus a body that contains every inline fragment.
+// into a single MR note, so the note body travelling via stdin must
+// contain the summary plus every inline fragment.
 func TestCLIGitLabPostPRReviewFallsBackToSingleNote(t *testing.T) {
 	var calls []recordedCall
 	c := NewCLIGitLabClientWithExec(fakeExec([]byte(`{"id":42}`), nil, &calls))
@@ -96,10 +105,15 @@ func TestCLIGitLabPostPRReviewFallsBackToSingleNote(t *testing.T) {
 	require.Len(t, calls, 1)
 	joined := strings.Join(calls[0].Args, " ")
 	assert.Contains(t, joined, "projects/grp%2Fproj/merge_requests/6/notes")
-	// The note body should contain the summary plus each inline snippet.
-	assert.Contains(t, joined, "body=Summary")
-	assert.Contains(t, joined, "a.go:10")
-	assert.Contains(t, joined, "b.go:20")
+	assert.Contains(t, joined, "--input")
+
+	var payload struct {
+		Body string `json:"body"`
+	}
+	require.NoError(t, json.Unmarshal(calls[0].Stdin, &payload))
+	assert.Contains(t, payload.Body, "Summary")
+	assert.Contains(t, payload.Body, "a.go:10")
+	assert.Contains(t, payload.Body, "b.go:20")
 }
 
 func TestCLIGitLabUploadSARIFIsNoOp(t *testing.T) {

--- a/internal/platform/github.go
+++ b/internal/platform/github.go
@@ -156,10 +156,10 @@ func gzipBase64(data []byte) (string, error) {
 	var buf bytes.Buffer
 	gz := gzip.NewWriter(&buf)
 	if _, err := gz.Write(data); err != nil {
-		return "", err
+		return "", fmt.Errorf("gzip write: %w", err)
 	}
 	if err := gz.Close(); err != nil {
-		return "", err
+		return "", fmt.Errorf("gzip close: %w", err)
 	}
 	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -6,7 +6,16 @@ package platform
 import (
 	"context"
 	"fmt"
+	"os/exec"
 )
+
+// cliAvailable reports whether the given CLI binary is installed and
+// executable on PATH. Overridable by tests that must not depend on the
+// host having `gh` or `glab` present.
+var cliAvailable = func(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
 
 // Platform abstracts git hosting platform operations.
 type Platform interface {
@@ -83,19 +92,49 @@ type DetectedEnv struct {
 }
 
 // New creates a Platform client from the detected environment.
+//
+// Selection order:
+//  1. SDK-backed client when env.Token is set (preferred: type-safe,
+//     pagination, rate-limit handling).
+//  2. CLI-backed fallback when no token is present but the platform's
+//     CLI (`gh` or `glab`) is installed — those binaries authenticate
+//     via their own token caches (e.g. `gh auth login`).
+//  3. Descriptive error pointing at both options.
+//
 // Returns an error if env is nil or the platform is unsupported.
 func New(env *DetectedEnv) (Platform, error) {
 	if env == nil {
 		return nil, fmt.Errorf("no platform environment detected")
 	}
-	if env.Token == "" {
-		return nil, fmt.Errorf("no authentication token for %s; set GITHUB_TOKEN or GITLAB_TOKEN", env.PlatformName)
+
+	if env.Token != "" {
+		switch env.PlatformName {
+		case "github":
+			return NewGitHubClient(env.Token), nil
+		case "gitlab":
+			return NewGitLabClient(env.Token)
+		default:
+			return nil, fmt.Errorf("unsupported platform: %q", env.PlatformName)
+		}
 	}
+
+	// CLI fallback path: no token but the local binary may be able
+	// to authenticate on our behalf via its own token cache.
 	switch env.PlatformName {
 	case "github":
-		return NewGitHubClient(env.Token), nil
+		if cliAvailable("gh") {
+			return NewCLIGitHubClient(), nil
+		}
+		return nil, fmt.Errorf(
+			"GITHUB_TOKEN not set and 'gh' CLI not installed; " +
+				"set GITHUB_TOKEN or install gh (https://cli.github.com)")
 	case "gitlab":
-		return NewGitLabClient(env.Token)
+		if cliAvailable("glab") {
+			return NewCLIGitLabClient(), nil
+		}
+		return nil, fmt.Errorf(
+			"GITLAB_TOKEN not set and 'glab' CLI not installed; " +
+				"set GITLAB_TOKEN or install glab (https://gitlab.com/gitlab-org/cli)")
 	default:
 		return nil, fmt.Errorf("unsupported platform: %q", env.PlatformName)
 	}

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -128,6 +128,11 @@ func TestNewReturnsErrorForNilEnv(t *testing.T) {
 }
 
 func TestNewReturnsErrorForEmptyToken(t *testing.T) {
+	// Explicitly disable the CLI fallback so this test measures the
+	// "no token AND no CLI" path regardless of whether gh/glab are
+	// installed on the host running the tests.
+	withCLIAvailable(t, map[string]bool{"gh": false, "glab": false})
+
 	env := &DetectedEnv{
 		PlatformName: "github",
 		Token:        "",

--- a/internal/platform/select_test.go
+++ b/internal/platform/select_test.go
@@ -1,0 +1,85 @@
+package platform
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withCLIAvailable temporarily overrides the package-level cliAvailable
+// hook so selection tests don't depend on whether gh/glab are installed.
+// The override is reverted when the test completes.
+func withCLIAvailable(t *testing.T, present map[string]bool) {
+	t.Helper()
+	orig := cliAvailable
+	cliAvailable = func(name string) bool {
+		p, ok := present[name]
+		return ok && p
+	}
+	t.Cleanup(func() { cliAvailable = orig })
+}
+
+func TestCLIClientDetection_TokenAvailable(t *testing.T) {
+	// Even if the CLI is installed, an explicit token must prefer the SDK.
+	withCLIAvailable(t, map[string]bool{"gh": true})
+
+	env := &DetectedEnv{PlatformName: "github", Token: "ghp_test"}
+	p, err := New(env)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	_, ok := p.(*GitHubClient)
+	assert.True(t, ok, "SDK client must be preferred when token is present; got %T", p)
+}
+
+func TestCLIClientDetection_CLIAvailable_GitHub(t *testing.T) {
+	withCLIAvailable(t, map[string]bool{"gh": true})
+
+	env := &DetectedEnv{PlatformName: "github", Token: ""}
+	p, err := New(env)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	_, ok := p.(*CLIGitHubClient)
+	assert.True(t, ok, "CLI client must be selected when no token and gh is installed; got %T", p)
+}
+
+func TestCLIClientDetection_CLIAvailable_GitLab(t *testing.T) {
+	withCLIAvailable(t, map[string]bool{"glab": true})
+
+	env := &DetectedEnv{PlatformName: "gitlab", Token: ""}
+	p, err := New(env)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	_, ok := p.(*CLIGitLabClient)
+	assert.True(t, ok, "CLI client must be selected when no token and glab is installed; got %T", p)
+}
+
+func TestCLIClientDetection_NeitherAvailable_GitHub(t *testing.T) {
+	withCLIAvailable(t, map[string]bool{"gh": false})
+
+	env := &DetectedEnv{PlatformName: "github", Token: ""}
+	_, err := New(env)
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "GITHUB_TOKEN",
+		"error must mention the missing token")
+	assert.Contains(t, msg, "gh",
+		"error must mention the fallback CLI by name")
+	assert.True(t, strings.Contains(msg, "install") || strings.Contains(msg, "cli.github.com"),
+		"error must direct user to install instructions; got: %q", msg)
+}
+
+func TestCLIClientDetection_NeitherAvailable_GitLab(t *testing.T) {
+	withCLIAvailable(t, map[string]bool{"glab": false})
+
+	env := &DetectedEnv{PlatformName: "gitlab", Token: ""}
+	_, err := New(env)
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "GITLAB_TOKEN")
+	assert.Contains(t, msg, "glab")
+}

--- a/plan-git-platform-automation.md
+++ b/plan-git-platform-automation.md
@@ -316,16 +316,16 @@ GitLab equivalents use `glab api` with corresponding GitLab API paths.
 
 ### Tests
 
-- [ ] **4.01** `TestCLIGitHubClientImplementsPlatform` — `*CLIGitHubClient` satisfies `Platform`
-- [ ] **4.02** `TestCLIGitLabClientImplementsPlatform` — `*CLIGitLabClient` satisfies `Platform`
-- [ ] **4.03** `TestCLIGitHubPostPRComment` — Executes correct `gh api` command with args
-- [ ] **4.04** `TestCLIGitHubPostPRReview` — Passes review JSON to `gh api` via stdin
-- [ ] **4.05** `TestCLIGitHubGetPRDiff` — Parses `gh pr diff` output
-- [ ] **4.06** `TestCLIGitLabPostMRComment` — Executes correct `glab api` command
-- [ ] **4.07** `TestCLIClientDetection_TokenAvailable` — Returns SDK client when token present
-- [ ] **4.08** `TestCLIClientDetection_CLIAvailable` — Returns CLI client when no token but CLI installed
-- [ ] **4.09** `TestCLIClientDetection_NeitherAvailable` — Returns descriptive error with install instructions
-- [ ] **4.10** `TestCLIClientExecFailure` — CLI error propagated with stderr context
+- [x] **4.01** `TestCLIGitHubClientImplementsPlatform` — `*CLIGitHubClient` satisfies `Platform`
+- [x] **4.02** `TestCLIGitLabClientImplementsPlatform` — `*CLIGitLabClient` satisfies `Platform`
+- [x] **4.03** `TestCLIGitHubPostPRComment` — Executes correct `gh api` command with args
+- [x] **4.04** `TestCLIGitHubPostPRReview` — Passes review JSON to `gh api` via stdin
+- [x] **4.05** `TestCLIGitHubGetPRDiff` — Parses `gh pr diff` output
+- [x] **4.06** `TestCLIGitLabPostMRComment` — Executes correct `glab api` command
+- [x] **4.07** `TestCLIClientDetection_TokenAvailable` — Returns SDK client when token present
+- [x] **4.08** `TestCLIClientDetection_CLIAvailable_{GitHub,GitLab}` — Returns CLI client when no token but CLI installed
+- [x] **4.09** `TestCLIClientDetection_NeitherAvailable_{GitHub,GitLab}` — Returns descriptive error with install instructions
+- [x] **4.10** `TestCLIGitHubExecFailurePropagates` — CLI error propagated with stderr context via `%w`
 
 ### Implementation Notes
 


### PR DESCRIPTION
## Summary

Completes PR 4 of `plan-git-platform-automation.md`: CLI-backed `Platform`
implementations that shell out to `gh`/`glab` when no API token is available,
so `--post-to-pr` / `--upload-sarif` work in environments where the operator
has authenticated the CLI (e.g. `gh auth login`) but hasn't exported a
`GITHUB_TOKEN`.

Everything else in `plan-git-platform-automation.md` has already landed (SDK
clients, bridge, detect, CLI flags, example CI files). This was the last
missing piece.

## What's in it

| File | Purpose |
|---|---|
| `internal/platform/cli_exec.go` | `ExecFunc` abstraction + `defaultExec` that preserves stderr via `%w` |
| `internal/platform/cli_github.go` | `*CLIGitHubClient` — all 6 `Platform` methods via `gh api` / `gh pr diff` |
| `internal/platform/cli_gitlab.go` | `*CLIGitLabClient` — all 6 `Platform` methods via `glab api` / `glab mr diff`; `UploadSARIF` is a no-op (GitLab ingests SARIF as CI artifact, not via API) |
| `internal/platform/platform.go` | Selection refactor in `New()`: SDK → CLI → descriptive error |
| `cli_github_test.go` / `cli_gitlab_test.go` / `select_test.go` | 17 tests (10 from plan + 7 smoke for extras) |

## Selection logic

```
env.Token present                  → SDK client (preferred)
env.Token empty, binary on PATH    → CLI fallback client
env.Token empty, binary missing    → descriptive error with install link
```

The CLI-availability probe is a package-level `cliAvailable` hook so tests
don't depend on whether `gh`/`glab` are installed on the host running them.
`TestNewReturnsErrorForEmptyToken` is pinned to the "no CLI" branch to stay
deterministic.

## Design choices

- **Exec injection**: `NewCLIGitHubClientWithExec(execFn)` for tests,
  `NewCLIGitHubClient()` for production. Zero process spawns in the test
  suite — every test uses a fake exec that records `(name, args, stdin)`.
- **GitLab path encoding**: `url.PathEscape("group/proj")` →
  `group%2Fproj`, matching the GitLab REST API convention.
- **GitLab review fallback**: `PostPRReview` collapses to a single MR note
  with inline comments prefixed by `path:line`. The GitLab Discussions API
  requires diff position SHAs the CLI can't cheaply supply; the fallback
  keeps the information visible without lying about hunk positioning.
- **GitHub SARIF upload**: gzip+base64-encodes the body and posts it as a
  JSON payload via `gh api repos/{repo}/code-scanning/sarifs --input -`.
- **GitHub `ListPRFiles`**: uses `--paginate` so large PRs return fully in a
  single flattened JSON array, matching the SDK client's behavior.
- **Error preservation**: `%w`-wrapping means `errors.Is` finds the
  underlying exec error and the stderr context survives to the operator.

## Test plan

- [x] `go test ./internal/platform/...` — 17 new tests green, all
  pre-existing platform tests still green
- [x] `go vet ./internal/platform/...` — clean
- [x] `gofmt -l internal/platform/` — clean
- [x] `go test ./...` — only pre-existing `internal/tools/browser` DNS
  failures (unrelated sandbox issue)
- [ ] Manual end-to-end: run `rubichan --headless --mode=code-review
  --post-to-pr` in a repo with `gh auth login` but no `GITHUB_TOKEN`, verify
  comment lands
- [ ] Manual: same flow on GitLab with `glab auth login`

## Plan progress

`plan-git-platform-automation.md` PR 4 — all 10 checkboxes now `[x]`:
4.01–4.10 covering interface compliance, all 6 Platform methods across both
platforms, selection (SDK/CLI/neither), and exec error propagation.

https://claude.ai/code/session_01LsWMR4cLKRK695Q5e9itet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI-based fallback authentication for GitHub (`gh`) and GitLab (`glab`) when tokens are unavailable
  * Expanded GitHub/GitLab integration to support PR interactions through local CLI tools

* **Tests**
  * Added comprehensive test coverage for CLI client implementations and authentication selection logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->