### PR TITLE
Wire NonStream into TurnRetry as final-attempt fallback (#236 follow-on)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1279,6 +1279,16 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		}
 
 		retryCfg := TurnRetryConfig{} // use defaults: 3 attempts, 2s base delay, 30s max delay
+		// Providers that implement NonStreamer get a non-streaming
+		// fallback wired in automatically. TurnRetry only invokes it
+		// after all streaming attempts exhaust with retryable errors,
+		// so the common path still hits the streaming endpoint first.
+		if ns, ok := a.provider.(NonStreamer); ok {
+			reqCopy := req
+			retryCfg.NonStreamFallback = func(ctx context.Context) ([]provider.StreamEvent, error) {
+				return ns.NonStream(ctx, reqCopy)
+			}
+		}
 		onRetry := func(attempt int, delay time.Duration, cause error) {
 			a.emit(ctx, ch, TurnEvent{
 				Type:  "retrying",

--- a/internal/agent/turnretry.go
+++ b/internal/agent/turnretry.go
@@ -18,7 +18,20 @@ type TurnRetryConfig struct {
 	BaseDelay time.Duration
 	// MaxDelay caps the exponential backoff. Defaults to 30 seconds if zero.
 	MaxDelay time.Duration
+	// NonStreamFallback, if set, is called once after every streaming
+	// attempt has failed with a retryable error. Its event slice is
+	// replayed on a fresh channel that mirrors the streaming output,
+	// giving callers a way out of environments where SSE is corrupted
+	// end-to-end (proxies that strip or misframe chunks). Leave nil to
+	// keep the pure streaming behavior and surface the stream error.
+	NonStreamFallback NonStreamFunc
 }
+
+// NonStreamFunc builds a full response in a single non-streaming HTTP
+// call and returns the equivalent StreamEvent slice. TurnRetry invokes
+// this at most once, after all streaming attempts have failed with
+// retryable errors.
+type NonStreamFunc func(ctx context.Context) ([]provider.StreamEvent, error)
 
 func (c TurnRetryConfig) maxAttempts() int {
 	if c.MaxAttempts <= 0 {
@@ -45,6 +58,17 @@ func (c TurnRetryConfig) maxDelay() time.Duration {
 // TurnRetry calls this once per attempt.
 type StreamFunc func(ctx context.Context) (<-chan provider.StreamEvent, error)
 
+// NonStreamer is an optional interface providers may implement to expose
+// a non-streaming fallback call. The agent loop detects this via type
+// assertion and wires it into TurnRetryConfig.NonStreamFallback — only
+// providers that implement it get the fallback benefit, the rest keep
+// the pure streaming behavior. Today only *anthropic.Provider satisfies
+// this; adding it elsewhere is a matter of defining a NonStream method
+// with the same signature.
+type NonStreamer interface {
+	NonStream(ctx context.Context, req provider.CompletionRequest) ([]provider.StreamEvent, error)
+}
+
 // OnRetry is called before each retry attempt (not before the first attempt).
 // Use it to emit telemetry events.
 type OnRetry func(attempt int, delay time.Duration, cause error)
@@ -54,6 +78,13 @@ type OnRetry func(attempt int, delay time.Duration, cause error)
 // Mid-stream errors (errors emitted on the channel after fn returns) are NOT
 // retried — by the time they appear, the caller may already have consumed
 // partial events, so replay is unsafe.
+//
+// If every streaming attempt exhausts with retryable errors and cfg has a
+// NonStreamFallback set, that function is called one more time; its slice
+// is replayed on a fresh channel that mirrors the streaming output. This
+// is the final escape hatch for proxies that corrupt SSE mid-stream.
+// Non-retryable errors (auth, 400, etc.) short-circuit immediately and do
+// NOT trigger the fallback — NonStream wouldn't fix them.
 //
 // Returns the channel from the successful attempt, or the last error.
 func TurnRetry(ctx context.Context, cfg TurnRetryConfig, fn StreamFunc, onRetry OnRetry) (<-chan provider.StreamEvent, error) {
@@ -82,11 +113,40 @@ func TurnRetry(ctx context.Context, cfg TurnRetryConfig, fn StreamFunc, onRetry 
 		}
 		lastErr = err
 
-		if !isRetryableProviderError(err) || attempt == cfg.maxAttempts() {
+		if !isRetryableProviderError(err) {
+			// Non-retryable: bail immediately. NonStream won't rescue
+			// auth failures or 400s — they'll hit the same upstream
+			// validation path.
 			return nil, lastErr
 		}
 	}
+
+	// All streaming attempts exhausted on retryable errors.
+	if cfg.NonStreamFallback != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		events, nsErr := cfg.NonStreamFallback(ctx)
+		if nsErr == nil {
+			return eventsToChannel(events), nil
+		}
+		// NonStream also failed — return its error since it reflects
+		// the most recent attempt and is what the operator should act on.
+		return nil, nsErr
+	}
 	return nil, lastErr
+}
+
+// eventsToChannel replays a slice of StreamEvents on a fresh buffered
+// channel so downstream consumers that expect a <-chan interface can be
+// fed a non-streaming response without knowing the difference.
+func eventsToChannel(events []provider.StreamEvent) <-chan provider.StreamEvent {
+	ch := make(chan provider.StreamEvent, len(events))
+	for _, e := range events {
+		ch <- e
+	}
+	close(ch)
+	return ch
 }
 
 func isRetryableProviderError(err error) bool {

--- a/internal/agent/turnretry_test.go
+++ b/internal/agent/turnretry_test.go
@@ -124,3 +124,145 @@ func TestTurnRetry_RespectsContext(t *testing.T) {
 	// After cancel during delay, the err should be ctx.Err(), not the retry error.
 	assert.ErrorIs(t, err, context.Canceled)
 }
+
+// When every streaming attempt fails with a retryable error and the
+// caller has supplied a NonStream fallback, TurnRetry must invoke it
+// once and replay its events on the returned channel in order. This
+// is the "proxy that corrupts SSE" escape hatch documented in PR #236.
+func TestTurnRetry_NonStreamFallbackAfterAllRetryableFailures(t *testing.T) {
+	streamAttempts := 0
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		streamAttempts++
+		return nil, &provider.ProviderError{Kind: provider.ErrStreamError, Message: "stream stalled"}
+	}
+
+	fallbackCalls := 0
+	want := []provider.StreamEvent{
+		{Type: "message_start", Model: "m"},
+		{Type: "text_delta", Text: "hello"},
+		{Type: agentsdk.EventStop, StopReason: "end_turn"},
+	}
+	cfg := TurnRetryConfig{
+		MaxAttempts: 2,
+		BaseDelay:   time.Millisecond,
+		NonStreamFallback: func(ctx context.Context) ([]provider.StreamEvent, error) {
+			fallbackCalls++
+			return want, nil
+		},
+	}
+
+	ch, err := TurnRetry(context.Background(), cfg, fn, nil)
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+	assert.Equal(t, 2, streamAttempts, "all streaming attempts must run before fallback")
+	assert.Equal(t, 1, fallbackCalls, "fallback must be called exactly once")
+
+	var got []provider.StreamEvent
+	for e := range ch {
+		got = append(got, e)
+	}
+	assert.Equal(t, want, got, "fallback events must be replayed in order, channel closed at end")
+}
+
+// Non-retryable errors (auth, 400, etc.) must NOT trigger NonStream —
+// the fallback hits the same upstream validation and will fail the same
+// way, wasting a round-trip and confusing logs. Short-circuit instead.
+func TestTurnRetry_NonStreamFallbackSkippedOnNonRetryable(t *testing.T) {
+	streamAttempts := 0
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		streamAttempts++
+		return nil, &provider.ProviderError{Kind: provider.ErrAuthFailed, Message: "bad api key"}
+	}
+
+	fallbackCalls := 0
+	cfg := TurnRetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   time.Millisecond,
+		NonStreamFallback: func(ctx context.Context) ([]provider.StreamEvent, error) {
+			fallbackCalls++
+			return nil, nil
+		},
+	}
+
+	_, err := TurnRetry(context.Background(), cfg, fn, nil)
+	require.Error(t, err)
+	assert.Equal(t, 1, streamAttempts, "non-retryable errors must short-circuit the retry loop")
+	assert.Equal(t, 0, fallbackCalls, "non-retryable errors must NOT trigger NonStream fallback")
+	var pe *provider.ProviderError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, provider.ErrAuthFailed, pe.Kind)
+}
+
+// When streaming exhausts AND the fallback also fails, the caller should
+// see the fallback's error — it's the most recent upstream response and
+// is what the operator should investigate.
+func TestTurnRetry_NonStreamFallbackError(t *testing.T) {
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		return nil, &provider.ProviderError{Kind: provider.ErrStreamError, Message: "sse corrupted"}
+	}
+
+	nonStreamErr := &provider.ProviderError{Kind: provider.ErrServerError, Message: "502 from proxy"}
+	cfg := TurnRetryConfig{
+		MaxAttempts: 2,
+		BaseDelay:   time.Millisecond,
+		NonStreamFallback: func(ctx context.Context) ([]provider.StreamEvent, error) {
+			return nil, nonStreamErr
+		},
+	}
+
+	_, err := TurnRetry(context.Background(), cfg, fn, nil)
+	require.Error(t, err)
+	var pe *provider.ProviderError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, provider.ErrServerError, pe.Kind,
+		"returned error must reflect the NonStream failure, not the stream failure")
+	assert.Contains(t, pe.Message, "502")
+}
+
+// Without a NonStreamFallback, TurnRetry must preserve its original
+// behavior: return the last stream error after exhausting attempts.
+func TestTurnRetry_NoFallbackConfigured(t *testing.T) {
+	attempts := 0
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		attempts++
+		return nil, &provider.ProviderError{Kind: provider.ErrServerError, Message: "503"}
+	}
+
+	cfg := TurnRetryConfig{MaxAttempts: 2, BaseDelay: time.Millisecond}
+	_, err := TurnRetry(context.Background(), cfg, fn, nil)
+	require.Error(t, err)
+	assert.Equal(t, 2, attempts)
+	var pe *provider.ProviderError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, provider.ErrServerError, pe.Kind)
+}
+
+// If the context is cancelled by the time all streaming attempts are
+// exhausted, the fallback must not be invoked — its work would just
+// reveal the same ctx error. Return ctx.Err() directly.
+func TestTurnRetry_NonStreamFallbackSkippedOnCancelledCtx(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		// Fail retryably so we get to the fallback path.
+		// Cancel between attempts so the ctx check at the top of the
+		// fallback branch trips.
+		cancel()
+		return nil, &provider.ProviderError{Kind: provider.ErrStreamError, Message: "stall"}
+	}
+
+	fallbackCalls := 0
+	cfg := TurnRetryConfig{
+		MaxAttempts: 1, // one attempt → straight to fallback
+		BaseDelay:   time.Millisecond,
+		NonStreamFallback: func(ctx context.Context) ([]provider.StreamEvent, error) {
+			fallbackCalls++
+			return nil, nil
+		},
+	}
+
+	_, err := TurnRetry(ctx, cfg, fn, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, fallbackCalls, "cancelled ctx must short-circuit the fallback")
+}


### PR DESCRIPTION
## Summary

Closes one of the three deferred follow-ons called out in julianshen/rubichan#236's description: *"Wire `NonStream` into `TurnRetry` as a final-attempt fallback."*

## What

`TurnRetry` now accepts an optional `NonStreamFallback` function. After every streaming attempt has failed with a retryable error, `TurnRetry` invokes the fallback once and replays its event slice on a fresh buffered channel that mirrors the streaming output — callers reading from `<-chan StreamEvent` can't tell the difference.

Non-retryable errors (auth, 400, etc.) still short-circuit immediately, because `NonStream` hits the same upstream validation path and can't rescue them.

## Integration

- **`NonStreamer` interface** in the agent package describes providers that support the fallback. Only `*anthropic.Provider` implements it today (via the `NonStream` method added in #236); adding support to other providers is a matter of defining a method with the same signature.
- **`agent.go`** type-asserts the provider to `NonStreamer` and wires the fallback only when it's available, so providers without `NonStream` keep the pure-streaming behavior.
- **Request values** are captured by copy into the closure, not referenced, to avoid a later iteration mutating the in-flight fallback.

## Design decisions

- **Fallback fires after the full retry budget, not mid-loop.** A mid-loop fallback would double the request volume in the steady-state healthy path and create confusing log timelines. Placing it after the last streaming attempt keeps the common path unchanged.
- **`NonStream` error wins over stream error when both fail.** The NonStream attempt is the most recent signal from the upstream, so its error is what an operator should act on.
- **Cancelled context short-circuits the fallback.** If ctx is already dead by the time streaming exhausts, the fallback would just reveal the same ctx error; skip the round-trip.
- **Nil `NonStreamFallback` preserves exact existing behavior.** Callers that don't opt in see no behavioral change.

## Tests (5 new, 6 existing retained — 11 total)

- `TestTurnRetry_NonStreamFallbackAfterAllRetryableFailures` — happy path: all streaming attempts fail retryably, fallback succeeds, events replay in order, channel closes.
- `TestTurnRetry_NonStreamFallbackSkippedOnNonRetryable` — auth failure must NOT trigger the fallback.
- `TestTurnRetry_NonStreamFallbackError` — both paths fail, the NonStream error is returned.
- `TestTurnRetry_NoFallbackConfigured` — nil fallback, existing behavior preserved.
- `TestTurnRetry_NonStreamFallbackSkippedOnCancelledCtx` — cancelled context short-circuits the fallback.

## Test plan

- [x] `go test ./internal/agent/` — 11 TurnRetry tests green
- [x] `go vet ./internal/agent/...` — clean
- [x] `gofmt -l internal/agent/` — clean
- [ ] Manual end-to-end: force stream failures against a proxy that corrupts SSE, verify the anthropic provider falls back to `NonStream` and the agent loop completes normally.

## Scope

26 LOC in `agent.go` + 62 LOC in `turnretry.go` + 142 LOC in `turnretry_test.go`. No other packages touched. Independent of julianshen/rubichan#237 — this PR branches directly from `main`.

## Deferred follow-ons from julianshen/rubichan#236

- [x] Wire `NonStream` into `TurnRetry` as a final-attempt fallback *(this PR)*
- [ ] Extend typed error handling to ctx-cancel and JSON-parse branches in `ssecompat/processor.go`
- [ ] Add `SupportsNativeToolUse` to `sessionLatches` if capability hot-reload ever ships

https://claude.ai/code/session_01LsWMR4cLKRK695Q5e9itet