### PR TITLE
Wire dead skill hook phases into production dispatch sites

### DIFF
--- a/cmd/rubichan/init.go
+++ b/cmd/rubichan/init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -16,9 +17,10 @@ import (
 
 func initCmd() *cobra.Command {
 	var (
-		dir       string
-		force     bool
-		hooksOnly bool
+		dir        string
+		force      bool
+		hooksOnly  bool
+		trustHooks bool
 	)
 
 	cmd := &cobra.Command{
@@ -40,7 +42,7 @@ AGENT.md sections. Sections that cannot be auto-detected use TODO placeholders.`
 
 			if hooksOnly {
 				fmt.Fprintf(cmd.OutOrStdout(), "Running setup hooks (mode=hooks-only)...\n")
-				return runSetupHooks(cmd.Context(), dir)
+				return runSetupHooks(cmd.Context(), cmd.OutOrStdout(), dir, trustHooks)
 			}
 
 			for _, sub := range []string{".agent/skills", ".agent/hooks"} {
@@ -74,26 +76,34 @@ AGENT.md sections. Sections that cannot be auto-detected use TODO placeholders.`
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Generated AGENT.md and .agent/ structure in %s\n", dir)
-			return runSetupHooks(cmd.Context(), dir)
+			return runSetupHooks(cmd.Context(), cmd.OutOrStdout(), dir, trustHooks)
 		},
 	}
 
 	cmd.Flags().StringVar(&dir, "dir", "", "Project directory (default: current directory)")
 	cmd.Flags().BoolVar(&force, "force", false, "Overwrite existing AGENT.md")
 	cmd.Flags().BoolVar(&hooksOnly, "hooks-only", false, "Run setup hooks only, skip file generation")
+	cmd.Flags().BoolVar(&trustHooks, "trust-hooks", false, "Execute setup hooks from .agent/hooks.toml (runs shell commands; review the file first)")
 
 	return cmd
 }
 
 // runSetupHooks loads .agent/hooks.toml in dir and dispatches HookOnSetup to
-// any registered handlers. Missing hooks.toml is not an error — init may run
-// in projects that haven't configured hooks yet.
-func runSetupHooks(ctx context.Context, dir string) error {
+// any registered handlers. Hooks are shell commands, so they only run when
+// trustHooks is true — mirroring the trust gate used by the agent entry points
+// so an attacker who can write .agent/hooks.toml cannot get code execution via
+// `rubichan init`.
+func runSetupHooks(ctx context.Context, out io.Writer, dir string, trustHooks bool) error {
 	configs, err := hooks.LoadHooksTOML(dir)
 	if err != nil {
 		return fmt.Errorf("loading .agent/hooks.toml: %w", err)
 	}
 	if len(configs) == 0 {
+		return nil
+	}
+
+	if !trustHooks {
+		fmt.Fprintf(out, "Skipping %d setup hook(s) in .agent/hooks.toml — re-run with --trust-hooks after reviewing the file to execute them.\n", len(configs))
 		return nil
 	}
 

--- a/cmd/rubichan/init.go
+++ b/cmd/rubichan/init.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -9,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/julianshen/rubichan/internal/commands"
+	"github.com/julianshen/rubichan/internal/hooks"
+	"github.com/julianshen/rubichan/internal/skills"
 )
 
 func initCmd() *cobra.Command {
@@ -37,7 +40,7 @@ AGENT.md sections. Sections that cannot be auto-detected use TODO placeholders.`
 
 			if hooksOnly {
 				fmt.Fprintf(cmd.OutOrStdout(), "Running setup hooks (mode=hooks-only)...\n")
-				return nil
+				return runSetupHooks(cmd.Context(), dir)
 			}
 
 			for _, sub := range []string{".agent/skills", ".agent/hooks"} {
@@ -71,7 +74,7 @@ AGENT.md sections. Sections that cannot be auto-detected use TODO placeholders.`
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Generated AGENT.md and .agent/ structure in %s\n", dir)
-			return nil
+			return runSetupHooks(cmd.Context(), dir)
 		},
 	}
 
@@ -80,4 +83,32 @@ AGENT.md sections. Sections that cannot be auto-detected use TODO placeholders.`
 	cmd.Flags().BoolVar(&hooksOnly, "hooks-only", false, "Run setup hooks only, skip file generation")
 
 	return cmd
+}
+
+// runSetupHooks loads .agent/hooks.toml in dir and dispatches HookOnSetup to
+// any registered handlers. Missing hooks.toml is not an error — init may run
+// in projects that haven't configured hooks yet.
+func runSetupHooks(ctx context.Context, dir string) error {
+	configs, err := hooks.LoadHooksTOML(dir)
+	if err != nil {
+		return fmt.Errorf("loading .agent/hooks.toml: %w", err)
+	}
+	if len(configs) == 0 {
+		return nil
+	}
+
+	lm := skills.NewLifecycleManager()
+	hooks.NewUserHookRunner(configs, dir).RegisterIntoLM(lm)
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, err := lm.Dispatch(skills.HookEvent{
+		Phase: skills.HookOnSetup,
+		Ctx:   ctx,
+		Data:  map[string]any{"mode": "init", "dir": dir},
+	}); err != nil {
+		return fmt.Errorf("dispatching setup hooks: %w", err)
+	}
+	return nil
 }

--- a/cmd/rubichan/init.go
+++ b/cmd/rubichan/init.go
@@ -100,9 +100,6 @@ func runSetupHooks(ctx context.Context, dir string) error {
 	lm := skills.NewLifecycleManager()
 	hooks.NewUserHookRunner(configs, dir).RegisterIntoLM(lm)
 
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	if _, err := lm.Dispatch(skills.HookEvent{
 		Phase: skills.HookOnSetup,
 		Ctx:   ctx,

--- a/cmd/rubichan/init_test.go
+++ b/cmd/rubichan/init_test.go
@@ -83,9 +83,30 @@ func TestInitCmdFiresSetupHookFromTOML(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(agentDir, "hooks.toml"), []byte(tomlContent), 0o644))
 
 	cmd := initCmd()
-	cmd.SetArgs([]string{"--dir", dir, "--hooks-only"})
+	cmd.SetArgs([]string{"--dir", dir, "--hooks-only", "--trust-hooks"})
 	require.NoError(t, cmd.Execute())
 
 	_, err := os.Stat(marker)
 	assert.NoError(t, err, "setup hook should have created marker file")
+}
+
+// TestInitCmdSkipsUntrustedSetupHooks asserts that setup hooks defined in
+// .agent/hooks.toml are NOT executed unless --trust-hooks is passed. This
+// closes the code-execution hole where an attacker who can write
+// .agent/hooks.toml could get shell execution on `rubichan init`.
+func TestInitCmdSkipsUntrustedSetupHooks(t *testing.T) {
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, ".agent")
+	require.NoError(t, os.MkdirAll(agentDir, 0o755))
+
+	marker := filepath.Join(dir, "should-not-exist")
+	tomlContent := "[[hooks]]\nevent = \"setup\"\ncommand = \"touch " + marker + "\"\ntimeout = \"5s\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(agentDir, "hooks.toml"), []byte(tomlContent), 0o644))
+
+	cmd := initCmd()
+	cmd.SetArgs([]string{"--dir", dir, "--hooks-only"})
+	require.NoError(t, cmd.Execute())
+
+	_, err := os.Stat(marker)
+	assert.True(t, os.IsNotExist(err), "untrusted setup hook must not run without --trust-hooks")
 }

--- a/cmd/rubichan/init_test.go
+++ b/cmd/rubichan/init_test.go
@@ -69,3 +69,23 @@ func TestInitCmdHooksOnly(t *testing.T) {
 	_, err := os.Stat(filepath.Join(dir, "AGENT.md"))
 	assert.True(t, os.IsNotExist(err))
 }
+
+// TestInitCmdFiresSetupHookFromTOML asserts that `rubichan init` loads
+// .agent/hooks.toml and actually fires hooks registered for the "setup"
+// event, rather than just printing a placeholder message.
+func TestInitCmdFiresSetupHookFromTOML(t *testing.T) {
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, ".agent")
+	require.NoError(t, os.MkdirAll(agentDir, 0o755))
+
+	marker := filepath.Join(dir, "setup-ran")
+	tomlContent := "[[hooks]]\nevent = \"setup\"\ncommand = \"touch " + marker + "\"\ntimeout = \"5s\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(agentDir, "hooks.toml"), []byte(tomlContent), 0o644))
+
+	cmd := initCmd()
+	cmd.SetArgs([]string{"--dir", dir, "--hooks-only"})
+	require.NoError(t, cmd.Execute())
+
+	_, err := os.Stat(marker)
+	assert.NoError(t, err, "setup hook should have created marker file")
+}

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1140,23 +1140,30 @@ func newDefaultSecurityEngine(cfg security.EngineConfig, llm provider.LLMProvide
 
 // securityScanCompleteHook returns an OnScanComplete callback that forwards
 // the final scan report to the skill runtime as a HookOnSecurityScanComplete
-// event so security-rule skills can observe scan results.
+// event so security-rule skills can observe scan results. The full Findings
+// and AttackChains slices are exposed so handlers can react to specific
+// vulnerabilities, not just summary counts.
 func securityScanCompleteHook(rt *skills.Runtime) func(context.Context, *security.Report) {
 	return func(ctx context.Context, report *security.Report) {
 		if rt == nil || report == nil {
 			return
 		}
-		_, _ = rt.DispatchHook(skills.HookEvent{
+		if _, err := rt.DispatchHook(skills.HookEvent{
 			Phase: skills.HookOnSecurityScanComplete,
 			Ctx:   ctx,
 			Data: map[string]any{
+				"findings":       report.Findings,
+				"attack_chains":  report.AttackChains,
+				"errors":         report.Errors,
 				"findings_count": report.Stats.FindingsCount,
 				"chain_count":    report.Stats.ChainCount,
 				"files_scanned":  report.Stats.FilesScanned,
 				"duration_ms":    report.Stats.Duration.Milliseconds(),
 				"errors_count":   len(report.Errors),
 			},
-		})
+		}); err != nil {
+			log.Printf("HookOnSecurityScanComplete failed: %v", err)
+		}
 	}
 }
 

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1138,6 +1138,28 @@ func newDefaultSecurityEngine(cfg security.EngineConfig, llm provider.LLMProvide
 	return e
 }
 
+// securityScanCompleteHook returns an OnScanComplete callback that forwards
+// the final scan report to the skill runtime as a HookOnSecurityScanComplete
+// event so security-rule skills can observe scan results.
+func securityScanCompleteHook(rt *skills.Runtime) func(context.Context, *security.Report) {
+	return func(ctx context.Context, report *security.Report) {
+		if rt == nil || report == nil {
+			return
+		}
+		_, _ = rt.DispatchHook(skills.HookEvent{
+			Phase: skills.HookOnSecurityScanComplete,
+			Ctx:   ctx,
+			Data: map[string]any{
+				"findings_count": report.Stats.FindingsCount,
+				"chain_count":    report.Stats.ChainCount,
+				"files_scanned":  report.Stats.FilesScanned,
+				"duration_ms":    report.Stats.Duration.Milliseconds(),
+				"errors_count":   len(report.Errors),
+			},
+		})
+	}
+}
+
 // pipelineComponents holds the pipeline and its key components for
 // integration with the approval system.
 type pipelineComponents struct {
@@ -2334,6 +2356,9 @@ func runHeadless() error {
 			Concurrency:     4,
 			MaxLLMChunks:    cfg.Security.MaxLLMCalls,
 			ExcludePatterns: cfg.Security.ExcludePatterns,
+		}
+		if rt != nil {
+			engineCfg.OnScanComplete = securityScanCompleteHook(rt)
 		}
 		// Only pass the provider when LLM analysis is explicitly enabled;
 		// the config defaults to false so users opt-in to the cost.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1176,6 +1176,35 @@ func (a *Agent) makeDoneEvent(inputTokens, outputTokens int, reason agentsdk.Tur
 	return event
 }
 
+// dispatchAfterResponseHook fires HookOnAfterResponse at the end of a turn
+// that completed without pending tool calls. Handlers receive the assembled
+// response text and the turn's exit reason. Failures are logged but do not
+// alter the done event, since post-response hooks are informational.
+func (a *Agent) dispatchAfterResponseHook(ctx context.Context, blocks []provider.ContentBlock, reason agentsdk.TurnExitReason) {
+	if a.skillRuntime == nil {
+		return
+	}
+
+	var responseText strings.Builder
+	for _, block := range blocks {
+		if block.Type == "text" {
+			responseText.WriteString(block.Text)
+		}
+	}
+
+	event := skills.HookEvent{
+		Phase: skills.HookOnAfterResponse,
+		Ctx:   ctx,
+		Data: map[string]any{
+			"response":    responseText.String(),
+			"exit_reason": reason.String(),
+		},
+	}
+	if _, err := a.skillRuntime.DispatchHook(event); err != nil {
+		a.logger.Warn("after-response hook failed: %v", err)
+	}
+}
+
 // runLoop iteratively processes LLM responses and tool calls.
 func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int, lastUserMessage string) {
 	var totalInputTokens, totalOutputTokens int
@@ -1534,6 +1563,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// empty in this branch, but Drain is cheap and safe).
 		if len(pendingTools) == 0 {
 			_ = execStream.Drain()
+			a.dispatchAfterResponseHook(ctx, blocks, exitReason)
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, exitReason))
 			return
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -857,8 +857,10 @@ func (a *Agent) saveSnapshotIfNeeded() {
 func (a *Agent) Turn(ctx context.Context, userMessage string) (<-chan TurnEvent, error) {
 	a.turnMu.Lock()
 
-	if len(a.conversation.Messages()) == 0 {
-		a.dispatchConversationStartHook(ctx, userMessage)
+	if a.conversation.Len() == 0 {
+		a.dispatchHook(ctx, skills.HookOnConversationStart, map[string]any{
+			"user_message": userMessage,
+		})
 	}
 
 	a.conversation.AddUser(userMessage)
@@ -1180,52 +1182,32 @@ func (a *Agent) makeDoneEvent(inputTokens, outputTokens int, reason agentsdk.Tur
 	return event
 }
 
-// dispatchConversationStartHook fires HookOnConversationStart at the
-// beginning of a conversation's first turn (before the first user message
-// is appended). Failures are logged and non-blocking.
-func (a *Agent) dispatchConversationStartHook(ctx context.Context, userMessage string) {
+// dispatchHook sends a hook event to the skill runtime. No-op when the
+// runtime is unset; failures are logged and non-blocking so hooks cannot
+// disrupt the turn lifecycle.
+func (a *Agent) dispatchHook(ctx context.Context, phase skills.HookPhase, data map[string]any) {
 	if a.skillRuntime == nil {
 		return
 	}
-	event := skills.HookEvent{
-		Phase: skills.HookOnConversationStart,
+	if _, err := a.skillRuntime.DispatchHook(skills.HookEvent{
+		Phase: phase,
 		Ctx:   ctx,
-		Data: map[string]any{
-			"user_message": userMessage,
-		},
-	}
-	if _, err := a.skillRuntime.DispatchHook(event); err != nil {
-		a.logger.Warn("conversation-start hook failed: %v", err)
+		Data:  data,
+	}); err != nil {
+		a.logger.Warn("%s hook failed: %v", phase, err)
 	}
 }
 
-// dispatchAfterResponseHook fires HookOnAfterResponse at the end of a turn
-// that completed without pending tool calls. Handlers receive the assembled
-// response text and the turn's exit reason. Failures are logged but do not
-// alter the done event, since post-response hooks are informational.
-func (a *Agent) dispatchAfterResponseHook(ctx context.Context, blocks []provider.ContentBlock, reason agentsdk.TurnExitReason) {
-	if a.skillRuntime == nil {
-		return
-	}
-
-	var responseText strings.Builder
+// assistantText concatenates the text of every text block in a content
+// block slice. Used to surface the final response to post-response hooks.
+func assistantText(blocks []provider.ContentBlock) string {
+	var b strings.Builder
 	for _, block := range blocks {
 		if block.Type == "text" {
-			responseText.WriteString(block.Text)
+			b.WriteString(block.Text)
 		}
 	}
-
-	event := skills.HookEvent{
-		Phase: skills.HookOnAfterResponse,
-		Ctx:   ctx,
-		Data: map[string]any{
-			"response":    responseText.String(),
-			"exit_reason": reason.String(),
-		},
-	}
-	if _, err := a.skillRuntime.DispatchHook(event); err != nil {
-		a.logger.Warn("after-response hook failed: %v", err)
-	}
+	return b.String()
 }
 
 // runLoop iteratively processes LLM responses and tool calls.
@@ -1586,7 +1568,10 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// empty in this branch, but Drain is cheap and safe).
 		if len(pendingTools) == 0 {
 			_ = execStream.Drain()
-			a.dispatchAfterResponseHook(ctx, blocks, exitReason)
+			a.dispatchHook(ctx, skills.HookOnAfterResponse, map[string]any{
+				"response":    assistantText(blocks),
+				"exit_reason": exitReason.String(),
+			})
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, exitReason))
 			return
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1210,6 +1210,63 @@ func assistantText(blocks []provider.ContentBlock) string {
 	return b.String()
 }
 
+// applyAfterResponseHook fires HookOnAfterResponse with the assembled response
+// text. When handlers return a modified "response" key, the text blocks are
+// rewritten so the persisted assistant message reflects the transform. This is
+// the consumer side of the transform-skill design (see internal/skills/integration.go).
+// No-op when skillRuntime is unset.
+func (a *Agent) applyAfterResponseHook(ctx context.Context, blocks []provider.ContentBlock, reason agentsdk.TurnExitReason) []provider.ContentBlock {
+	if a.skillRuntime == nil {
+		return blocks
+	}
+
+	original := assistantText(blocks)
+	event := skills.HookEvent{
+		Phase: skills.HookOnAfterResponse,
+		Ctx:   ctx,
+		Data: map[string]any{
+			"response":    original,
+			"exit_reason": reason.String(),
+		},
+	}
+	if _, err := a.skillRuntime.DispatchHook(event); err != nil {
+		a.logger.Warn("%s hook failed: %v", skills.HookOnAfterResponse, err)
+		return blocks
+	}
+
+	// modifyingPhases chains each handler's Modified into event.Data, so the
+	// final transformed text lives in event.Data after Dispatch returns.
+	mutated, ok := event.Data["response"].(string)
+	if !ok || mutated == original {
+		return blocks
+	}
+	return replaceAssistantText(blocks, mutated)
+}
+
+// replaceAssistantText rewrites the text content of a block slice so its
+// concatenated text equals newText. The first text block carries newText;
+// subsequent text blocks are dropped. Non-text blocks (thinking, tool_use)
+// are preserved in their original order. If no text block exists one is
+// appended at the end.
+func replaceAssistantText(blocks []provider.ContentBlock, newText string) []provider.ContentBlock {
+	out := make([]provider.ContentBlock, 0, len(blocks))
+	placed := false
+	for _, block := range blocks {
+		if block.Type == "text" {
+			if placed {
+				continue
+			}
+			block.Text = newText
+			placed = true
+		}
+		out = append(out, block)
+	}
+	if !placed {
+		out = append(out, provider.ContentBlock{Type: "text", Text: newText})
+	}
+	return out
+}
+
 // runLoop iteratively processes LLM responses and tool calls.
 func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int, lastUserMessage string) {
 	var totalInputTokens, totalOutputTokens int
@@ -1557,6 +1614,16 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			exitReason = agentsdk.ExitEmptyResponse
 		}
 
+		// On final-response turns (no pending tool calls), give the
+		// HookOnAfterResponse handlers a chance to rewrite the assistant
+		// text before it's persisted. The streamed text already reached
+		// the user, but the persisted version is what subsequent turns
+		// see in conversation context — that's the surface transform
+		// skills target.
+		if len(pendingTools) == 0 {
+			blocks = a.applyAfterResponseHook(ctx, blocks, exitReason)
+		}
+
 		// Add assistant message with accumulated blocks
 		if len(blocks) > 0 {
 			a.conversation.AddAssistant(blocks)
@@ -1568,10 +1635,6 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// empty in this branch, but Drain is cheap and safe).
 		if len(pendingTools) == 0 {
 			_ = execStream.Drain()
-			a.dispatchHook(ctx, skills.HookOnAfterResponse, map[string]any{
-				"response":    assistantText(blocks),
-				"exit_reason": exitReason.String(),
-			})
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, exitReason))
 			return
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -857,6 +857,10 @@ func (a *Agent) saveSnapshotIfNeeded() {
 func (a *Agent) Turn(ctx context.Context, userMessage string) (<-chan TurnEvent, error) {
 	a.turnMu.Lock()
 
+	if len(a.conversation.Messages()) == 0 {
+		a.dispatchConversationStartHook(ctx, userMessage)
+	}
+
 	a.conversation.AddUser(userMessage)
 	a.persistMessage("user", []provider.ContentBlock{{Type: "text", Text: userMessage}})
 	if err := a.context.Compact(ctx, a.conversation); err != nil {
@@ -1174,6 +1178,25 @@ func (a *Agent) makeDoneEvent(inputTokens, outputTokens int, reason agentsdk.Tur
 		event.DiffSummary = a.diffTracker.Summarize()
 	}
 	return event
+}
+
+// dispatchConversationStartHook fires HookOnConversationStart at the
+// beginning of a conversation's first turn (before the first user message
+// is appended). Failures are logged and non-blocking.
+func (a *Agent) dispatchConversationStartHook(ctx context.Context, userMessage string) {
+	if a.skillRuntime == nil {
+		return
+	}
+	event := skills.HookEvent{
+		Phase: skills.HookOnConversationStart,
+		Ctx:   ctx,
+		Data: map[string]any{
+			"user_message": userMessage,
+		},
+	}
+	if _, err := a.skillRuntime.DispatchHook(event); err != nil {
+		a.logger.Warn("conversation-start hook failed: %v", err)
+	}
 }
 
 // dispatchAfterResponseHook fires HookOnAfterResponse at the end of a turn

--- a/internal/agent/agent_skills_test.go
+++ b/internal/agent/agent_skills_test.go
@@ -479,6 +479,48 @@ func TestAgentAfterResponseHookFires(t *testing.T) {
 	assert.NotEmpty(t, capturedReason, "exit_reason should be passed in event data")
 }
 
+// TestAgentAfterResponseHookCanModifyPersistedText asserts that handlers
+// returning Modified["response"] actually rewrite the persisted assistant
+// message. Without this, transform skills (registered via the same phase)
+// would be silently dead — the dispatch would fire but the modification
+// would never be applied.
+func TestAgentAfterResponseHookCanModifyPersistedText(t *testing.T) {
+	hooks := map[skills.HookPhase]skills.HookHandler{
+		skills.HookOnAfterResponse: func(event skills.HookEvent) (skills.HookResult, error) {
+			original := event.Data["response"].(string)
+			return skills.HookResult{
+				Modified: map[string]any{
+					"response": strings.ToUpper(original),
+				},
+			}, nil
+		},
+	}
+
+	rt := makeTestRuntime(t, "after-response-mutator", toolManifest("after-response-mutator"), nil, hooks)
+
+	cp := &capturingMockProvider{
+		events: []provider.StreamEvent{
+			{Type: "text_delta", Text: "hello world"},
+			{Type: "stop"},
+		},
+	}
+
+	cfg := config.DefaultConfig()
+	a := New(cp, tools.NewRegistry(), autoApprove, cfg, WithSkillRuntime(rt))
+
+	ch, err := a.Turn(context.Background(), "hi")
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	msgs := a.conversation.Messages()
+	require.Len(t, msgs, 2, "user + assistant messages")
+	assistant := msgs[1]
+	require.Len(t, assistant.Content, 1, "single text block expected")
+	assert.Equal(t, "HELLO WORLD", assistant.Content[0].Text,
+		"persisted assistant text must reflect Modified[response] from the hook")
+}
+
 // TestAgentConversationStartHookFiresOnce asserts that HookOnConversationStart
 // fires on the first Turn of a new conversation and does NOT refire on
 // subsequent turns within the same conversation.

--- a/internal/agent/agent_skills_test.go
+++ b/internal/agent/agent_skills_test.go
@@ -433,6 +433,52 @@ func TestAgentBeforePromptBuildHookCanModifyPrompt(t *testing.T) {
 	assert.Contains(t, capturedReq.System, "hook-fragment-text")
 }
 
+// TestAgentAfterResponseHookFires asserts that HookOnAfterResponse is
+// dispatched when the agent finishes a turn with no pending tool calls —
+// the "response is final" branch at the end of runLoop.
+func TestAgentAfterResponseHookFires(t *testing.T) {
+	var (
+		hookCalled     bool
+		capturedText   string
+		capturedReason string
+	)
+	hooks := map[skills.HookPhase]skills.HookHandler{
+		skills.HookOnAfterResponse: func(event skills.HookEvent) (skills.HookResult, error) {
+			hookCalled = true
+			require.NotNil(t, event.Ctx)
+			if text, ok := event.Data["response"].(string); ok {
+				capturedText = text
+			}
+			if reason, ok := event.Data["exit_reason"].(string); ok {
+				capturedReason = reason
+			}
+			return skills.HookResult{}, nil
+		},
+	}
+
+	rt := makeTestRuntime(t, "after-response-hook", toolManifest("after-response-hook"), nil, hooks)
+
+	cp := &capturingMockProvider{
+		events: []provider.StreamEvent{
+			{Type: "text_delta", Text: "hello "},
+			{Type: "text_delta", Text: "world"},
+			{Type: "stop"},
+		},
+	}
+
+	cfg := config.DefaultConfig()
+	a := New(cp, tools.NewRegistry(), autoApprove, cfg, WithSkillRuntime(rt))
+
+	ch, err := a.Turn(context.Background(), "hi")
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	assert.True(t, hookCalled, "HookOnAfterResponse should fire when turn completes cleanly")
+	assert.Equal(t, "hello world", capturedText, "response text should be passed in event data")
+	assert.NotEmpty(t, capturedReason, "exit_reason should be passed in event data")
+}
+
 func TestAgentBeforePromptBuildHookReplacesAndAppendsPromptFragmentsInOrder(t *testing.T) {
 	basePromptManifest := &skills.SkillManifest{
 		Name:        "prompt-hook-order",

--- a/internal/agent/agent_skills_test.go
+++ b/internal/agent/agent_skills_test.go
@@ -479,6 +479,43 @@ func TestAgentAfterResponseHookFires(t *testing.T) {
 	assert.NotEmpty(t, capturedReason, "exit_reason should be passed in event data")
 }
 
+// TestAgentConversationStartHookFiresOnce asserts that HookOnConversationStart
+// fires on the first Turn of a new conversation and does NOT refire on
+// subsequent turns within the same conversation.
+func TestAgentConversationStartHookFiresOnce(t *testing.T) {
+	callCount := 0
+	hooks := map[skills.HookPhase]skills.HookHandler{
+		skills.HookOnConversationStart: func(event skills.HookEvent) (skills.HookResult, error) {
+			callCount++
+			require.NotNil(t, event.Ctx)
+			return skills.HookResult{}, nil
+		},
+	}
+
+	rt := makeTestRuntime(t, "conv-start-hook", toolManifest("conv-start-hook"), nil, hooks)
+
+	cp := &capturingMockProvider{
+		events: []provider.StreamEvent{{Type: "text_delta", Text: "ok"}, {Type: "stop"}},
+	}
+
+	cfg := config.DefaultConfig()
+	a := New(cp, tools.NewRegistry(), autoApprove, cfg, WithSkillRuntime(rt))
+
+	ch1, err := a.Turn(context.Background(), "first")
+	require.NoError(t, err)
+	for range ch1 {
+	}
+
+	// Rewind provider events for a second turn.
+	cp.events = []provider.StreamEvent{{Type: "text_delta", Text: "ok"}, {Type: "stop"}}
+	ch2, err := a.Turn(context.Background(), "second")
+	require.NoError(t, err)
+	for range ch2 {
+	}
+
+	assert.Equal(t, 1, callCount, "HookOnConversationStart should fire exactly once per conversation")
+}
+
 func TestAgentBeforePromptBuildHookReplacesAndAppendsPromptFragmentsInOrder(t *testing.T) {
 	basePromptManifest := &skills.SkillManifest{
 		Name:        "prompt-hook-order",

--- a/internal/agent/conversation.go
+++ b/internal/agent/conversation.go
@@ -27,6 +27,11 @@ func (c *Conversation) Messages() []provider.Message {
 	return cp
 }
 
+// Len returns the number of messages without allocating a copy.
+func (c *Conversation) Len() int {
+	return len(c.messages)
+}
+
 // AddUser appends a user message to the conversation.
 func (c *Conversation) AddUser(text string) {
 	c.messages = append(c.messages, provider.NewUserMessage(text))

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -77,7 +77,7 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 			return nil, fmt.Errorf("worktree isolation requested but no WorktreeProvider configured")
 		}
 		wtName := fmt.Sprintf("subagent-%s-%d", cfg.Name, time.Now().UnixNano())
-		s.dispatchTaskHook(ctx, skills.HookOnWorktreeCreate, map[string]any{
+		s.dispatchHook(ctx, skills.HookOnWorktreeCreate, map[string]any{
 			"subagent_name": cfg.Name,
 			"worktree_name": wtName,
 		})
@@ -91,7 +91,7 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 			if err != nil || changed {
 				return // Preserve on error or dirty state.
 			}
-			s.dispatchTaskHook(ctx, skills.HookOnWorktreeRemove, map[string]any{
+			s.dispatchHook(ctx, skills.HookOnWorktreeRemove, map[string]any{
 				"subagent_name": cfg.Name,
 				"worktree_name": wtName,
 			})
@@ -156,7 +156,7 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 	}
 	child := New(s.Provider, childTools, denyAllApproval, &childCfg, opts...)
 
-	s.dispatchTaskHook(ctx, skills.HookOnTaskCreated, map[string]any{
+	s.dispatchHook(ctx, skills.HookOnTaskCreated, map[string]any{
 		"name":   cfg.Name,
 		"prompt": prompt,
 		"depth":  cfg.Depth,
@@ -207,7 +207,7 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 	result.Output = output.String()
 	result.ToolsUsed = toolsUsed
 
-	s.dispatchTaskHook(ctx, skills.HookOnTaskCompleted, map[string]any{
+	s.dispatchHook(ctx, skills.HookOnTaskCompleted, map[string]any{
 		"name":          result.Name,
 		"output":        result.Output,
 		"turn_count":    result.TurnCount,
@@ -220,9 +220,9 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 	return result, nil
 }
 
-// dispatchTaskHook fires a task lifecycle hook on the parent runtime. Failures
-// are logged indirectly via the runtime and do not affect spawn behavior.
-func (s *DefaultSubagentSpawner) dispatchTaskHook(ctx context.Context, phase skills.HookPhase, data map[string]any) {
+// dispatchHook fires a skill lifecycle hook on the parent runtime. Failures
+// are surfaced via the runtime's own logging and never affect spawn behavior.
+func (s *DefaultSubagentSpawner) dispatchHook(ctx context.Context, phase skills.HookPhase, data map[string]any) {
 	if s.ParentSkillRuntime == nil {
 		return
 	}

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -148,6 +148,12 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 	}
 	child := New(s.Provider, childTools, denyAllApproval, &childCfg, opts...)
 
+	s.dispatchTaskHook(ctx, skills.HookOnTaskCreated, map[string]any{
+		"name":   cfg.Name,
+		"prompt": prompt,
+		"depth":  cfg.Depth,
+	})
+
 	// Run a single Turn — runLoop handles the full multi-turn loop internally,
 	// calling the LLM and executing tools iteratively until a text-only response
 	// or the turn limit is reached. This avoids appending empty user messages.
@@ -193,7 +199,37 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 	result.Output = output.String()
 	result.ToolsUsed = toolsUsed
 
+	s.dispatchTaskHook(ctx, skills.HookOnTaskCompleted, map[string]any{
+		"name":          result.Name,
+		"output":        result.Output,
+		"turn_count":    result.TurnCount,
+		"input_tokens":  result.InputTokens,
+		"output_tokens": result.OutputTokens,
+		"tools_used":    append([]string(nil), result.ToolsUsed...),
+		"error":         errString(result.Error),
+	})
+
 	return result, nil
+}
+
+// dispatchTaskHook fires a task lifecycle hook on the parent runtime. Failures
+// are logged indirectly via the runtime and do not affect spawn behavior.
+func (s *DefaultSubagentSpawner) dispatchTaskHook(ctx context.Context, phase skills.HookPhase, data map[string]any) {
+	if s.ParentSkillRuntime == nil {
+		return
+	}
+	_, _ = s.ParentSkillRuntime.DispatchHook(skills.HookEvent{
+		Phase: phase,
+		Ctx:   ctx,
+		Data:  data,
+	})
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 // SpawnParallel runs multiple subagent requests concurrently, returning one

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -213,24 +214,27 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 		"turn_count":    result.TurnCount,
 		"input_tokens":  result.InputTokens,
 		"output_tokens": result.OutputTokens,
-		"tools_used":    append([]string(nil), result.ToolsUsed...),
+		"tools_used":    result.ToolsUsed,
 		"error":         errString(result.Error),
 	})
 
 	return result, nil
 }
 
-// dispatchHook fires a skill lifecycle hook on the parent runtime. Failures
-// are surfaced via the runtime's own logging and never affect spawn behavior.
+// dispatchHook fires a skill lifecycle hook on the parent runtime. No-op
+// when no parent runtime is attached. Failures are logged and swallowed
+// so hook misbehavior never aborts a subagent spawn.
 func (s *DefaultSubagentSpawner) dispatchHook(ctx context.Context, phase skills.HookPhase, data map[string]any) {
 	if s.ParentSkillRuntime == nil {
 		return
 	}
-	_, _ = s.ParentSkillRuntime.DispatchHook(skills.HookEvent{
+	if _, err := s.ParentSkillRuntime.DispatchHook(skills.HookEvent{
 		Phase: phase,
 		Ctx:   ctx,
 		Data:  data,
-	})
+	}); err != nil {
+		log.Printf("%s hook failed: %v", phase, err)
+	}
 }
 
 func errString(err error) string {

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -77,6 +77,10 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 			return nil, fmt.Errorf("worktree isolation requested but no WorktreeProvider configured")
 		}
 		wtName := fmt.Sprintf("subagent-%s-%d", cfg.Name, time.Now().UnixNano())
+		s.dispatchTaskHook(ctx, skills.HookOnWorktreeCreate, map[string]any{
+			"subagent_name": cfg.Name,
+			"worktree_name": wtName,
+		})
 		wt, err := s.WorktreeProvider.CreateWorktree(ctx, wtName)
 		if err != nil {
 			return nil, fmt.Errorf("creating worktree for subagent: %w", err)
@@ -87,6 +91,10 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 			if err != nil || changed {
 				return // Preserve on error or dirty state.
 			}
+			s.dispatchTaskHook(ctx, skills.HookOnWorktreeRemove, map[string]any{
+				"subagent_name": cfg.Name,
+				"worktree_name": wtName,
+			})
 			_ = s.WorktreeProvider.RemoveWorktree(ctx, wtName)
 		}
 	}

--- a/internal/agent/subagent_test.go
+++ b/internal/agent/subagent_test.go
@@ -195,33 +195,7 @@ func TestSpawnDispatchesWorktreeCreateAndRemove(t *testing.T) {
 		},
 	}
 
-	s, err := store.NewStore(":memory:")
-	require.NoError(t, err)
-	defer s.Close()
-
-	loader := skills.NewLoader("", "")
-	loader.RegisterBuiltin(&skills.SkillManifest{
-		Name:        "worktree-hook-skill",
-		Version:     "1.0.0",
-		Description: "Worktree hook observer",
-		Types:       []skills.SkillType{skills.SkillTypeTool},
-		Implementation: skills.ImplementationConfig{
-			Backend:    skills.BackendStarlark,
-			Entrypoint: "main.star",
-		},
-	})
-
-	parentRuntime := skills.NewRuntime(loader, s, tools.NewRegistry(), []string{"worktree-hook-skill"},
-		func(_ skills.SkillManifest, _ string) (skills.SkillBackend, error) {
-			return &skillMockBackend{hooks: backendHooks}, nil
-		},
-		func(_ string, _ []skills.Permission) skills.PermissionChecker {
-			return &skillMockChecker{}
-		},
-	)
-	require.NoError(t, parentRuntime.Discover(nil))
-	require.NoError(t, parentRuntime.Activate("worktree-hook-skill"))
-
+	parentRuntime := makeTestRuntime(t, "worktree-hook-skill", toolManifest("worktree-hook-skill"), nil, backendHooks)
 	mockWT := &mockWorktreeProvider{dir: t.TempDir()}
 	spawner := &DefaultSubagentSpawner{
 		Provider:           &recordingProvider{},
@@ -231,7 +205,7 @@ func TestSpawnDispatchesWorktreeCreateAndRemove(t *testing.T) {
 		WorktreeProvider:   mockWT,
 	}
 
-	_, err = spawner.Spawn(context.Background(), SubagentConfig{
+	_, err := spawner.Spawn(context.Background(), SubagentConfig{
 		Name:      "wt-hook-worker",
 		Isolation: "worktree",
 	}, "go")
@@ -263,33 +237,7 @@ func TestSpawnDispatchesTaskCreatedAndCompleted(t *testing.T) {
 		},
 	}
 
-	s, err := store.NewStore(":memory:")
-	require.NoError(t, err)
-	defer s.Close()
-
-	loader := skills.NewLoader("", "")
-	loader.RegisterBuiltin(&skills.SkillManifest{
-		Name:        "task-hook-skill",
-		Version:     "1.0.0",
-		Description: "Task hook observer",
-		Types:       []skills.SkillType{skills.SkillTypeTool},
-		Implementation: skills.ImplementationConfig{
-			Backend:    skills.BackendStarlark,
-			Entrypoint: "main.star",
-		},
-	})
-
-	parentRuntime := skills.NewRuntime(loader, s, tools.NewRegistry(), []string{"task-hook-skill"},
-		func(_ skills.SkillManifest, _ string) (skills.SkillBackend, error) {
-			return &skillMockBackend{hooks: backendHooks}, nil
-		},
-		func(_ string, _ []skills.Permission) skills.PermissionChecker {
-			return &skillMockChecker{}
-		},
-	)
-	require.NoError(t, parentRuntime.Discover(nil))
-	require.NoError(t, parentRuntime.Activate("task-hook-skill"))
-
+	parentRuntime := makeTestRuntime(t, "task-hook-skill", toolManifest("task-hook-skill"), nil, backendHooks)
 	spawner := &DefaultSubagentSpawner{
 		Provider:           &recordingProvider{},
 		ParentTools:        tools.NewRegistry(),

--- a/internal/agent/subagent_test.go
+++ b/internal/agent/subagent_test.go
@@ -178,6 +178,73 @@ func TestSpawnParallelErrorPropagation(t *testing.T) {
 	assert.Error(t, results[1].Error)
 }
 
+// TestSpawnDispatchesWorktreeCreateAndRemove asserts that the spawner
+// fires HookOnWorktreeCreate before asking the provider to create a
+// worktree and HookOnWorktreeRemove before removing a clean worktree.
+func TestSpawnDispatchesWorktreeCreateAndRemove(t *testing.T) {
+	var createData, removeData map[string]any
+
+	backendHooks := map[skills.HookPhase]skills.HookHandler{
+		skills.HookOnWorktreeCreate: func(event skills.HookEvent) (skills.HookResult, error) {
+			createData = event.Data
+			return skills.HookResult{}, nil
+		},
+		skills.HookOnWorktreeRemove: func(event skills.HookEvent) (skills.HookResult, error) {
+			removeData = event.Data
+			return skills.HookResult{}, nil
+		},
+	}
+
+	s, err := store.NewStore(":memory:")
+	require.NoError(t, err)
+	defer s.Close()
+
+	loader := skills.NewLoader("", "")
+	loader.RegisterBuiltin(&skills.SkillManifest{
+		Name:        "worktree-hook-skill",
+		Version:     "1.0.0",
+		Description: "Worktree hook observer",
+		Types:       []skills.SkillType{skills.SkillTypeTool},
+		Implementation: skills.ImplementationConfig{
+			Backend:    skills.BackendStarlark,
+			Entrypoint: "main.star",
+		},
+	})
+
+	parentRuntime := skills.NewRuntime(loader, s, tools.NewRegistry(), []string{"worktree-hook-skill"},
+		func(_ skills.SkillManifest, _ string) (skills.SkillBackend, error) {
+			return &skillMockBackend{hooks: backendHooks}, nil
+		},
+		func(_ string, _ []skills.Permission) skills.PermissionChecker {
+			return &skillMockChecker{}
+		},
+	)
+	require.NoError(t, parentRuntime.Discover(nil))
+	require.NoError(t, parentRuntime.Activate("worktree-hook-skill"))
+
+	mockWT := &mockWorktreeProvider{dir: t.TempDir()}
+	spawner := &DefaultSubagentSpawner{
+		Provider:           &recordingProvider{},
+		ParentTools:        tools.NewRegistry(),
+		ParentSkillRuntime: parentRuntime,
+		Config:             &config.Config{Provider: config.ProviderConfig{Model: "test"}},
+		WorktreeProvider:   mockWT,
+	}
+
+	_, err = spawner.Spawn(context.Background(), SubagentConfig{
+		Name:      "wt-hook-worker",
+		Isolation: "worktree",
+	}, "go")
+	require.NoError(t, err)
+
+	require.NotNil(t, createData, "HookOnWorktreeCreate should fire before worktree is created")
+	assert.Equal(t, "wt-hook-worker", createData["subagent_name"])
+	assert.NotEmpty(t, createData["worktree_name"])
+
+	require.NotNil(t, removeData, "HookOnWorktreeRemove should fire before clean worktree is removed")
+	assert.Equal(t, "wt-hook-worker", removeData["subagent_name"])
+}
+
 // TestSpawnDispatchesTaskCreatedAndCompleted asserts that the spawner
 // fires HookOnTaskCreated before running the child and HookOnTaskCompleted
 // after the child returns, dispatching on the parent runtime so parent

--- a/internal/agent/subagent_test.go
+++ b/internal/agent/subagent_test.go
@@ -178,6 +178,73 @@ func TestSpawnParallelErrorPropagation(t *testing.T) {
 	assert.Error(t, results[1].Error)
 }
 
+// TestSpawnDispatchesTaskCreatedAndCompleted asserts that the spawner
+// fires HookOnTaskCreated before running the child and HookOnTaskCompleted
+// after the child returns, dispatching on the parent runtime so parent
+// hooks observe the task lifecycle.
+func TestSpawnDispatchesTaskCreatedAndCompleted(t *testing.T) {
+	var createdData, completedData map[string]any
+
+	backendHooks := map[skills.HookPhase]skills.HookHandler{
+		skills.HookOnTaskCreated: func(event skills.HookEvent) (skills.HookResult, error) {
+			createdData = event.Data
+			return skills.HookResult{}, nil
+		},
+		skills.HookOnTaskCompleted: func(event skills.HookEvent) (skills.HookResult, error) {
+			completedData = event.Data
+			return skills.HookResult{}, nil
+		},
+	}
+
+	s, err := store.NewStore(":memory:")
+	require.NoError(t, err)
+	defer s.Close()
+
+	loader := skills.NewLoader("", "")
+	loader.RegisterBuiltin(&skills.SkillManifest{
+		Name:        "task-hook-skill",
+		Version:     "1.0.0",
+		Description: "Task hook observer",
+		Types:       []skills.SkillType{skills.SkillTypeTool},
+		Implementation: skills.ImplementationConfig{
+			Backend:    skills.BackendStarlark,
+			Entrypoint: "main.star",
+		},
+	})
+
+	parentRuntime := skills.NewRuntime(loader, s, tools.NewRegistry(), []string{"task-hook-skill"},
+		func(_ skills.SkillManifest, _ string) (skills.SkillBackend, error) {
+			return &skillMockBackend{hooks: backendHooks}, nil
+		},
+		func(_ string, _ []skills.Permission) skills.PermissionChecker {
+			return &skillMockChecker{}
+		},
+	)
+	require.NoError(t, parentRuntime.Discover(nil))
+	require.NoError(t, parentRuntime.Activate("task-hook-skill"))
+
+	spawner := &DefaultSubagentSpawner{
+		Provider:           &recordingProvider{},
+		ParentTools:        tools.NewRegistry(),
+		ParentSkillRuntime: parentRuntime,
+		Config:             &config.Config{Provider: config.ProviderConfig{Model: "test"}},
+	}
+
+	result, err := spawner.Spawn(context.Background(), SubagentConfig{
+		Name: "hook-observed",
+	}, "do the thing")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.NotNil(t, createdData, "HookOnTaskCreated should fire before child runs")
+	assert.Equal(t, "hook-observed", createdData["name"])
+	assert.Equal(t, "do the thing", createdData["prompt"])
+
+	require.NotNil(t, completedData, "HookOnTaskCompleted should fire after child returns")
+	assert.Equal(t, "hook-observed", completedData["name"])
+	assert.NotNil(t, completedData["output"])
+}
+
 func TestDefaultSubagentSpawnerSkillSnapshotFiltering(t *testing.T) {
 	s, err := store.NewStore(":memory:")
 	require.NoError(t, err)

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -24,6 +24,8 @@ const (
 	EventPreEdit       = "pre_edit"
 	EventPostEdit      = "post_edit"
 	EventPreShell      = "pre_shell"
+	EventPrePrompt     = "pre_prompt"
+	EventPostResponse  = "post_response"
 	EventSessionStart  = "session_start"
 	EventSetup         = "setup"
 	EventTaskCreated   = "task_created"
@@ -290,6 +292,10 @@ func mapEventToPhase(event string) (skills.HookPhase, bool, func(skills.HookEven
 		return skills.HookOnAfterToolResult, false, filterFileWritePatch
 	case EventPreShell:
 		return skills.HookOnBeforeToolCall, true, filterShellTool
+	case EventPrePrompt:
+		return skills.HookOnBeforePromptBuild, false, noFilter
+	case EventPostResponse:
+		return skills.HookOnAfterResponse, false, noFilter
 	case EventSessionStart:
 		return skills.HookOnConversationStart, false, noFilter
 	case EventSetup:

--- a/internal/hooks/runner_test.go
+++ b/internal/hooks/runner_test.go
@@ -419,6 +419,80 @@ func TestTaskCompletedEventMaps(t *testing.T) {
 	}
 }
 
+// --- Enhancement 4: Prompt/Response Lifecycle Hook Tests ---
+
+func TestPrePromptEventMaps(t *testing.T) {
+	lm := skills.NewLifecycleManager()
+	runner := hooks.NewUserHookRunner([]hooks.UserHookConfig{
+		{Event: "pre_prompt", Command: "echo pre-prompt", Timeout: 5 * time.Second},
+	}, t.TempDir())
+	runner.RegisterIntoLM(lm)
+
+	result, err := lm.Dispatch(skills.HookEvent{
+		Phase: skills.HookOnBeforePromptBuild,
+		Ctx:   context.Background(),
+		Data:  map[string]any{"prompt": "hello"},
+	})
+	require.NoError(t, err)
+	if result != nil {
+		assert.False(t, result.Cancel, "pre_prompt success should not cancel")
+	}
+}
+
+func TestPrePromptModifiesPrompt(t *testing.T) {
+	lm := skills.NewLifecycleManager()
+	runner := hooks.NewUserHookRunner([]hooks.UserHookConfig{
+		{Event: "pre_prompt", Command: `echo '{"modified":{"prompt":"rewritten"}}'`, Timeout: 5 * time.Second},
+	}, t.TempDir())
+	runner.RegisterIntoLM(lm)
+
+	result, err := lm.Dispatch(skills.HookEvent{
+		Phase: skills.HookOnBeforePromptBuild,
+		Ctx:   context.Background(),
+		Data:  map[string]any{"prompt": "original"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Modified)
+	assert.Equal(t, "rewritten", result.Modified["prompt"])
+}
+
+func TestPostResponseEventMaps(t *testing.T) {
+	lm := skills.NewLifecycleManager()
+	runner := hooks.NewUserHookRunner([]hooks.UserHookConfig{
+		{Event: "post_response", Command: "echo post-response", Timeout: 5 * time.Second},
+	}, t.TempDir())
+	runner.RegisterIntoLM(lm)
+
+	result, err := lm.Dispatch(skills.HookEvent{
+		Phase: skills.HookOnAfterResponse,
+		Ctx:   context.Background(),
+		Data:  map[string]any{"response": "hi"},
+	})
+	require.NoError(t, err)
+	if result != nil {
+		assert.False(t, result.Cancel, "post_response is non-blocking")
+	}
+}
+
+func TestPostResponseNonBlockingOnFailure(t *testing.T) {
+	lm := skills.NewLifecycleManager()
+	runner := hooks.NewUserHookRunner([]hooks.UserHookConfig{
+		{Event: "post_response", Command: "exit 1", Timeout: 5 * time.Second},
+	}, t.TempDir())
+	runner.RegisterIntoLM(lm)
+
+	result, err := lm.Dispatch(skills.HookEvent{
+		Phase: skills.HookOnAfterResponse,
+		Ctx:   context.Background(),
+		Data:  map[string]any{"response": "hi"},
+	})
+	require.NoError(t, err)
+	if result != nil {
+		assert.False(t, result.Cancel, "post_response failure must not cancel")
+	}
+}
+
 // --- ParseHookTimeout edge cases ---
 
 func TestParseHookTimeoutUnparseable(t *testing.T) {

--- a/internal/security/engine.go
+++ b/internal/security/engine.go
@@ -113,6 +113,10 @@ func (e *Engine) Run(ctx context.Context, target ScanTarget) (*Report, error) {
 		Errors: allErrors,
 	}
 
+	if e.config.OnScanComplete != nil {
+		e.config.OnScanComplete(ctx, report)
+	}
+
 	return report, nil
 }
 

--- a/internal/security/engine_test.go
+++ b/internal/security/engine_test.go
@@ -74,6 +74,49 @@ func main() { exec.Command("sh").Run() }
 	assert.Greater(t, report.Stats.Duration, time.Duration(0))
 }
 
+// TestEngineRunFiresOnScanCompleteCallback asserts that a configured
+// OnScanComplete callback fires once per Run and receives the final
+// report. This is the extension point that the agent wires to
+// HookOnSecurityScanComplete.
+func TestEngineRunFiresOnScanCompleteCallback(t *testing.T) {
+	t.Parallel()
+
+	var (
+		callCount  int
+		gotReport  *Report
+		gotContext context.Context
+	)
+
+	e := NewEngine(EngineConfig{
+		MaxLLMChunks: 100,
+		Concurrency:  1,
+		OnScanComplete: func(ctx context.Context, report *Report) {
+			callCount++
+			gotReport = report
+			gotContext = ctx
+		},
+	})
+	e.AddScanner(&mockScanner{
+		name: "cb-scanner",
+		findings: []Finding{
+			{ID: "cb-1", Severity: SeverityLow, Category: CategorySecretsExposure, Title: "x",
+				CWE: "CWE-798", Location: Location{File: "a.go", StartLine: 1}},
+		},
+	})
+
+	dir := t.TempDir()
+	writeTestFile(t, dir, "a.go", "package a\n")
+
+	ctx := context.Background()
+	report, err := e.Run(ctx, ScanTarget{RootDir: dir})
+	require.NoError(t, err)
+	require.NotNil(t, report)
+
+	assert.Equal(t, 1, callCount, "OnScanComplete should fire exactly once")
+	assert.Same(t, report, gotReport, "callback should receive the final report")
+	assert.NotNil(t, gotContext, "callback should receive the run context")
+}
+
 func TestEngineHandlesScannerError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/security/types.go
+++ b/internal/security/types.go
@@ -225,6 +225,13 @@ type EngineConfig struct {
 	ExcludePatterns []string      // file patterns to exclude from scanning
 	Concurrency     int           // maximum concurrent scanner/analyzer goroutines
 	ScannerTimeout  time.Duration // per-scanner timeout; zero means 30s default
+
+	// OnScanComplete, when non-nil, is invoked once after Run produces the final
+	// report. It runs synchronously in Run's goroutine and must not block, since
+	// the caller receives the report only after the callback returns. This is
+	// the extension point that bridges the engine to skill lifecycle hooks
+	// (HookOnSecurityScanComplete) without coupling the engine to internal/skills.
+	OnScanComplete func(ctx context.Context, report *Report)
 }
 
 // OutputFormatter is the interface for rendering a security report into a


### PR DESCRIPTION
## Summary

Six `skills.HookPhase` values were defined and registered for user events via `internal/hooks/runner.go`, but had no production dispatch sites — handlers silently never fired. This PR wires each one into the correct code path with TDD, and exposes two additional existing phases as user events. Also gates init-time hook execution behind `--trust-hooks` to close a code-execution hole.

### What fires now in production

| Phase | User event | Dispatch site |
|---|---|---|
| `HookOnAfterResponse` | `post_response` | `Agent.runLoop` clean-completion branch |
| `HookOnConversationStart` | `session_start` | `Agent.Turn` on first message |
| `HookOnTaskCreated` / `HookOnTaskCompleted` | `task_created` / `task_completed` | `DefaultSubagentSpawner.Spawn` |
| `HookOnSetup` | `setup` | `rubichan init` (behind `--trust-hooks`) |
| `HookOnWorktreeCreate` / `HookOnWorktreeRemove` | — | `DefaultSubagentSpawner.Spawn` worktree-isolation path |
| `HookOnSecurityScanComplete` | — | `security.Engine.Run` via new `OnScanComplete` callback (wired in code-review mode) |
| `HookOnBeforePromptBuild` | `pre_prompt` (new) | already dispatched; new user-event mapping |
| `HookOnAfterResponse` | `post_response` (new) | new user-event mapping |

### Design notes

- **Security engine coupling**: used an `OnScanComplete func(context.Context, *Report)` callback on `EngineConfig` rather than passing `skills.Runtime` into the engine. The bridge to `skills.HookOnSecurityScanComplete` happens at the call site in `cmd/rubichan/main.go`.
- **Agent.dispatchHook**: single generic helper used for all agent-side dispatches. Builds a `HookEvent`, logs failures via `a.logger.Warn`, no-op when `skillRuntime == nil`. The spawner has a symmetric helper using `log.Printf` (no logger on `DefaultSubagentSpawner`).
- **Conversation.Len()**: new method avoids per-turn `make`+`copy` that would happen if `Turn` had used `len(Messages())` for its conversation-empty check.
- **Trust gate for init**: `rubichan init` and `rubichan init --hooks-only` now require `--trust-hooks` to execute commands from `.agent/hooks.toml`. Without the flag, init prints the number of skipped hooks and how to re-run.

### Deferred

- `HookOnBeforeWikiSection` — requires implementing the skill-wiki-contribution flow first (`internal/wiki/pipeline.go:150` passes `nil` for skill sections). Out of scope.

### Test plan

- [x] TDD: each phase has a dedicated red→green test with a registered mock handler
- [x] `TestAgentConversationStartHookFiresOnce` asserts once-per-conversation semantics
- [x] `TestInitCmdSkipsUntrustedSetupHooks` asserts hooks do NOT fire without `--trust-hooks`
- [x] Full regression: `go test ./internal/agent/... ./internal/security/... ./internal/hooks/... ./cmd/rubichan/...`
- [x] `go vet` and `gofmt -l` clean on all changed files

### Follow-ups (separate PRs)

1. Typed constants for hook event-data keys (currently raw strings: `"exit_reason"`, `"worktree_name"`, `"findings_count"`, etc.)
2. Negative test that `HookOnAfterResponse` does NOT fire on error/cancel/panic paths
3. Decide on `HookOnWorktreeCreate` failure semantics (create hook can fire without a matching remove if `CreateWorktree` fails)
4. Implement `HookOnBeforeWikiSection` once the skill-wiki-contribution feature exists

https://claude.ai/code/session_012RJ5oN6B9BcDuJDjZ5bkov

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--trust-hooks` CLI flag and enabled running init setup hooks when trusted
  * New lifecycle hook events: pre-prompt and post-response; conversation-start and after-response hooks can modify persisted assistant text
  * Subagent worktree/task lifecycle hooks and a security-scan-complete hook are now emitted

* **Tests**
  * Added tests validating hook execution with/without trust, agent/subagent hook dispatch, and prompt/response hook behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->