### PR TITLE
Research: RTK shell tools + shell output filtering plan

### DIFF
--- a/docs/plans/2026-04-16-shell-output-filtering-design.md
+++ b/docs/plans/2026-04-16-shell-output-filtering-design.md
@@ -49,10 +49,10 @@ raw output (bytes)
 [StripANSI]          — remove terminal escape sequences
         │
         ▼
-[CommandFilter]      — command-aware compression (git, test, ls, …)
+[LogDeduplicator]    — collapse repeated log lines with [×N] counts
         │
         ▼
-[LogDeduplicator]    — collapse repeated log lines with [×N] counts
+[CommandFilter]      — command-aware compression (git, test, ls, …)
         │
         ▼
 [HeadTailWindow]     — keep first N + last M lines, elide middle
@@ -64,6 +64,13 @@ raw output (bytes)
 Each stage is a pure function `func(input string, cmd string) string` (or
 equivalent). Stages are composable and independently testable. A stage that
 recognises nothing passes input through unchanged.
+
+**Why LogDeduplicator precedes CommandFilter**: log dedup operates on raw line
+structure (timestamps, repeated messages). Running it before command-specific
+compression ensures it sees the original log lines, not structured output that
+a command filter may have already transformed. Command filters (e.g. git, test
+runner) are designed for their own output format and do not produce log-like
+lines that dedup would accidentally collapse.
 
 ### 2.2 New Package: `internal/tools/filter`
 
@@ -108,29 +115,51 @@ if len(output) > maxOutputBytes {
 Becomes:
 
 ```go
-content := filter.Apply(in.Command, string(output))
+rawOutput := string(output)
+
+// DisplayContent: raw output for the human viewer (ANSI preserved, uncompressed).
+// Populated only when output exceeded the LLM cap so the user still sees full output.
 var displayContent string
+if len(output) > maxOutputBytes {
+    displayContent = rawOutput
+    if len(output) > maxDisplayBytes {
+        displayContent = rawOutput[:maxDisplayBytes] + "\n... output truncated"
+    }
+}
+
+// filter.Apply owns the LLM byte cap. All pipeline stages run inside Apply,
+// which guarantees len(result) ≤ maxOutputBytes on return.
+content := filter.Apply(in.Command, rawOutput)
+
+// Defensive assertion: Apply guarantees the cap, but guard against filter bugs.
 if len(content) > maxOutputBytes {
-    content = filter.HeadTail(content, headLines, tailLines) // already within cap
+    content = filter.HeadTail(content, headLines, tailLines)
 }
 ```
 
-`filter.Apply` is the pipeline entry point. It runs all stages and returns a
-string that is already within the LLM size budget.
+`filter.Apply` is the sole pipeline entry point. It is responsible for the byte
+cap — callers must not impose an independent truncation before calling it.
+`DisplayContent` is set from `rawOutput` before filtering so the human always
+sees uncompressed, ANSI-coloured output regardless of what the LLM receives.
 
 ### 2.4 Failure Tee
 
 When exit code is non-zero **and** output was filtered or truncated, write the
-complete raw output to `os.TempDir()/rubichan-tee/<timestamp>-<hash>.txt` and
-append a hint line to the LLM content:
+complete raw output to a persistent per-user directory and append a hint line
+to the LLM content:
 
 ```
-[Full output: /tmp/rubichan-tee/20260416-143201-a3f2.txt]
+[Full output: ~/.cache/rubichan/tee/20260416-143201-a3f2.txt]
 ```
 
-The agent can re-read it via the file tool. The tee directory is capped at 20
-files; oldest are removed. Enabled by default; disabled via
-`config.Shell.DisableTee = true`.
+**Tee directory**: `os.UserCacheDir()/rubichan/tee/` (resolves to
+`~/.cache/rubichan/tee/` on Linux, `~/Library/Caches/rubichan/tee/` on macOS).
+This survives reboots unlike `os.TempDir()` (`/tmp`), so hint paths remain
+valid across sessions. The agent can re-read the file via the file tool without
+re-running the command.
+
+The tee directory is capped at 20 files; oldest files are removed on each new
+write. Enabled by default; disabled via `config.Shell.DisableTee = true`.
 
 ---
 
@@ -192,24 +221,34 @@ Normalization replacements (in order):
 4. Large numbers `\b\d{5,}\b` → `<NUM>`
 5. Absolute paths `/[a-zA-Z0-9_/.-]{10,}` → `<PATH>`
 
-Count normalized occurrences; for any line with count ≥ 2, output one
-representative line (the first occurrence, de-normalized for readability)
-with `[×N]` appended:
+Count normalized occurrences. Emit lines in **first-occurrence order** —
+temporal sequence is preserved. For any line with count ≥ 2, replace it with
+the first occurrence (original text, not normalized) and append `[×N]`:
 
 ```
-[ERROR] Connection refused [×47]
+[ERROR] Connection refused at 14:32:01 [×47]
 [WARN]  Retry attempt 3 of 5 [×12]
 [INFO]  Server started on :8080
 ```
 
-Show top-10 errors, top-5 warnings, then remaining unique info lines up to
-`maxUniqueLines = 30`.
+Output order mirrors the original log order (by first occurrence), not
+re-sorted by severity. This preserves the causal sequence of events, which
+matters when diagnosing startup failures or cascading errors. When unique line
+count exceeds `maxUniqueLines = 30`, the excess is truncated with a count
+message.
 
 ### 3.4 Git Output Compression (`filter/git.go`)
 
-Applied when the command matches `^git\s+(status|log|diff|show)\b`.
+Applied when the command matches `^git\s+(status|log|diff|show)\b`. Commands
+with flags before the subcommand (e.g. `git -C /path status`,
+`git --no-pager log`) are a known limitation: the regex will not match and
+output passes through unchanged. This is acceptable for the initial
+implementation; a shell-argument parser can be added later.
 
-**git status** — parse `git status --porcelain` format emitted inline:
+**git status** — two format paths:
+
+*Porcelain format* (detected when first non-empty line matches
+`^[MADRCU? ][MADRCU? ] `): parse two-char status codes.
 
 | Symbol | Section |
 |---|---|
@@ -218,7 +257,16 @@ Applied when the command matches `^git\s+(status|log|diff|show)\b`.
 | `??` | Untracked |
 | `UU`, `AA`, `DD` | Conflicts |
 
-Output:
+*Human-readable format* (default output of plain `git status`): detect section
+headers and extract file lists.
+
+| Header | Section |
+|---|---|
+| `Changes to be committed:` | Staged |
+| `Changes not staged for commit:` | Modified |
+| `Untracked files:` | Untracked |
+
+Both paths produce the same structured output:
 ```
 Staged (3): main.go, cmd/agent/main.go, internal/tools/shell.go
 Modified (7): internal/agent/agent.go ... +5 more
@@ -226,9 +274,8 @@ Untracked (2): docs/notes.txt, scratch.sh
 ```
 
 Cap: 15 staged, 15 modified, 10 untracked. Conflicts always shown in full.
-
-If output is not in porcelain format (user passed `--short`, `--long`, custom
-format), pass through unchanged.
+If neither format is detected (unknown `git status` flags or custom format),
+pass through unchanged.
 
 **git log** — detect log output by leading `commit [0-9a-f]{40}` lines:
 
@@ -326,7 +373,7 @@ Loaded at startup from:
 1. `.rubichan/filters.toml` (project-local, requires explicit trust grant)
 2. `~/.config/rubichan/filters.toml` (user-global)
 
-Schema (subset of RTK's TOML format for compatibility):
+Schema:
 
 ```toml
 schema_version = 1
@@ -341,11 +388,22 @@ strip_lines_matching = [
 ]
 tail_lines          = 40
 on_empty            = "Build produced no output"
+
+# match_output: short-circuit entire output with a canned message if the
+# full output blob matches this pattern (useful for "build succeeded" cases).
+[[filters.my-tool.match_output]]
+pattern = "BUILD SUCCESS"
+message = "Build succeeded."
+unless  = "ERROR"          # optional: suppress match when this also matches
 ```
 
 Supported fields: `match_command`, `strip_ansi`, `strip_lines_matching`,
 `keep_lines_matching`, `replace` (pattern+replacement pairs), `head_lines`,
-`tail_lines`, `max_lines`, `on_empty`.
+`tail_lines`, `max_lines`, `on_empty`, `match_output` (array of
+`{pattern, message, unless?}` short-circuit rules).
+
+`strip_lines_matching` and `keep_lines_matching` are mutually exclusive — a
+validation error is returned at load time if both are present.
 
 Project-local filters require `rubichan trust .rubichan/filters.toml` to
 activate. Untrusted project filters are silently skipped with a warning
@@ -391,6 +449,11 @@ max_files            = 20
    streaming events. Users see full output in real time; LLM sees compressed.
 5. **Idempotent**: Applying a filter twice produces the same result as
    applying it once.
+6. **DisplayContent preserved**: `ToolResult.DisplayContent` is populated from
+   the raw (pre-filter) byte buffer when output exceeded `maxOutputBytes`.
+   It retains ANSI codes and is not passed through any compression stage.
+   The human viewer always sees the unmodified output; only the LLM receives
+   the compressed version.
 
 ---
 

--- a/docs/plans/2026-04-16-shell-output-filtering-design.md
+++ b/docs/plans/2026-04-16-shell-output-filtering-design.md
@@ -1,0 +1,413 @@
+# Shell Output Filtering — Design Document
+
+> **Date:** 2026-04-16 · **Status:** Draft  
+> **Research:** `docs/rtk-shell-tools-research.md`  
+> **Feature:** RTK-inspired output filtering to reduce LLM token consumption
+
+---
+
+## 1. Overview
+
+Rubichan's shell tool currently sends raw command output to the LLM, capped
+at a naive 30 KB head-chop. RTK (rtk-ai/rtk) demonstrates that command-aware
+output compression achieves 60–90% token reduction without losing actionable
+information.
+
+This document specifies a layered filtering system that:
+
+1. Replaces naive head-chop with **head+tail windowing** and **ANSI stripping**
+2. Adds **log deduplication** for build/test/server output
+3. Adds **command-aware compression** for git, test runners, ls/tree/find/grep
+4. Introduces a **declarative filter rule** layer for extensibility
+5. Adds **failure output preservation** (tee) so full output is never truly lost
+
+The existing security model (sandboxing, command substitution blocking,
+recursive-rm interception) is untouched. The existing streaming architecture
+(`EventBegin`/`EventDelta`/`EventEnd`) is untouched. Filtering is a pure
+post-execution transformation applied to the captured byte buffer.
+
+### Scope Boundary
+
+This design covers output **post-processing** only. It does not cover:
+- Shell mode UI (see `2026-03-30-shell-enhancements-design.md`)
+- Agent loop or provider layer
+- The dedicated `git_status`/`git_diff`/`git_log` tool family
+
+---
+
+## 2. Architecture
+
+### 2.1 Filter Pipeline
+
+Filtering is applied inside `ShellTool.ExecuteStream` immediately after
+`wg.Wait()` captures the complete byte buffer, before truncation is applied.
+
+```
+raw output (bytes)
+        │
+        ▼
+[StripANSI]          — remove terminal escape sequences
+        │
+        ▼
+[CommandFilter]      — command-aware compression (git, test, ls, …)
+        │
+        ▼
+[LogDeduplicator]    — collapse repeated log lines with [×N] counts
+        │
+        ▼
+[HeadTailWindow]     — keep first N + last M lines, elide middle
+        │
+        ▼
+ LLM content (≤ 30 KB)
+```
+
+Each stage is a pure function `func(input string, cmd string) string` (or
+equivalent). Stages are composable and independently testable. A stage that
+recognises nothing passes input through unchanged.
+
+### 2.2 New Package: `internal/tools/filter`
+
+All filtering logic lives in a new package to keep `shell.go` clean and make
+the filter stages unit-testable in isolation.
+
+```
+internal/tools/filter/
+    ansi.go          — StripANSI(s string) string
+    ansi_test.go
+    headtail.go      — HeadTail(s string, head, tail int) string
+    headtail_test.go
+    logdedup.go      — DeduplicateLog(s string) string
+    logdedup_test.go
+    git.go           — CompressGitOutput(subcmd, output string) string
+    git_test.go
+    testrunner.go    — SummarizeTestOutput(cmd, output string) string
+    testrunner_test.go
+    dirlist.go       — CompressDirList(cmd, output string) string
+    dirlist_test.go
+    grep.go          — CompressGrepOutput(output string) string
+    grep_test.go
+    rules.go         — Rule registry + TOML loader
+    rules_test.go
+    pipeline.go      — Apply(cmd, output string, rules []Rule) string
+    pipeline_test.go
+```
+
+### 2.3 Integration Point in `shell.go`
+
+Current code at `shell.go:428–452`:
+
+```go
+content := string(output)
+var displayContent string
+if len(output) > maxOutputBytes {
+    content = string(output[:maxOutputBytes]) + "\n... output truncated"
+    ...
+}
+```
+
+Becomes:
+
+```go
+content := filter.Apply(in.Command, string(output))
+var displayContent string
+if len(content) > maxOutputBytes {
+    content = filter.HeadTail(content, headLines, tailLines) // already within cap
+}
+```
+
+`filter.Apply` is the pipeline entry point. It runs all stages and returns a
+string that is already within the LLM size budget.
+
+### 2.4 Failure Tee
+
+When exit code is non-zero **and** output was filtered or truncated, write the
+complete raw output to `os.TempDir()/rubichan-tee/<timestamp>-<hash>.txt` and
+append a hint line to the LLM content:
+
+```
+[Full output: /tmp/rubichan-tee/20260416-143201-a3f2.txt]
+```
+
+The agent can re-read it via the file tool. The tee directory is capped at 20
+files; oldest are removed. Enabled by default; disabled via
+`config.Shell.DisableTee = true`.
+
+---
+
+## 3. Feature Specifications
+
+### 3.1 ANSI Stripping (`filter/ansi.go`)
+
+Strip all ANSI SGR sequences (`ESC[...m`), cursor control sequences, and OSC
+sequences before any other processing.
+
+Regex: `\x1b\[[0-9;]*[mGKHFABCDJsu]` plus `\x1b\][^\x07]*\x07`.
+
+Input (42 chars of escapes, 8 chars of text):
+```
+\x1b[32m✓ passed\x1b[0m
+```
+Output:
+```
+✓ passed
+```
+
+Always applied. Zero configuration.
+
+### 3.2 Head+Tail Windowing (`filter/headtail.go`)
+
+Replace the naive `output[:maxOutputBytes]` chop.
+
+Parameters (configurable, with sensible defaults):
+- `headLines = 200` — lines to keep from the start
+- `tailLines = 100` — lines to keep from the end
+- `maxBytes = 30 * 1024` — absolute byte cap (applied after line windowing)
+
+When `total > headLines + tailLines`:
+```
+<first 200 lines>
+... (N lines omitted)
+<last 100 lines>
+```
+
+When total ≤ headLines + tailLines: pass through unchanged (no elision message
+injected unnecessarily).
+
+Byte cap is a second safety net applied to the already-windowed string. If
+windowed output still exceeds `maxBytes`, apply a final `[:maxBytes]` chop
+at a newline boundary.
+
+### 3.3 Log Deduplication (`filter/logdedup.go`)
+
+Triggered when output contains ≥ 10 lines that structurally resemble log
+entries (i.e., begin with a timestamp, log level, or bracket pattern).
+
+Detection heuristic: if ≥ 40% of lines match
+`^\s*(\d{4}[-/]\d{2}[-/]\d{2}|[A-Z]{3,5}|\[\w+\])` → treat as log stream.
+
+Normalization replacements (in order):
+1. ISO timestamps `\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}` → `<TIME>`
+2. UUIDs `[0-9a-f]{8}-[0-9a-f]{4}-…` → `<UUID>`
+3. Hex strings `0x[0-9a-fA-F]{4,}` → `<HEX>`
+4. Large numbers `\b\d{5,}\b` → `<NUM>`
+5. Absolute paths `/[a-zA-Z0-9_/.-]{10,}` → `<PATH>`
+
+Count normalized occurrences; for any line with count ≥ 2, output one
+representative line (the first occurrence, de-normalized for readability)
+with `[×N]` appended:
+
+```
+[ERROR] Connection refused [×47]
+[WARN]  Retry attempt 3 of 5 [×12]
+[INFO]  Server started on :8080
+```
+
+Show top-10 errors, top-5 warnings, then remaining unique info lines up to
+`maxUniqueLines = 30`.
+
+### 3.4 Git Output Compression (`filter/git.go`)
+
+Applied when the command matches `^git\s+(status|log|diff|show)\b`.
+
+**git status** — parse `git status --porcelain` format emitted inline:
+
+| Symbol | Section |
+|---|---|
+| `M `, `A `, `D `, `R `, `C ` (first col) | Staged |
+| ` M`, ` D` (second col) | Modified |
+| `??` | Untracked |
+| `UU`, `AA`, `DD` | Conflicts |
+
+Output:
+```
+Staged (3): main.go, cmd/agent/main.go, internal/tools/shell.go
+Modified (7): internal/agent/agent.go ... +5 more
+Untracked (2): docs/notes.txt, scratch.sh
+```
+
+Cap: 15 staged, 15 modified, 10 untracked. Conflicts always shown in full.
+
+If output is not in porcelain format (user passed `--short`, `--long`, custom
+format), pass through unchanged.
+
+**git log** — detect log output by leading `commit [0-9a-f]{40}` lines:
+
+- Truncate commit message lines to 100 chars
+- Strip `Signed-off-by:`, `Co-authored-by:`, `Change-Id:` trailers
+- Keep up to 3 body lines per commit
+- Cap at 15 commits total; append `... (N more commits)` if needed
+
+**git diff** — detect by `diff --git` headers:
+
+- Keep file headers (`diff --git`, `index`, `---`, `+++`) intact
+- Per-hunk: keep `@@` context line + first 60 added/removed lines
+- Excess hunk lines → `... (N lines omitted in this hunk)`
+- Append `+X -Y` total counter at end
+- If any truncation occurred: append hint
+  `[Full diff available: re-run with git diff | head -n 500]`
+
+### 3.5 Test Runner Summarization (`filter/testrunner.go`)
+
+Detect test runner output by command prefix and/or output patterns.
+
+| Trigger | Patterns to detect |
+|---|---|
+| `^go test` | `^--- FAIL`, `^--- PASS`, `^ok`, `^FAIL`, `^=== RUN` |
+| `^pytest` | `PASSED`, `FAILED`, `ERROR`, `=====`, `short test summary` |
+| `^cargo test` | `test .* \.\.\. ok`, `test .* \.\.\. FAILED`, `test result:` |
+| `^npm test`, `^jest`, `^vitest` | `✓`, `✗`, `PASS`, `FAIL`, `Tests:` |
+
+Strategy:
+1. Extract summary line (pass/fail/skip counts) — always kept
+2. Extract all failure blocks — always kept
+3. Discard passing test lines (`=== RUN …`, `--- PASS …`, `✓ …`)
+4. If no failures: emit `All N tests passed.`
+5. If failures: emit counts + full failure output
+
+Example (`go test -v ./...`, 2,500 lines → ~30 lines):
+```
+go test ./...
+FAIL internal/tools: 2 failures
+
+--- FAIL: TestShellToolTimeout (0.01s)
+    shell_test.go:89: expected timeout error, got nil
+
+--- FAIL: TestSandboxPolicy (0.00s)
+    shell_sandbox_test.go:212: policy mismatch
+
+ok  internal/agent (47 tests)
+ok  internal/provider (23 tests)
+FAIL
+```
+
+### 3.6 Directory Listing Compression (`filter/dirlist.go`)
+
+**`ls` command** — detected by command matching `^ls(\s|$)`.
+
+When output is from `ls -la` / `ls -l` (long format):
+- Parse with date-field anchor (month-name anchor regex)
+- Skip `.`, `..`, `total` lines
+- Exclude noise directories unless `-a` flag present:
+  `node_modules`, `.git`, `target`, `__pycache__`, `.next`, `dist`, `vendor`,
+  `.cache`, `coverage`, `build`, `.idea`, `.vscode`
+- Show directories first with `/` suffix
+- Human-readable sizes: 500B, 1.2K, 3.4M
+- Append extension frequency summary: `[38F 6D: .go×22 .md×8 .json×5 .yaml×3]`
+
+When output is from plain `ls` (no `-l`): pass through (already compact).
+
+**`tree` command** — detected by `^tree(\s|$)`:
+- If no `-I` in original command, note that noise dirs would improve output
+  (rubichan does not rewrite the command, but can suggest via warning)
+- Strip trailing summary line (`N directories, M files`)
+- Cap at 200 lines; head+tail elision if exceeded
+
+**`find` command** — detected by `^find(\s|$)`:
+- Group results by parent directory
+- Cap at 50 results total; append `+N more` if exceeded
+- Abbreviate long paths: keep last 47 chars → `...last/47/chars`
+- Append extension frequency summary
+
+### 3.7 Grep/Ripgrep Compression (`filter/grep.go`)
+
+Detected by command matching `^(grep|rg|ripgrep)(\s|$)`.
+
+- Group matches by filename
+- Per-file cap: 5 matches (configurable)
+- Excess per file: `... (+N more in this file)`
+- Total file cap: 20 files; `... (+N more files)`
+- Long match lines: center a 60-char window around the match + `...`
+- Long paths: compress to `first/.../last` format
+
+### 3.8 Declarative Filter Rules (`filter/rules.go`)
+
+A TOML-based rule system for commands not covered by built-in Rust handlers.
+Loaded at startup from:
+1. `.rubichan/filters.toml` (project-local, requires explicit trust grant)
+2. `~/.config/rubichan/filters.toml` (user-global)
+
+Schema (subset of RTK's TOML format for compatibility):
+
+```toml
+schema_version = 1
+
+[filters.my-tool]
+description         = "My internal build tool"
+match_command       = "^my-build"
+strip_ansi          = true
+strip_lines_matching = [
+  "^Downloading",
+  "^Resolving",
+]
+tail_lines          = 40
+on_empty            = "Build produced no output"
+```
+
+Supported fields: `match_command`, `strip_ansi`, `strip_lines_matching`,
+`keep_lines_matching`, `replace` (pattern+replacement pairs), `head_lines`,
+`tail_lines`, `max_lines`, `on_empty`.
+
+Project-local filters require `rubichan trust .rubichan/filters.toml` to
+activate. Untrusted project filters are silently skipped with a warning
+printed to stderr only (not sent to LLM).
+
+---
+
+## 4. Configuration
+
+New section in `~/.config/rubichan/config.toml`:
+
+```toml
+[shell.output_filter]
+enabled              = true          # master switch; false → bypass all filtering
+ansi_strip           = true
+log_dedup            = true
+git_compress         = true
+test_summarize       = true
+dir_compress         = true
+grep_compress        = true
+
+head_lines           = 200
+tail_lines           = 100
+
+[shell.tee]
+enabled              = true
+mode                 = "failures"    # "never" | "failures" | "always"
+max_files            = 20
+```
+
+---
+
+## 5. Correctness Invariants
+
+1. **Pass-through on error**: If any filter stage panics or returns empty for
+   non-empty input, the previous stage's output is used (never lose content).
+2. **Failure full output**: Non-zero exit code always triggers tee write
+   regardless of filter settings, unless `tee.enabled = false`.
+3. **No command modification**: Filtering is output-only. The command string
+   sent to `sh -c` is never altered.
+4. **Streaming unaffected**: `EventDelta` events during execution emit raw
+   bytes. Filtering applies only to the final `ToolResult.Content`, not to
+   streaming events. Users see full output in real time; LLM sees compressed.
+5. **Idempotent**: Applying a filter twice produces the same result as
+   applying it once.
+
+---
+
+## 6. Non-Goals
+
+- Command rewriting (RTK-style hook) — rubichan owns execution, no hook needed
+- LLM-powered summarization of arbitrary output — out of scope, different cost
+- Token counting via LLM tokenizer — approximate char/4 is sufficient
+- Windows support for tee paths — follow existing OS path conventions
+
+---
+
+## 7. Open Questions
+
+1. Should `head_lines`/`tail_lines` be per-command configurable, or global
+   only? Start global; per-command in declarative rules handles edge cases.
+2. Should git compression apply when the user explicitly pipes git output
+   (`git log | grep foo`)? No — only apply when `git` is the root command.
+3. Should test runner summarization be skipped when the user passes `-v` or
+   `--verbose`? Yes — respect explicit verbosity flags.

--- a/docs/plans/2026-04-16-shell-output-filtering-plan.md
+++ b/docs/plans/2026-04-16-shell-output-filtering-plan.md
@@ -1,0 +1,338 @@
+# Shell Output Filtering — TDD Implementation Plan
+
+> **Date:** 2026-04-16 · **Status:** Draft  
+> **Design:** `2026-04-16-shell-output-filtering-design.md`  
+> **Research:** `docs/rtk-shell-tools-research.md`
+
+---
+
+## Stage 0: Package Scaffold
+
+- [ ] **0.1** `TestPackageCompiles` — Create `internal/tools/filter/` package
+  with a no-op `Apply(cmd, output string) string` that returns `output`
+  unchanged. Verify `go build ./internal/tools/filter/...` passes.
+
+---
+
+## Stage 1: ANSI Stripping
+
+- [ ] **1.1** `TestStripANSIEmpty` — `StripANSI("")` returns `""`.
+- [ ] **1.2** `TestStripANSINoEscapes` — Plain text passes through unchanged.
+- [ ] **1.3** `TestStripANSIColorCode` — `"\x1b[32mgreen\x1b[0m"` → `"green"`.
+- [ ] **1.4** `TestStripANSIBoldAndReset` — `"\x1b[1;31mred bold\x1b[0m"` →
+  `"red bold"`.
+- [ ] **1.5** `TestStripANSICursorControl` — Cursor movement sequences (`\x1b[A`,
+  `\x1b[2J`) are removed.
+- [ ] **1.6** `TestStripANSIOSCSequence` — OSC sequences (`\x1b]0;title\x07`)
+  are removed.
+- [ ] **1.7** `TestStripANSIMultiline` — Strip works correctly across multiple
+  lines (newlines preserved, only escape sequences removed).
+- [ ] **1.8** `TestStripANSIPreservesUnicode` — Multi-byte Unicode characters
+  survive stripping unchanged.
+
+---
+
+## Stage 2: Head+Tail Windowing
+
+- [ ] **2.1** `TestHeadTailBelowThreshold` — Input with fewer lines than
+  `head + tail` passes through with no elision message inserted.
+- [ ] **2.2** `TestHeadTailExactThreshold` — Input with exactly `head + tail`
+  lines passes through unchanged.
+- [ ] **2.3** `TestHeadTailElision` — Input with `head + tail + 50` lines
+  produces `head` leading lines + `"... (50 lines omitted)"` + `tail` trailing
+  lines.
+- [ ] **2.4** `TestHeadTailElisionCount` — The omitted count in the message is
+  exactly `total - head - tail`.
+- [ ] **2.5** `TestHeadTailZeroTail` — `tail = 0` keeps only first `head` lines
+  with elision at end; no trailing section.
+- [ ] **2.6** `TestHeadTailZeroHead` — `head = 0` keeps only last `tail` lines
+  with elision at start.
+- [ ] **2.7** `TestHeadTailPreservesNewlines` — Output ends with a newline iff
+  the original input ended with a newline.
+- [ ] **2.8** `TestHeadTailByteCapNewlineBoundary` — When windowed output still
+  exceeds `maxBytes`, final chop occurs at a newline boundary, not mid-line.
+- [ ] **2.9** `TestHeadTailEmptyInput` — `HeadTail("", 200, 100)` returns `""`.
+
+---
+
+## Stage 3: Log Deduplication
+
+- [ ] **3.1** `TestLogDedupNoLogLines` — Non-log output (plain text below 40%
+  log-pattern threshold) is returned unchanged.
+- [ ] **3.2** `TestLogDedupDetectionThreshold` — Exactly 40% log lines triggers
+  dedup; 39% does not.
+- [ ] **3.3** `TestLogDedupTimestampNormalization` — Lines differing only by
+  ISO timestamp are collapsed into one `[×N]` entry.
+- [ ] **3.4** `TestLogDedupUUIDNormalization` — Lines differing only by UUID
+  are collapsed.
+- [ ] **3.5** `TestLogDedupHexNormalization` — Lines differing only by hex
+  values are collapsed.
+- [ ] **3.6** `TestLogDedupLargeNumberNormalization` — Numbers ≥ 5 digits are
+  normalized before comparison.
+- [ ] **3.7** `TestLogDedupUniqueLines` — Lines that do not repeat are preserved
+  verbatim (first occurrence, no `[×1]` tag).
+- [ ] **3.8** `TestLogDedupCountAccuracy` — Three identical normalized lines →
+  `[×3]`, not `[×2]` or `[×4]`.
+- [ ] **3.9** `TestLogDedupPreservesOrder` — Deduplicated output preserves the
+  order of first occurrence.
+- [ ] **3.10** `TestLogDedupMaxUniqueLines` — When unique line count exceeds
+  `maxUniqueLines`, excess lines are truncated with a count message.
+- [ ] **3.11** `TestLogDedupMultibyteCharacters` — Lines containing multi-byte
+  Unicode are normalized and counted correctly without panicking.
+- [ ] **3.12** `TestLogDedupShortInput` — Input with fewer than 10 lines is
+  returned unchanged (deduplification not worth the overhead).
+
+---
+
+## Stage 4: Git Output Compression
+
+### 4A. git status
+
+- [ ] **4.1** `TestGitStatusEmpty` — Empty `git status --porcelain` output →
+  `"nothing to commit, working tree clean"`.
+- [ ] **4.2** `TestGitStatusStagedFiles` — Lines with first-column `M` are
+  grouped under `Staged (N):`.
+- [ ] **4.3** `TestGitStatusModifiedFiles` — Lines with second-column `M` or
+  `D` are grouped under `Modified (N):`.
+- [ ] **4.4** `TestGitStatusUntracked` — `??` lines grouped under
+  `Untracked (N):`.
+- [ ] **4.5** `TestGitStatusConflicts` — `UU`/`AA`/`DD` lines shown in full
+  under `Conflicts (N):`.
+- [ ] **4.6** `TestGitStatusStagedCap` — More than 15 staged files shows first
+  15 + `... +N more`.
+- [ ] **4.7** `TestGitStatusUntrackedCap` — More than 10 untracked files shows
+  first 10 + `... +N more`.
+- [ ] **4.8** `TestGitStatusNonPorcelainPassthrough` — Output not in porcelain
+  format (no two-char status codes) passes through unchanged.
+- [ ] **4.9** `TestGitStatusMixedCategories` — Single output with staged +
+  modified + untracked correctly groups all three sections.
+
+### 4B. git log
+
+- [ ] **4.10** `TestGitLogCommitCap` — More than 15 commits → first 15 + count
+  message.
+- [ ] **4.11** `TestGitLogMessageTruncation` — Commit message lines exceeding
+  100 chars are truncated with `...`.
+- [ ] **4.12** `TestGitLogTrailerStripping` — `Signed-off-by:`,
+  `Co-authored-by:`, `Change-Id:` lines are removed.
+- [ ] **4.13** `TestGitLogBodyLineLimit` — More than 3 body lines per commit →
+  first 3 + `[+N lines omitted]`.
+- [ ] **4.14** `TestGitLogNoBodyCommit` — Commit with subject only (no body)
+  passes through without empty line injection.
+- [ ] **4.15** `TestGitLogNonLogFormatPassthrough` — Input that does not begin
+  with `commit [0-9a-f]{40}` passes through unchanged.
+
+### 4C. git diff
+
+- [ ] **4.16** `TestGitDiffFileHeaders` — `diff --git`, `index`, `---`, `+++`
+  lines are preserved intact.
+- [ ] **4.17** `TestGitDiffHunkHeader` — `@@` lines are preserved intact.
+- [ ] **4.18** `TestGitDiffHunkTruncation` — Hunk with more than 60
+  added/removed lines → first 60 + `... (N lines omitted in this hunk)`.
+- [ ] **4.19** `TestGitDiffNoTruncationSmallHunk` — Hunk with ≤ 60 changed
+  lines is preserved in full.
+- [ ] **4.20** `TestGitDiffTotalCounter` — Output ends with `+X -Y` total
+  counter.
+- [ ] **4.21** `TestGitDiffHintOnTruncation` — When any truncation occurred,
+  hint line is appended.
+- [ ] **4.22** `TestGitDiffNoHintWhenNoTruncation` — No hint when output was
+  not truncated.
+- [ ] **4.23** `TestGitDiffNonDiffFormatPassthrough` — Input without
+  `diff --git` header passes through unchanged.
+
+---
+
+## Stage 5: Test Runner Summarization
+
+- [ ] **5.1** `TestGoTestAllPassed` — Output with all `--- PASS` lines + final
+  `ok` line → `"All N tests passed."`.
+- [ ] **5.2** `TestGoTestWithFailures` — Extract `--- FAIL` blocks + failure
+  output; discard `--- PASS` and `=== RUN` lines.
+- [ ] **5.3** `TestGoTestSummaryLine` — Final `ok`/`FAIL` summary line is
+  always preserved.
+- [ ] **5.4** `TestGoTestVerboseRespected` — When command contains `-v`, do
+  NOT apply summarization (user requested verbose).
+- [ ] **5.5** `TestPytestAllPassed` — Output with only `PASSED` lines +
+  summary → `"N passed in Xs"`.
+- [ ] **5.6** `TestPytestWithFailures` — Extract failure section between
+  `FAILURES` and `short test summary`; discard passing lines.
+- [ ] **5.7** `TestCargoTestAllPassed` — `test ... ok` lines collapsed to
+  count; `test result: ok` summary preserved.
+- [ ] **5.8** `TestCargoTestWithFailures` — `FAILED` lines + `failures:` block
+  preserved; passing lines discarded.
+- [ ] **5.9** `TestTestRunnerUnrecognizedPassthrough` — Output that doesn't
+  match any known test runner pattern passes through unchanged.
+- [ ] **5.10** `TestTestRunnerEmptyOutput` — Empty output returns `""` (no
+  fabricated summary).
+
+---
+
+## Stage 6: Directory Listing Compression
+
+- [ ] **6.1** `TestLsLongFormatBasic` — Long-format `ls -la` output: `.` and
+  `..` and `total` lines removed; remaining entries formatted with human-
+  readable size.
+- [ ] **6.2** `TestLsLongFormatNoiseExclusion` — `node_modules/`, `.git/`,
+  `target/` excluded by default.
+- [ ] **6.3** `TestLsLongFormatNoiseIncludedWithFlag` — Command `ls -la -a`
+  (contains `-a`) → noise directories are NOT excluded.
+- [ ] **6.4** `TestLsLongFormatDirectoriesFirst` — Directories appear before
+  files in output.
+- [ ] **6.5** `TestLsLongFormatHumanSizes` — `1024` bytes shown as `1.0K`;
+  `1048576` as `1.0M`; `500` as `500B`.
+- [ ] **6.6** `TestLsLongFormatExtensionSummary` — Summary line appended
+  showing top-5 extensions by frequency.
+- [ ] **6.7** `TestLsPlainFormatPassthrough` — Non-long-format `ls` output
+  (no date anchor) passes through unchanged.
+- [ ] **6.8** `TestTreeStripSummaryLine` — `5 directories, 23 files` trailing
+  line is removed.
+- [ ] **6.9** `TestTreePreservesStructure` — Tree symbols (`├──`, `│`, `└──`)
+  are preserved exactly.
+- [ ] **6.10** `TestFindGroupsByDirectory` — Results grouped by parent directory.
+- [ ] **6.11** `TestFindResultCap` — More than 50 results → first 50 + `+N more`.
+- [ ] **6.12** `TestFindPathAbbreviation` — Paths longer than 50 chars
+  abbreviated to `...last47chars`.
+- [ ] **6.13** `TestFindExtensionSummary` — Extension frequency summary appended.
+
+---
+
+## Stage 7: Grep/Ripgrep Compression
+
+- [ ] **7.1** `TestGrepGroupByFile` — Matches grouped by filename.
+- [ ] **7.2** `TestGrepPerFileCap` — More than 5 matches per file → first 5 +
+  `... (+N more in this file)`.
+- [ ] **7.3** `TestGrepTotalFileCap` — More than 20 files → first 20 +
+  `... (+N more files)`.
+- [ ] **7.4** `TestGrepLineTruncation` — Match lines longer than 120 chars
+  truncated to 60-char window centered on match.
+- [ ] **7.5** `TestGrepPathCompression` — Long file paths compressed to
+  `first/.../last` format.
+- [ ] **7.6** `TestGrepSingleMatch` — Single match file with one result needs
+  no truncation message.
+- [ ] **7.7** `TestGrepNoMatchPassthrough` — Output with no file:line: format
+  passes through unchanged.
+
+---
+
+## Stage 8: Declarative Filter Rules
+
+- [ ] **8.1** `TestRuleParseValidTOML` — Valid TOML with `match_command`,
+  `strip_lines_matching`, `tail_lines` parses without error.
+- [ ] **8.2** `TestRuleParseInvalidTOML` — Malformed TOML returns parse error;
+  no rules loaded.
+- [ ] **8.3** `TestRuleMutualExclusion` — Filter with both `strip_lines_matching`
+  and `keep_lines_matching` returns validation error.
+- [ ] **8.4** `TestRuleMatchCommand` — Rule with `match_command = "^my-tool"`
+  matches `"my-tool --flag"` and does not match `"other-tool"`.
+- [ ] **8.5** `TestRuleStripLines` — Lines matching `strip_lines_matching`
+  patterns are removed.
+- [ ] **8.6** `TestRuleKeepLines` — Only lines matching `keep_lines_matching`
+  patterns are kept.
+- [ ] **8.7** `TestRuleTailLines` — Only last N lines retained with elision
+  prefix.
+- [ ] **8.8** `TestRuleHeadLines` — Only first N lines retained with elision
+  suffix.
+- [ ] **8.9** `TestRuleOnEmpty` — When filtering empties output, `on_empty`
+  message returned.
+- [ ] **8.10** `TestRuleReplace` — Regex replace rule applied line-by-line.
+- [ ] **8.11** `TestRuleStripANSI` — `strip_ansi = true` strips escape codes
+  as the first stage.
+- [ ] **8.12** `TestRuleMaxLines` — Output capped at `max_lines` with truncation
+  message.
+- [ ] **8.13** `TestRulePriorityCascade` — Project-local rule takes precedence
+  over user-global rule with the same `match_command`.
+- [ ] **8.14** `TestRuleUntrustedProjectSkipped` — Project-local rule without
+  trust grant is silently skipped; warning only to stderr.
+- [ ] **8.15** `TestRuleSchemaVersionEnforced` — TOML with
+  `schema_version = 2` rejected with error.
+- [ ] **8.16** `TestRuleNoMatchPassthrough` — Command that matches no rule
+  passes output through unchanged.
+
+---
+
+## Stage 9: Pipeline Integration
+
+- [ ] **9.1** `TestPipelineANSIFirst` — ANSI stripping occurs before all other
+  stages (escape codes don't confuse downstream regex).
+- [ ] **9.2** `TestPipelineCommandRouting` — `git status` output routed to git
+  compressor; `go test` to test summarizer; `ls -la` to dir compressor.
+- [ ] **9.3** `TestPipelineLogDedupAfterCommandFilter` — Log dedup stage runs
+  on output from command filter, not on raw input.
+- [ ] **9.4** `TestPipelineHeadTailLast` — Head+tail windowing is applied last,
+  after all command-specific compression.
+- [ ] **9.5** `TestPipelineDeclarativeRuleOverride` — A matching TOML rule
+  overrides built-in compression for that command.
+- [ ] **9.6** `TestPipelinePassthroughNoMatch` — Command with no matching
+  filter passes raw output through the pipeline unchanged.
+- [ ] **9.7** `TestPipelineDisabledMasterSwitch` — `enabled = false` in config
+  bypasses all filtering; raw output returned.
+- [ ] **9.8** `TestPipelineFilterPanicRecovery` — If a filter stage panics, the
+  panic is recovered and the previous stage's output is used (no crash).
+
+---
+
+## Stage 10: Failure Tee
+
+- [ ] **10.1** `TestTeeWritesOnNonZeroExit` — Non-zero exit code triggers write
+  to tee dir; file contains full raw output.
+- [ ] **10.2** `TestTeeSkipsOnZeroExitInFailuresMode` — Exit code 0 in
+  `mode = "failures"` does not write tee file.
+- [ ] **10.3** `TestTeeWritesOnZeroExitInAlwaysMode` — `mode = "always"` writes
+  tee file even on exit code 0.
+- [ ] **10.4** `TestTeeHintAppendedToContent` — After tee write, LLM content
+  contains `[Full output: /path/to/file]` hint line.
+- [ ] **10.5** `TestTeeFilenameFormat` — Filename matches
+  `<yyyyMMdd-HHmmss>-<hash>.txt` format.
+- [ ] **10.6** `TestTeeDirectoryCreated` — Tee directory is created if it does
+  not exist.
+- [ ] **10.7** `TestTeeRotation` — When file count exceeds `max_files`, oldest
+  file is deleted.
+- [ ] **10.8** `TestTeeDisabled` — `enabled = false` never writes files.
+- [ ] **10.9** `TestTeeUTF8Boundary` — When output is truncated to
+  `max_file_size`, truncation occurs at a valid UTF-8 boundary.
+- [ ] **10.10** `TestTeeFileSizeLimit` — Output exceeding `max_file_size` is
+  truncated in the tee file (raw hint file is size-bounded).
+
+---
+
+## Stage 11: Shell Tool Integration
+
+- [ ] **11.1** `TestShellToolFilterApplied` — `ShellTool.Execute` with a
+  `git status` command: LLM content uses compressed porcelain grouping.
+- [ ] **11.2** `TestShellToolStreamingUnaffected` — `EventDelta` events emit
+  raw bytes during execution; filtering only affects final `ToolResult.Content`.
+- [ ] **11.3** `TestShellToolANSIStrippedInResult` — Command that emits ANSI
+  codes: `ToolResult.Content` contains no escape sequences.
+- [ ] **11.4** `TestShellToolDisplayContentUnfiltered` — `DisplayContent` (shown
+  to human) preserves ANSI and is not compressed (user sees full output).
+- [ ] **11.5** `TestShellToolTeeOnFailure` — Failed command (exit code 1) with
+  `tee.enabled = true` produces tee file and hint in content.
+- [ ] **11.6** `TestShellToolFilterDisabled` — Config `enabled = false`:
+  `ToolResult.Content` is raw output (same as current behavior).
+- [ ] **11.7** `TestShellToolMaxBytesRespected` — After all filtering, content
+  never exceeds `maxOutputBytes`.
+
+---
+
+## Commit Sequence
+
+Each stage maps to one `[BEHAVIORAL]` commit after all tests in that stage pass.
+Structural commits (e.g., creating the package, moving constants) use
+`[STRUCTURAL]` prefix and are committed separately before any behavioral change.
+
+| Commit | Scope |
+|---|---|
+| `[STRUCTURAL]` | Create `internal/tools/filter/` package scaffold |
+| `[BEHAVIORAL]` | Stage 1: ANSI stripping |
+| `[BEHAVIORAL]` | Stage 2: Head+tail windowing |
+| `[BEHAVIORAL]` | Stage 3: Log deduplication |
+| `[BEHAVIORAL]` | Stage 4: Git output compression |
+| `[BEHAVIORAL]` | Stage 5: Test runner summarization |
+| `[BEHAVIORAL]` | Stage 6: Directory listing compression |
+| `[BEHAVIORAL]` | Stage 7: Grep compression |
+| `[BEHAVIORAL]` | Stage 8: Declarative filter rules |
+| `[BEHAVIORAL]` | Stage 9: Pipeline integration |
+| `[BEHAVIORAL]` | Stage 10: Failure tee |
+| `[BEHAVIORAL]` | Stage 11: Shell tool integration |
+
+Total: ~110 test cases across 12 commits.

--- a/docs/plans/2026-04-16-shell-output-filtering-plan.md
+++ b/docs/plans/2026-04-16-shell-output-filtering-plan.md
@@ -57,10 +57,11 @@
 
 ## Stage 3: Log Deduplication
 
-- [ ] **3.1** `TestLogDedupNoLogLines` — Non-log output (plain text below 40%
-  log-pattern threshold) is returned unchanged.
-- [ ] **3.2** `TestLogDedupDetectionThreshold` — Exactly 40% log lines triggers
-  dedup; 39% does not.
+- [ ] **3.1** `TestLogDedupNoLogLines` — Non-log output (e.g. plain Go source
+  code, ~5% log-pattern lines) is returned unchanged.
+- [ ] **3.2** `TestLogDedupDetectionThreshold` — Input with ~80% log-pattern
+  lines triggers dedup; input with ~10% log-pattern lines does not. Tests use
+  clearly supra- and sub-threshold inputs, not boundary values.
 - [ ] **3.3** `TestLogDedupTimestampNormalization` — Lines differing only by
   ISO timestamp are collapsed into one `[×N]` entry.
 - [ ] **3.4** `TestLogDedupUUIDNormalization` — Lines differing only by UUID
@@ -103,41 +104,50 @@
 - [ ] **4.7** `TestGitStatusUntrackedCap` — More than 10 untracked files shows
   first 10 + `... +N more`.
 - [ ] **4.8** `TestGitStatusNonPorcelainPassthrough` — Output not in porcelain
-  format (no two-char status codes) passes through unchanged.
-- [ ] **4.9** `TestGitStatusMixedCategories` — Single output with staged +
-  modified + untracked correctly groups all three sections.
+  format and not in human-readable format (no recognised headers, no two-char
+  status codes) passes through unchanged.
+- [ ] **4.9** `TestGitStatusMixedCategories` — Single porcelain output with
+  staged + modified + untracked correctly groups all three sections.
+- [ ] **4.10** `TestGitStatusHumanReadableStaged` — Human-readable `git status`
+  output with `Changes to be committed:` section → staged files extracted,
+  capped at 15, with `+N more` when exceeded.
+- [ ] **4.11** `TestGitStatusHumanReadableUntracked` — Human-readable output
+  with `Untracked files:` section capped at 10 with `+N more`.
+- [ ] **4.12** `TestGitStatusFlagsBeforeSubcmd` — `git -C /some/path status`
+  (flag before subcommand) does not match the filter regex; output passes
+  through unchanged. Documents the known limitation.
 
 ### 4B. git log
 
-- [ ] **4.10** `TestGitLogCommitCap` — More than 15 commits → first 15 + count
+- [ ] **4.13** `TestGitLogCommitCap` — More than 15 commits → first 15 + count
   message.
-- [ ] **4.11** `TestGitLogMessageTruncation` — Commit message lines exceeding
+- [ ] **4.14** `TestGitLogMessageTruncation` — Commit message lines exceeding
   100 chars are truncated with `...`.
-- [ ] **4.12** `TestGitLogTrailerStripping` — `Signed-off-by:`,
+- [ ] **4.15** `TestGitLogTrailerStripping` — `Signed-off-by:`,
   `Co-authored-by:`, `Change-Id:` lines are removed.
-- [ ] **4.13** `TestGitLogBodyLineLimit` — More than 3 body lines per commit →
+- [ ] **4.16** `TestGitLogBodyLineLimit` — More than 3 body lines per commit →
   first 3 + `[+N lines omitted]`.
-- [ ] **4.14** `TestGitLogNoBodyCommit` — Commit with subject only (no body)
+- [ ] **4.17** `TestGitLogNoBodyCommit` — Commit with subject only (no body)
   passes through without empty line injection.
-- [ ] **4.15** `TestGitLogNonLogFormatPassthrough` — Input that does not begin
+- [ ] **4.18** `TestGitLogNonLogFormatPassthrough` — Input that does not begin
   with `commit [0-9a-f]{40}` passes through unchanged.
 
 ### 4C. git diff
 
-- [ ] **4.16** `TestGitDiffFileHeaders` — `diff --git`, `index`, `---`, `+++`
+- [ ] **4.19** `TestGitDiffFileHeaders` — `diff --git`, `index`, `---`, `+++`
   lines are preserved intact.
-- [ ] **4.17** `TestGitDiffHunkHeader` — `@@` lines are preserved intact.
-- [ ] **4.18** `TestGitDiffHunkTruncation` — Hunk with more than 60
+- [ ] **4.20** `TestGitDiffHunkHeader` — `@@` lines are preserved intact.
+- [ ] **4.21** `TestGitDiffHunkTruncation` — Hunk with more than 60
   added/removed lines → first 60 + `... (N lines omitted in this hunk)`.
-- [ ] **4.19** `TestGitDiffNoTruncationSmallHunk` — Hunk with ≤ 60 changed
+- [ ] **4.22** `TestGitDiffNoTruncationSmallHunk` — Hunk with ≤ 60 changed
   lines is preserved in full.
-- [ ] **4.20** `TestGitDiffTotalCounter` — Output ends with `+X -Y` total
+- [ ] **4.23** `TestGitDiffTotalCounter` — Output ends with `+X -Y` total
   counter.
-- [ ] **4.21** `TestGitDiffHintOnTruncation` — When any truncation occurred,
+- [ ] **4.24** `TestGitDiffHintOnTruncation` — When any truncation occurred,
   hint line is appended.
-- [ ] **4.22** `TestGitDiffNoHintWhenNoTruncation` — No hint when output was
+- [ ] **4.25** `TestGitDiffNoHintWhenNoTruncation` — No hint when output was
   not truncated.
-- [ ] **4.23** `TestGitDiffNonDiffFormatPassthrough` — Input without
+- [ ] **4.26** `TestGitDiffNonDiffFormatPassthrough` — Input without
   `diff --git` header passes through unchanged.
 
 ---
@@ -150,8 +160,9 @@
   output; discard `--- PASS` and `=== RUN` lines.
 - [ ] **5.3** `TestGoTestSummaryLine` — Final `ok`/`FAIL` summary line is
   always preserved.
-- [ ] **5.4** `TestGoTestVerboseRespected` — When command contains `-v`, do
-  NOT apply summarization (user requested verbose).
+- [ ] **5.4** `TestVerboseFlagRespected` — When command contains `-v` (go
+  test), `--verbose` (pytest, cargo test), or `-v`/`--verbose` (jest/vitest),
+  do NOT apply summarization. Tests each runner's verbosity flag.
 - [ ] **5.5** `TestPytestAllPassed` — Output with only `PASSED` lines +
   summary → `"N passed in Xs"`.
 - [ ] **5.6** `TestPytestWithFailures` — Extract failure section between
@@ -256,8 +267,10 @@
   stages (escape codes don't confuse downstream regex).
 - [ ] **9.2** `TestPipelineCommandRouting` — `git status` output routed to git
   compressor; `go test` to test summarizer; `ls -la` to dir compressor.
-- [ ] **9.3** `TestPipelineLogDedupAfterCommandFilter` — Log dedup stage runs
-  on output from command filter, not on raw input.
+- [ ] **9.3** `TestPipelineLogDedupBeforeCommandFilter` — Log dedup stage runs
+  on post-ANSI-stripped output, before the command filter. Verifies that a
+  log-heavy output with repeated lines is deduplicated before git/test
+  compression runs on the result.
 - [ ] **9.4** `TestPipelineHeadTailLast` — Head+tail windowing is applied last,
   after all command-specific compression.
 - [ ] **9.5** `TestPipelineDeclarativeRuleOverride` — A matching TOML rule
@@ -304,12 +317,18 @@
 - [ ] **11.3** `TestShellToolANSIStrippedInResult` — Command that emits ANSI
   codes: `ToolResult.Content` contains no escape sequences.
 - [ ] **11.4** `TestShellToolDisplayContentUnfiltered` — `DisplayContent` (shown
-  to human) preserves ANSI and is not compressed (user sees full output).
-- [ ] **11.5** `TestShellToolTeeOnFailure` — Failed command (exit code 1) with
-  `tee.enabled = true` produces tee file and hint in content.
-- [ ] **11.6** `TestShellToolFilterDisabled` — Config `enabled = false`:
+  to human) is set from raw bytes when output exceeded `maxOutputBytes`; it is
+  not passed through any compression stage.
+- [ ] **11.5** `TestShellToolDisplayContentRetainsANSI` — Command that emits
+  ANSI codes with output exceeding `maxOutputBytes`: `ToolResult.Content` has
+  no escape sequences; `ToolResult.DisplayContent` retains the original ANSI
+  codes verbatim.
+- [ ] **11.6** `TestShellToolTeeOnFailure` — Failed command (exit code 1) with
+  `tee.enabled = true` produces tee file under `os.UserCacheDir()/rubichan/tee/`
+  and appends hint to content.
+- [ ] **11.7** `TestShellToolFilterDisabled` — Config `enabled = false`:
   `ToolResult.Content` is raw output (same as current behavior).
-- [ ] **11.7** `TestShellToolMaxBytesRespected` — After all filtering, content
+- [ ] **11.8** `TestShellToolMaxBytesRespected` — After all filtering, content
   never exceeds `maxOutputBytes`.
 
 ---
@@ -335,4 +354,4 @@ Structural commits (e.g., creating the package, moving constants) use
 | `[BEHAVIORAL]` | Stage 10: Failure tee |
 | `[BEHAVIORAL]` | Stage 11: Shell tool integration |
 
-Total: ~110 test cases across 12 commits.
+Total: ~117 test cases across 12 commits.

--- a/docs/rtk-shell-tools-research.md
+++ b/docs/rtk-shell-tools-research.md
@@ -1,0 +1,361 @@
+# RTK Shell Tools Research
+
+**Branch**: `claude/research-rtk-shell-tools-sTSYa`  
+**Date**: 2026-04-16  
+**Source**: https://github.com/rtk-ai/rtk/tree/master
+
+---
+
+## What RTK Is
+
+RTK (rtk-ai/rtk) is a Rust CLI proxy that intercepts shell command output and
+compresses it before it reaches an AI agent's context window. It is not an
+agent — it is transparent middleware. The user or a PreToolUse hook rewrites
+`git status` to `rtk git status`; the agent receives compressed output and
+never sees the rewrite. RTK reports 60–90% token reduction on typical
+development workflows.
+
+### Repository Composition
+
+| Layer | Path | Purpose |
+|---|---|---|
+| Core | `src/core/` | Filter pipeline, runner, config, tee, tracking, TOML registry |
+| Command handlers | `src/cmds/` | Per-command Rust modules (git, system, go, js, python, …) |
+| Declarative filters | `src/filters/*.toml` | 59 TOML definitions for tools without Rust handlers |
+| Discovery | `src/discover/` | Rewrites live commands; mines session history for missed optimizations |
+| Learning | `src/learn/` | Detects fail→correct CLI mistake patterns, auto-generates rules |
+| Hooks | `hooks/` | PreToolUse scripts for Claude Code, Cursor, Copilot, Gemini, Windsurf, Cline |
+
+Primary language: **Rust**. Single static binary, zero runtime dependencies.
+
+---
+
+## RTK's Core Techniques
+
+### 1. Eight-Stage Filter Pipeline (`src/core/toml_filter.rs`)
+
+Every filter, whether written in Rust or declared in TOML, runs through the
+same ordered pipeline:
+
+```
+Stage 1: strip_ansi          — remove terminal escape sequences
+Stage 2: replace             — line-by-line regex substitution (chained rules)
+Stage 3: match_output        — if blob matches pattern → short-circuit with summary message
+Stage 4: strip / keep lines  — regex-based line filter (mutually exclusive)
+Stage 5: truncate_lines_at   — cap individual line length in characters
+Stage 6: head + tail         — keep first N + last N lines, elide middle
+Stage 7: max_lines           — absolute output cap
+Stage 8: on_empty            — fallback message when nothing remains
+```
+
+Head+tail elision format:
+```
+line 1
+line 2
+... (847 lines omitted)
+line 850
+line 851
+```
+
+TOML filter schema (one file per command family):
+```toml
+[filters.pytest]
+description         = "pytest test runner output"
+match_command       = "^pytest"
+strip_ansi          = true
+strip_lines_matching = [
+  "^platform ",
+  "^rootdir:",
+  "^plugins:",
+  "^collecting …",
+]
+tail_lines          = 30
+on_empty            = "No output"
+
+[[tests.pytest]]
+input    = "platform linux\nrootdir: /app\n1 passed in 0.5s"
+expected = "1 passed in 0.5s"
+```
+
+Priority cascade: **project-local** `.rtk/filters.toml` (trust-gated) →
+**user-global** `~/.config/rtk/filters.toml` → **built-in** (compiled in).
+
+### 2. Git Command Compression (`src/cmds/git/git.rs`)
+
+| Subcommand | Strategy |
+|---|---|
+| `git status` | Parses `--porcelain` output. Groups into Staged / Modified / Untracked / Conflict sections. Caps each section (15 / 15 / 10 files) with `+N more`. |
+| `git log` | Truncates commit messages to 80 chars, caps at 10 commits, strips `Signed-off-by` / `Co-authored-by` trailers, keeps up to 3 body lines per commit. |
+| `git diff` | Per-hunk truncation at 100 changed lines. `+X -Y` per-file counters. Recovery hint appended: `[full diff: rtk git diff --no-compact]`. |
+
+### 3. Log Deduplication (`src/cmds/system/log_cmd.rs`)
+
+Normalizes log lines with five patterns before comparison:
+
+| Pattern | Replaced With |
+|---|---|
+| Timestamps | *(stripped)* |
+| UUIDs | `<UUID>` |
+| Hex values | `<HEX>` |
+| Numbers ≥ 4 digits | `<NUM>` |
+| File paths | `<PATH>` |
+
+Counts occurrences; collapses N identical normalized lines into one entry
+with `[×N]`. Displays top-10 errors, top-5 warnings sorted by frequency.
+
+Example:
+```
+# raw (47 lines)
+[ERROR] Connection refused at 14:32:01
+[ERROR] Connection refused at 14:32:02
+…
+
+# filtered (1 line)
+[ERROR] Connection refused [×47]
+```
+
+### 4. File Read Filtering (`src/core/filter.rs`, `src/cmds/system/read.rs`)
+
+Language detected from file extension. Three filter levels:
+
+| Level | Effect |
+|---|---|
+| None | Raw content |
+| Minimal | Remove comments, normalize multiple blank lines to max 2 |
+| Aggressive | Keep only imports + function/class signatures; replace bodies with `// ... implementation` |
+
+Safety fallback: if filtering empties a non-empty file, revert to raw content
+with a warning.
+
+### 5. System Command Compression
+
+| Command | Strategy |
+|---|---|
+| `ls -la` | Parse with date-field anchor regex, skip `.`/`..`/`total`, exclude noise dirs (`node_modules`, `.git`, `target`, `__pycache__`), human-readable sizes, extension frequency summary |
+| `tree` | Auto-inject `-I 'node_modules\|.git\|target\|…'` unless `-a` given; strip summary lines |
+| `find` | Group results by directory; path abbreviation (`...last-47-chars`); top-5 extension summary; cap at N files |
+| `grep`/`rg` | Group by filename with match count; per-file result cap; context window centered on match; long path compression to `first/.../last` |
+| `wc` | Compact single-line summary |
+| `ps` | Keep only significant process fields |
+
+### 6. Failure Output Preservation (`src/core/tee.rs`)
+
+When a filter truncates output or a command fails, RTK writes the complete raw
+output to `~/.local/share/rtk/tee/<timestamp>-<command>.txt` and appends a
+hint to the LLM result:
+
+```
+[Full output saved to: ~/.local/share/rtk/tee/20260416-143201-git-diff.txt]
+```
+
+Config: `TeeConfig { enabled, mode: Never|Failures|Always, max_files: 20,
+max_file_size: 1MB }`. Old files are rotated automatically.
+
+### 7. Command Rewrite Hook for Claude Code (`hooks/claude/rtk-rewrite.sh`)
+
+A `PreToolUse` Bash hook reads the tool's `command` field from JSON via `jq`,
+delegates to `rtk rewrite`, and interprets exit codes:
+
+| Exit | Meaning | Hook action |
+|---|---|---|
+| 0 | Rewrite found, safe | Output rewritten command + `"permissionDecision": "allow"` |
+| 1 | No RTK equivalent | Pass command through unchanged |
+| 2 | Deny rule triggered | Let native denial handle it |
+| 3 | Rewrite found, needs confirmation | Output rewritten command, omit permission decision |
+
+The LLM never sees the rewrite. It issues `git status`; it receives compressed
+output.
+
+### 8. Token Analytics (`src/core/tracking.rs`)
+
+SQLite database at `~/.local/share/rtk/history.db`. Records per-execution:
+command, raw size, filtered size, estimated token savings (`chars / 4`),
+execution time, project path. Retention: 90 days. Powers:
+
+- `rtk gain` — cumulative savings report with per-command breakdown
+- `rtk session` — savings for recent sessions
+- `rtk discover` — mines Claude Code `.jsonl` session files to find commands
+  that _could_ have been rewritten but weren't
+
+### 9. Discover & Learn (`src/discover/`, `src/learn/`)
+
+**discover**: 73-rule regex registry maps command patterns to `rtk <cmd>`
+rewrites. For live interception: match → rewrite. For history analysis: parse
+session JSONL, find unoptimized commands, report missed savings.
+
+**learn**: Analyzes session history for fail→succeed command pairs. Classifies
+error type (unknown flag, wrong path, missing argument). Assigns confidence
+score. Auto-generates correction rules above threshold.
+
+---
+
+## Rubichan's Current Shell Tool State
+
+| Aspect | Current Implementation | File |
+|---|---|---|
+| LLM output cap | Naive head chop at 30 KB | `internal/tools/limits.go:5` |
+| Display cap | Naive head chop at 100 KB | `internal/tools/limits.go:7` |
+| Truncation strategy | `output[:maxOutputBytes] + "\n... output truncated"` — head only, tail lost | `internal/tools/shell.go:431` |
+| ANSI stripping | None — raw escape codes reach the LLM | — |
+| Command-aware filtering | None — `ls`, `git log`, `pytest` all treated identically | — |
+| Log deduplication | None | — |
+| Failure output preservation | None — failed commands lose output same as success | — |
+| Token analytics | None | — |
+
+Rubichan does have strong points RTK lacks: OS-level sandboxing (seatbelt /
+bubblewrap), command substitution blocking, recursive-rm interception,
+diff tracking, background process management, and a streaming event
+architecture. These are orthogonal to output filtering and should be
+preserved.
+
+---
+
+## Token Reduction Benchmarks (from RTK README)
+
+Measured over a representative 30-minute Claude Code session:
+
+| Command family | Raw tokens | Filtered tokens | Reduction |
+|---|---|---|---|
+| `ls` / `tree` | 2,000 | 400 | −80% |
+| File reads (`cat`) | 40,000 | 12,000 | −70% |
+| Test runners | 25,000 | 2,500 | −90% |
+| **Session total** | **~118,000** | **~23,900** | **−80%** |
+
+Per-category savings from RTK's rule registry:
+
+| Category | Example commands | Claimed savings |
+|---|---|---|
+| Git | git, yadm | 70% |
+| GitHub CLI | gh pr/issue/run | 82% |
+| Test runners | vitest, jest, pytest | 90–99% |
+| Linters | eslint, biome, tsc | 83–87% |
+| Build tools | cargo, next build | 80–87% |
+| Infra | docker, kubectl, aws | 80–85% |
+| Go toolchain | go test/build, golangci-lint | 85% |
+
+---
+
+## Improvement Opportunities for Rubichan
+
+### Quick Wins (Low Complexity, High Impact)
+
+**QW-1: Head+tail truncation**  
+Replace `output[:maxOutputBytes]` with a head+tail window. Keep the first
+`N` lines and last `M` lines, elide the middle. The tail is where errors,
+test failure summaries, and build results appear — losing it on truncation
+is a significant quality regression.
+
+**QW-2: ANSI escape code stripping**  
+Strip terminal color/formatting sequences before storing output in the
+`ToolResult`. ANSI codes consume tokens without conveying meaning to the LLM.
+A single `go test` run with color enabled can waste hundreds of tokens on
+escape sequences alone.
+
+**QW-3: Failure output preservation (tee)**  
+On non-zero exit code, write full raw output to a temp file and append the
+path as a hint. The LLM can re-read it via the file tool without re-running
+the command. Prevents information loss when filtered/truncated output omits
+the root cause.
+
+**QW-4: Noise directory exclusion for ls / tree**  
+When `ls -la` or `tree` is invoked through the shell tool, automatically
+inject ignore patterns for `node_modules`, `.git`, `target`, `__pycache__`,
+`.next`, `dist`, `vendor`. Skip when `-a` is present (respecting user intent).
+
+### Medium Complexity, High Impact
+
+**MI-1: Log deduplication**  
+Detect when shell output is a log stream (consecutive timestamped lines).
+Normalize and collapse repeated lines with `[×N]` counts. Particularly
+valuable for build systems, test runners, and server logs.
+
+**MI-2: Git output compression in shell tool**  
+When `git status`, `git log`, or `git diff` is invoked through the shell
+tool (not the dedicated git tools), apply structured compression: porcelain
+parsing for status, message truncation and trailer stripping for log, per-hunk
+limiting for diff. Rubichan's dedicated git tools handle the structured path
+but raw `git` through shell is unfiltered.
+
+**MI-3: Test runner summarization**  
+Detect `go test`, `pytest`, `cargo test`, `npm test`, `jest`, `vitest` output
+patterns. Extract pass/fail/skip counts + failure details only. Discard
+passing test output. A full `go test -v ./...` on a large codebase can produce
+megabytes of output; only failures and the summary line matter to the LLM.
+
+**MI-4: Language-aware `cat` filtering**  
+When `cat <file>` is invoked through shell, detect the file's language from
+its extension and apply minimal filtering: strip comment blocks, collapse
+repeated blank lines to max 2. (Aggressive mode — signature-only — is better
+left to an explicit agent request.)
+
+### Architectural / Strategic
+
+**AR-1: Declarative output filter rules (TOML/YAML)**  
+Introduce a per-command filter registry analogous to RTK's TOML system. Store
+filter definitions at `~/.config/rubichan/filters.toml` and
+`.rubichan/filters.toml` (project-local, trust-gated). Each definition
+specifies `match_command` regex plus pipeline stages. Enables users to add
+filters for internal tools without modifying rubichan source.
+
+**AR-2: Token usage analytics**  
+Track raw vs. filtered output sizes per command. Store in the SQLite database
+(already planned in Milestone 4). Surface via `rubichan stats` or in the TUI
+status bar. Helps users and developers understand the real impact of filtering.
+
+**AR-3: Session history mining**  
+Analyse completed session logs to identify commands with large raw output that
+had no filter applied. Report them as optimization opportunities. Analogous to
+`rtk discover`.
+
+---
+
+## Prioritized Improvement Matrix
+
+| ID | Opportunity | Token Impact | Complexity | Milestone Fit |
+|---|---|---|---|---|
+| QW-1 | Head+tail truncation | High | Low | M1 (agent loop) |
+| QW-2 | ANSI stripping | High | Low | M1 (agent loop) |
+| QW-3 | Failure tee | Medium | Low | M1 (agent loop) |
+| QW-4 | Noise dir exclusion | Medium | Low | M1 (shell tool) |
+| MI-1 | Log deduplication | High | Medium | M2 (tool layer) |
+| MI-2 | Git shell compression | High | Medium | M2 (tool layer) |
+| MI-3 | Test runner summary | High | Medium | M2 (tool layer) |
+| MI-4 | Language-aware cat | Medium | Medium | M2 (tool layer) |
+| AR-1 | Declarative filters | High | High | M3 (skill system) |
+| AR-2 | Token analytics | Low | High | M4 (SQLite) |
+| AR-3 | Session mining | Low | High | M4 (SQLite) |
+
+Milestone alignment uses rubichan's existing roadmap from `CLAUDE.md`.
+
+---
+
+## What NOT to Copy
+
+RTK's hook-based command rewriting (rewiring `git` → `rtk git` in the shell)
+is elegant for a proxy tool but wrong for rubichan. Rubichan owns the tool
+execution loop directly — it can filter output at the point of capture without
+any shell hook indirection. The equivalent in rubichan is a filter applied
+inside `ExecuteStream` after `wg.Wait()` at `shell.go:408`.
+
+RTK's separate binary model also does not apply. Rubichan is a single agent
+binary; filtering belongs inside `internal/tools/` as a pure library concern.
+
+---
+
+## Key Source Locations in RTK
+
+| File | What to study |
+|---|---|
+| `src/core/toml_filter.rs` | Full 8-stage pipeline + TOML schema |
+| `src/core/filter.rs` | Language-aware comment/whitespace filter + smart_truncate |
+| `src/core/runner.rs` | run_filtered() — how filters hook into command execution |
+| `src/core/tee.rs` | Failure output preservation |
+| `src/core/tracking.rs` | Token savings analytics with SQLite |
+| `src/cmds/git/git.rs` | Git status/log/diff compression |
+| `src/cmds/system/ls.rs` | ls compact format |
+| `src/cmds/system/log_cmd.rs` | Log deduplication with normalization |
+| `src/cmds/system/summary.rs` | Auto-detect output type + summarize |
+| `src/cmds/system/grep_cmd.rs` | Grep grouping + path compression |
+| `src/cmds/system/find_cmd.rs` | Find directory grouping |
+| `src/discover/rules.rs` | Full 73-rule rewrite registry |
+| `hooks/claude/rtk-rewrite.sh` | Claude Code PreToolUse hook |


### PR DESCRIPTION
## Summary

- Deep research into [rtk-ai/rtk](https://github.com/rtk-ai/rtk), a Rust CLI proxy that achieves 60–90% LLM token reduction via command-aware output compression
- Design document specifying a layered `internal/tools/filter/` package for rubichan
- TDD implementation plan with ~110 test cases across 11 stages

## Motivation

Rubichan's shell tool currently sends raw command output to the LLM with a naive 30 KB head-chop. The tail — where errors, test failures, and build summaries appear — is silently lost on truncation. RTK demonstrates that command-aware compression can reduce token consumption 60–90% while _improving_ signal quality by keeping the most actionable parts of output.

## Documents

| File | Purpose |
|---|---|
| `docs/rtk-shell-tools-research.md` | Full RTK architecture analysis: 8-stage pipeline, TOML filter schema, git/test/ls/grep compression, failure tee, token analytics, benchmark data |
| `docs/plans/2026-04-16-shell-output-filtering-design.md` | Design spec: new `internal/tools/filter/` package, pipeline integration point in `ExecuteStream`, config schema, correctness invariants |
| `docs/plans/2026-04-16-shell-output-filtering-plan.md` | TDD plan: ~110 failing-test-first cases across 11 stages, mapping to 12 commits |

## Key Findings from RTK

**What rubichan is missing:**

| Gap | Impact |
|---|---|
| Naive head-only truncation (tail lost) | Errors/failures at end of output silently dropped |
| No ANSI stripping | Raw escape codes consume tokens without conveying meaning |
| No command-aware compression | `git log`, `pytest`, `ls -la` treated identically to `echo` |
| No log deduplication | 47 identical error lines sent as 47 lines instead of 1 |
| No failure output preservation | Full output lost after filtering; can't recover without re-running |

**Benchmarks from a 30-minute Claude Code session:**

| Command family | Raw tokens | Filtered | Reduction |
|---|---|---|---|
| `ls` / `tree` | 2,000 | 400 | −80% |
| File reads (`cat`) | 40,000 | 12,000 | −70% |
| Test runners | 25,000 | 2,500 | −90% |
| **Session total** | **~118,000** | **~23,900** | **−80%** |

## Proposed Filter Pipeline

```
raw output (bytes)
        │
        ▼
[StripANSI]          — remove terminal escape sequences
        │
        ▼
[CommandFilter]      — git/test/ls/grep/find compression
        │
        ▼
[LogDeduplicator]    — collapse repeated log lines with [×N]
        │
        ▼
[HeadTailWindow]     — keep first 200 + last 100 lines, elide middle
        │
        ▼
 LLM content (≤ 30 KB)
```

Streaming `EventDelta` events are unaffected — users still see full live output. Filtering only applies to the final `ToolResult.Content` sent to the LLM.

## Implementation Stages (plan)

| Stage | Scope | Tests |
|---|---|---|
| 0 | Package scaffold | 1 |
| 1 | ANSI stripping | 8 |
| 2 | Head+tail windowing | 9 |
| 3 | Log deduplication | 12 |
| 4 | Git compression (status/log/diff) | 23 |
| 5 | Test runner summarization | 10 |
| 6 | Directory listing compression | 13 |
| 7 | Grep/ripgrep compression | 7 |
| 8 | Declarative TOML filter rules | 16 |
| 9 | Pipeline integration | 8 |
| 10 | Failure tee | 10 |
| 11 | Shell tool integration | 7 |

## What NOT to Copy from RTK

RTK's command-rewriting hook (rewiring `git` → `rtk git` in the shell) is not needed. Rubichan owns the execution loop directly and can filter output at the capture point inside `ExecuteStream` — no shell hook indirection required.

## Test plan

- [ ] Review research findings in `docs/rtk-shell-tools-research.md`
- [ ] Review design in `docs/plans/2026-04-16-shell-output-filtering-design.md`
- [ ] Review TDD plan in `docs/plans/2026-04-16-shell-output-filtering-plan.md`
- [ ] Confirm milestone fit (QW-1/QW-2/QW-3/QW-4 → M1; MI-1 through MI-4 → M2; AR-1 → M3)
- [ ] Approve plan before implementation begins

https://claude.ai/code/session_01HubtXdHzan9i516y3chRZZ