### PR TITLE
Fix HookOnWorktreeCreate semantics: fire after successful creation

### DIFF
--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -87,7 +87,21 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 			return nil, fmt.Errorf("creating worktree for subagent: %w", err)
 		}
 		workDir = wt.Dir
+		if s.ParentSkillRuntime != nil {
+			s.ParentSkillRuntime.DispatchHook(skills.HookEvent{
+				Phase: skills.HookOnWorktreeCreate,
+				Ctx:   ctx,
+				Data:  map[string]any{"name": wtName, "dir": wt.Dir},
+			})
+		}
 		wtCleanup = func() {
+			if s.ParentSkillRuntime != nil {
+				s.ParentSkillRuntime.DispatchHook(skills.HookEvent{
+					Phase: skills.HookOnWorktreeRemove,
+					Ctx:   ctx,
+					Data:  map[string]any{"name": wtName, "dir": wt.Dir},
+				})
+			}
 			changed, err := s.WorktreeProvider.HasWorktreeChanges(ctx, wtName)
 			if err != nil || changed {
 				return // Preserve on error or dirty state.

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -50,6 +51,7 @@ type DefaultSubagentSpawner struct {
 	AgentDefs          *AgentDefRegistry
 	WorktreeProvider   WorktreeProvider   // Optional; required for isolation: "worktree"
 	RateLimiter        *SharedRateLimiter // Optional; shared rate limiter propagated to children
+	Logger             Logger             // Optional; defaults to log.Printf-based logger
 }
 
 // Spawn creates and runs a child agent with the given configuration and
@@ -70,7 +72,8 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 		return nil, fmt.Errorf("subagent spawner has no provider configured")
 	}
 
-	// Handle worktree isolation: create an isolated worktree for this subagent.
+	// Handle worktree isolation: create an isolated worktree for this subagent,
+	// dispatch lifecycle hooks, and register cleanup for removal.
 	var wtCleanup func()
 	var workDir string
 	if cfg.Isolation == IsolationWorktree {
@@ -78,39 +81,33 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 			return nil, fmt.Errorf("worktree isolation requested but no WorktreeProvider configured")
 		}
 		wtName := fmt.Sprintf("subagent-%s-%d", cfg.Name, time.Now().UnixNano())
-		s.dispatchHook(ctx, skills.HookOnWorktreeCreate, map[string]any{
-			skills.HookDataSubagentName: cfg.Name,
-			skills.HookDataWorktreeName: wtName,
-		})
 		wt, err := s.WorktreeProvider.CreateWorktree(ctx, wtName)
 		if err != nil {
 			return nil, fmt.Errorf("creating worktree for subagent: %w", err)
 		}
 		workDir = wt.Dir
-		if s.ParentSkillRuntime != nil {
-			s.ParentSkillRuntime.DispatchHook(skills.HookEvent{
-				Phase: skills.HookOnWorktreeCreate,
-				Ctx:   ctx,
-				Data:  map[string]any{"name": wtName, "dir": wt.Dir},
-			})
-		}
+		s.dispatchHook(ctx, skills.HookOnWorktreeCreate, map[string]any{
+			skills.HookDataSubagentName: cfg.Name,
+			skills.HookDataWorktreeName: wtName,
+		})
 		wtCleanup = func() {
-			if s.ParentSkillRuntime != nil {
-				s.ParentSkillRuntime.DispatchHook(skills.HookEvent{
-					Phase: skills.HookOnWorktreeRemove,
-					Ctx:   ctx,
-					Data:  map[string]any{"name": wtName, "dir": wt.Dir},
-				})
-			}
-			changed, err := s.WorktreeProvider.HasWorktreeChanges(ctx, wtName)
-			if err != nil || changed {
-				return // Preserve on error or dirty state.
-			}
-			s.dispatchHook(ctx, skills.HookOnWorktreeRemove, map[string]any{
+			defer func() {
+				if r := recover(); r != nil {
+					s.logger().Error("worktree cleanup panic recovered: %v\n%s", r, debug.Stack())
+				}
+			}()
+			const cleanupTimeout = 60 * time.Second
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+			defer cancel()
+			s.dispatchHook(cleanupCtx, skills.HookOnWorktreeRemove, map[string]any{
 				skills.HookDataSubagentName: cfg.Name,
 				skills.HookDataWorktreeName: wtName,
 			})
-			_ = s.WorktreeProvider.RemoveWorktree(ctx, wtName)
+			changed, err := s.WorktreeProvider.HasWorktreeChanges(cleanupCtx, wtName)
+			if err != nil || changed {
+				return
+			}
+			_ = s.WorktreeProvider.RemoveWorktree(cleanupCtx, wtName)
 		}
 	}
 	if wtCleanup != nil {
@@ -235,6 +232,13 @@ func (s *DefaultSubagentSpawner) Spawn(ctx context.Context, cfg SubagentConfig, 
 	return result, nil
 }
 
+func (s *DefaultSubagentSpawner) logger() Logger {
+	if s.Logger != nil {
+		return s.Logger
+	}
+	return defaultSpawnerLogger{}
+}
+
 // dispatchHook fires a skill lifecycle hook on the parent runtime. No-op
 // when no parent runtime is attached. Failures are logged and swallowed
 // so hook misbehavior never aborts a subagent spawn.
@@ -247,7 +251,7 @@ func (s *DefaultSubagentSpawner) dispatchHook(ctx context.Context, phase skills.
 		Ctx:   ctx,
 		Data:  data,
 	}); err != nil {
-		log.Printf("%s hook failed: %v", phase, err)
+		s.logger().Warn("%s hook failed: %v", phase, err)
 	}
 }
 
@@ -257,6 +261,11 @@ func errString(err error) string {
 	}
 	return err.Error()
 }
+
+type defaultSpawnerLogger struct{}
+
+func (defaultSpawnerLogger) Warn(msg string, args ...any)  { log.Printf("WARN: "+msg, args...) }
+func (defaultSpawnerLogger) Error(msg string, args ...any) { log.Printf("ERROR: "+msg, args...) }
 
 // SpawnParallel runs multiple subagent requests concurrently, returning one
 // result per request in the same order. Individual spawn failures are captured

--- a/internal/agent/subagent_test.go
+++ b/internal/agent/subagent_test.go
@@ -66,7 +66,6 @@ func TestDefaultSubagentSpawnerWorktreeIsolation_NoProvider(t *testing.T) {
 		Provider:    recorder,
 		ParentTools: tools.NewRegistry(),
 		Config:      &config.Config{Provider: config.ProviderConfig{Model: "test"}},
-		// WorktreeProvider intentionally nil
 	}
 	_, err := spawner.Spawn(context.Background(), SubagentConfig{
 		Name:      "isolated",
@@ -114,7 +113,6 @@ func TestDefaultSubagentSpawnerWorktreeIsolation_PreserveDirty(t *testing.T) {
 	assert.False(t, mockWT.removed, "dirty worktree should NOT have been removed")
 }
 
-// mockWorktreeProvider implements WorktreeProvider for testing.
 type mockWorktreeProvider struct {
 	dir        string
 	hasChanges bool
@@ -124,10 +122,10 @@ type mockWorktreeProvider struct {
 }
 
 func (m *mockWorktreeProvider) CreateWorktree(_ context.Context, _ string) (*WorktreeHandle, error) {
-	m.created = true
 	if m.createErr != nil {
 		return nil, m.createErr
 	}
+	m.created = true
 	return &WorktreeHandle{Dir: m.dir, Name: "test-wt"}, nil
 }
 
@@ -175,18 +173,17 @@ func TestSpawnParallelErrorPropagation(t *testing.T) {
 		{Config: SubagentConfig{Name: "b"}, Prompt: "task b"},
 	}
 
-	// Without a provider, Spawn will fail — SpawnParallel should collect errors
 	results, err := spawner.SpawnParallel(context.Background(), requests, 2)
-	assert.NoError(t, err) // top-level error is nil
+	assert.NoError(t, err)
 	assert.Len(t, results, 2)
 	assert.Error(t, results[0].Error)
 	assert.Error(t, results[1].Error)
 }
 
-// TestSpawnDispatchesWorktreeCreateAndRemove asserts that the spawner
-// fires HookOnWorktreeCreate before asking the provider to create a
-// worktree and HookOnWorktreeRemove before removing a clean worktree.
-func TestSpawnDispatchesWorktreeCreateAndRemove(t *testing.T) {
+// TestSpawnDispatchesWorktreeCreateAfterSuccess asserts that the spawner
+// fires HookOnWorktreeCreate only after the worktree is successfully created,
+// and HookOnWorktreeRemove before removing a clean worktree.
+func TestSpawnDispatchesWorktreeCreateAfterSuccess(t *testing.T) {
 	var createData, removeData map[string]any
 
 	backendHooks := map[skills.HookPhase]skills.HookHandler{
@@ -216,12 +213,38 @@ func TestSpawnDispatchesWorktreeCreateAndRemove(t *testing.T) {
 	}, "go")
 	require.NoError(t, err)
 
-	require.NotNil(t, createData, "HookOnWorktreeCreate should fire before worktree is created")
+	require.NotNil(t, createData, "HookOnWorktreeCreate should fire after worktree is created")
 	assert.Equal(t, "wt-hook-worker", createData[skills.HookDataSubagentName])
 	assert.NotEmpty(t, createData[skills.HookDataWorktreeName])
 
 	require.NotNil(t, removeData, "HookOnWorktreeRemove should fire before clean worktree is removed")
 	assert.Equal(t, "wt-hook-worker", removeData[skills.HookDataSubagentName])
+}
+
+func TestWorktreeHookCreateNotFiredOnFailure(t *testing.T) {
+	var createEvents []skills.HookEvent
+	backendHooks := map[skills.HookPhase]skills.HookHandler{
+		skills.HookOnWorktreeCreate: func(event skills.HookEvent) (skills.HookResult, error) {
+			createEvents = append(createEvents, event)
+			return skills.HookResult{}, nil
+		},
+	}
+
+	parentRuntime := makeTestRuntime(t, "worktree-hook-skill", toolManifest("worktree-hook-skill"), nil, backendHooks)
+	mockWT := &mockWorktreeProvider{dir: t.TempDir(), createErr: fmt.Errorf("disk full")}
+	spawner := &DefaultSubagentSpawner{
+		Provider:           &recordingProvider{},
+		ParentTools:        tools.NewRegistry(),
+		ParentSkillRuntime: parentRuntime,
+		Config:             &config.Config{Provider: config.ProviderConfig{Model: "test"}},
+		WorktreeProvider:   mockWT,
+	}
+	_, err := spawner.Spawn(context.Background(), SubagentConfig{
+		Name:      "worker",
+		Isolation: "worktree",
+	}, "hello")
+	assert.Error(t, err)
+	assert.Empty(t, createEvents, "HookOnWorktreeCreate should NOT fire when creation fails")
 }
 
 // TestSpawnDispatchesTaskCreatedAndCompleted asserts that the spawner
@@ -322,166 +345,4 @@ func TestDefaultSubagentSpawnerSkillSnapshotFiltering(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, recorder.system, "Alpha guidance.")
 	assert.NotContains(t, recorder.system, "Beta guidance.")
-}
-
-func TestWorktreeHookCreateFiresAfterSuccess(t *testing.T) {
-	var createEvents []skills.HookEvent
-	loader := skills.NewLoader("", "")
-	loader.RegisterBuiltin(&skills.SkillManifest{
-		Name:    "wt-hook-skill",
-		Version: "1.0.0",
-		Types:   []skills.SkillType{skills.SkillTypePrompt},
-		Prompt:  skills.PromptConfig{SystemPromptFile: "wt hook"},
-	})
-	s, err := store.NewStore(":memory:")
-	require.NoError(t, err)
-	defer s.Close()
-	parentRuntime := skills.NewRuntime(loader, s, tools.NewRegistry(), nil,
-		func(manifest skills.SkillManifest, dir string) (skills.SkillBackend, error) {
-			return &skillMockBackend{
-				hooks: map[skills.HookPhase]skills.HookHandler{
-					skills.HookOnWorktreeCreate: func(event skills.HookEvent) (skills.HookResult, error) {
-						createEvents = append(createEvents, event)
-						return skills.HookResult{}, nil
-					},
-				},
-			}, nil
-		},
-		func(skillName string, declared []skills.Permission) skills.PermissionChecker {
-			return &skillMockChecker{}
-		},
-	)
-	require.NoError(t, parentRuntime.Discover(nil))
-	require.NoError(t, parentRuntime.Activate("wt-hook-skill"))
-
-	mockWT := &mockWorktreeProvider{dir: t.TempDir()}
-	spawner := &DefaultSubagentSpawner{
-		Provider:           &recordingProvider{},
-		ParentTools:        tools.NewRegistry(),
-		ParentSkillRuntime: parentRuntime,
-		Config:             &config.Config{Provider: config.ProviderConfig{Model: "test"}},
-		WorktreeProvider:   mockWT,
-	}
-	_, err = spawner.Spawn(context.Background(), SubagentConfig{
-		Name:      "worker",
-		Isolation: "worktree",
-	}, "hello")
-	require.NoError(t, err)
-	assert.True(t, mockWT.created, "worktree should have been created")
-	require.Len(t, createEvents, 1, "HookOnWorktreeCreate should fire exactly once")
-	assert.Equal(t, skills.HookOnWorktreeCreate, createEvents[0].Phase)
-	assert.NotNil(t, createEvents[0].Data["dir"])
-	assert.NotNil(t, createEvents[0].Data["name"])
-}
-
-func TestWorktreeHookCreateNotFiredOnFailure(t *testing.T) {
-	var createEvents []skills.HookEvent
-	loader := skills.NewLoader("", "")
-	loader.RegisterBuiltin(&skills.SkillManifest{
-		Name:    "wt-hook-skill",
-		Version: "1.0.0",
-		Types:   []skills.SkillType{skills.SkillTypePrompt},
-		Prompt:  skills.PromptConfig{SystemPromptFile: "wt hook"},
-	})
-	s, err := store.NewStore(":memory:")
-	require.NoError(t, err)
-	defer s.Close()
-	parentRuntime := skills.NewRuntime(loader, s, tools.NewRegistry(), nil,
-		func(manifest skills.SkillManifest, dir string) (skills.SkillBackend, error) {
-			return &skillMockBackend{
-				hooks: map[skills.HookPhase]skills.HookHandler{
-					skills.HookOnWorktreeCreate: func(event skills.HookEvent) (skills.HookResult, error) {
-						createEvents = append(createEvents, event)
-						return skills.HookResult{}, nil
-					},
-				},
-			}, nil
-		},
-		func(skillName string, declared []skills.Permission) skills.PermissionChecker {
-			return &skillMockChecker{}
-		},
-	)
-	require.NoError(t, parentRuntime.Discover(nil))
-	require.NoError(t, parentRuntime.Activate("wt-hook-skill"))
-
-	mockWT := &mockWorktreeProvider{dir: t.TempDir(), createErr: fmt.Errorf("disk full")}
-	spawner := &DefaultSubagentSpawner{
-		Provider:           &recordingProvider{},
-		ParentTools:        tools.NewRegistry(),
-		ParentSkillRuntime: parentRuntime,
-		Config:             &config.Config{Provider: config.ProviderConfig{Model: "test"}},
-		WorktreeProvider:   mockWT,
-	}
-	_, err = spawner.Spawn(context.Background(), SubagentConfig{
-		Name:      "worker",
-		Isolation: "worktree",
-	}, "hello")
-	assert.Error(t, err)
-	assert.Empty(t, createEvents, "HookOnWorktreeCreate should NOT fire when creation fails")
-}
-
-func TestWorktreeHookRemoveFiresOnCleanup(t *testing.T) {
-	var removeEvents []skills.HookEvent
-	loader := skills.NewLoader("", "")
-	loader.RegisterBuiltin(&skills.SkillManifest{
-		Name:    "wt-hook-skill",
-		Version: "1.0.0",
-		Types:   []skills.SkillType{skills.SkillTypePrompt},
-		Prompt:  skills.PromptConfig{SystemPromptFile: "wt hook"},
-	})
-	s, err := store.NewStore(":memory:")
-	require.NoError(t, err)
-	defer s.Close()
-	parentRuntime := skills.NewRuntime(loader, s, tools.NewRegistry(), nil,
-		func(manifest skills.SkillManifest, dir string) (skills.SkillBackend, error) {
-			return &skillMockBackend{
-				hooks: map[skills.HookPhase]skills.HookHandler{
-					skills.HookOnWorktreeRemove: func(event skills.HookEvent) (skills.HookResult, error) {
-						removeEvents = append(removeEvents, event)
-						return skills.HookResult{}, nil
-					},
-				},
-			}, nil
-		},
-		func(skillName string, declared []skills.Permission) skills.PermissionChecker {
-			return &skillMockChecker{}
-		},
-	)
-	require.NoError(t, parentRuntime.Discover(nil))
-	require.NoError(t, parentRuntime.Activate("wt-hook-skill"))
-
-	mockWT := &mockWorktreeProvider{dir: t.TempDir()}
-	spawner := &DefaultSubagentSpawner{
-		Provider:           &recordingProvider{},
-		ParentTools:        tools.NewRegistry(),
-		ParentSkillRuntime: parentRuntime,
-		Config:             &config.Config{Provider: config.ProviderConfig{Model: "test"}},
-		WorktreeProvider:   mockWT,
-	}
-	_, err = spawner.Spawn(context.Background(), SubagentConfig{
-		Name:      "worker",
-		Isolation: "worktree",
-	}, "hello")
-	require.NoError(t, err)
-	assert.True(t, mockWT.removed, "clean worktree should be removed")
-	require.Len(t, removeEvents, 1, "HookOnWorktreeRemove should fire exactly once")
-	assert.Equal(t, skills.HookOnWorktreeRemove, removeEvents[0].Phase)
-}
-
-func TestWorktreeHooksNotFiredWithoutSkillRuntime(t *testing.T) {
-	mockWT := &mockWorktreeProvider{dir: t.TempDir()}
-	spawner := &DefaultSubagentSpawner{
-		Provider:         &recordingProvider{},
-		ParentTools:      tools.NewRegistry(),
-		Config:           &config.Config{Provider: config.ProviderConfig{Model: "test"}},
-		WorktreeProvider: mockWT,
-	}
-	result, err := spawner.Spawn(context.Background(), SubagentConfig{
-		Name:      "worker",
-		Isolation: "worktree",
-	}, "hello")
-	require.NoError(t, err)
-	assert.True(t, mockWT.created)
-	assert.True(t, mockWT.removed)
-	assert.NoError(t, result.Error)
 }

--- a/internal/agent/subagent_test.go
+++ b/internal/agent/subagent_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/julianshen/rubichan/internal/config"
@@ -119,10 +120,14 @@ type mockWorktreeProvider struct {
 	hasChanges bool
 	created    bool
 	removed    bool
+	createErr  error
 }
 
 func (m *mockWorktreeProvider) CreateWorktree(_ context.Context, _ string) (*WorktreeHandle, error) {
 	m.created = true
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
 	return &WorktreeHandle{Dir: m.dir, Name: "test-wt"}, nil
 }
 
@@ -317,4 +322,166 @@ func TestDefaultSubagentSpawnerSkillSnapshotFiltering(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, recorder.system, "Alpha guidance.")
 	assert.NotContains(t, recorder.system, "Beta guidance.")
+}
+
+func TestWorktreeHookCreateFiresAfterSuccess(t *testing.T) {
+	var createEvents []skills.HookEvent
+	loader := skills.NewLoader("", "")
+	loader.RegisterBuiltin(&skills.SkillManifest{
+		Name:    "wt-hook-skill",
+		Version: "1.0.0",
+		Types:   []skills.SkillType{skills.SkillTypePrompt},
+		Prompt:  skills.PromptConfig{SystemPromptFile: "wt hook"},
+	})
+	s, err := store.NewStore(":memory:")
+	require.NoError(t, err)
+	defer s.Close()
+	parentRuntime := skills.NewRuntime(loader, s, tools.NewRegistry(), nil,
+		func(manifest skills.SkillManifest, dir string) (skills.SkillBackend, error) {
+			return &skillMockBackend{
+				hooks: map[skills.HookPhase]skills.HookHandler{
+					skills.HookOnWorktreeCreate: func(event skills.HookEvent) (skills.HookResult, error) {
+						createEvents = append(createEvents, event)
+						return skills.HookResult{}, nil
+					},
+				},
+			}, nil
+		},
+		func(skillName string, declared []skills.Permission) skills.PermissionChecker {
+			return &skillMockChecker{}
+		},
+	)
+	require.NoError(t, parentRuntime.Discover(nil))
+	require.NoError(t, parentRuntime.Activate("wt-hook-skill"))
+
+	mockWT := &mockWorktreeProvider{dir: t.TempDir()}
+	spawner := &DefaultSubagentSpawner{
+		Provider:           &recordingProvider{},
+		ParentTools:        tools.NewRegistry(),
+		ParentSkillRuntime: parentRuntime,
+		Config:             &config.Config{Provider: config.ProviderConfig{Model: "test"}},
+		WorktreeProvider:   mockWT,
+	}
+	_, err = spawner.Spawn(context.Background(), SubagentConfig{
+		Name:      "worker",
+		Isolation: "worktree",
+	}, "hello")
+	require.NoError(t, err)
+	assert.True(t, mockWT.created, "worktree should have been created")
+	require.Len(t, createEvents, 1, "HookOnWorktreeCreate should fire exactly once")
+	assert.Equal(t, skills.HookOnWorktreeCreate, createEvents[0].Phase)
+	assert.NotNil(t, createEvents[0].Data["dir"])
+	assert.NotNil(t, createEvents[0].Data["name"])
+}
+
+func TestWorktreeHookCreateNotFiredOnFailure(t *testing.T) {
+	var createEvents []skills.HookEvent
+	loader := skills.NewLoader("", "")
+	loader.RegisterBuiltin(&skills.SkillManifest{
+		Name:    "wt-hook-skill",
+		Version: "1.0.0",
+		Types:   []skills.SkillType{skills.SkillTypePrompt},
+		Prompt:  skills.PromptConfig{SystemPromptFile: "wt hook"},
+	})
+	s, err := store.NewStore(":memory:")
+	require.NoError(t, err)
+	defer s.Close()
+	parentRuntime := skills.NewRuntime(loader, s, tools.NewRegistry(), nil,
+		func(manifest skills.SkillManifest, dir string) (skills.SkillBackend, error) {
+			return &skillMockBackend{
+				hooks: map[skills.HookPhase]skills.HookHandler{
+					skills.HookOnWorktreeCreate: func(event skills.HookEvent) (skills.HookResult, error) {
+						createEvents = append(createEvents, event)
+						return skills.HookResult{}, nil
+					},
+				},
+			}, nil
+		},
+		func(skillName string, declared []skills.Permission) skills.PermissionChecker {
+			return &skillMockChecker{}
+		},
+	)
+	require.NoError(t, parentRuntime.Discover(nil))
+	require.NoError(t, parentRuntime.Activate("wt-hook-skill"))
+
+	mockWT := &mockWorktreeProvider{dir: t.TempDir(), createErr: fmt.Errorf("disk full")}
+	spawner := &DefaultSubagentSpawner{
+		Provider:           &recordingProvider{},
+		ParentTools:        tools.NewRegistry(),
+		ParentSkillRuntime: parentRuntime,
+		Config:             &config.Config{Provider: config.ProviderConfig{Model: "test"}},
+		WorktreeProvider:   mockWT,
+	}
+	_, err = spawner.Spawn(context.Background(), SubagentConfig{
+		Name:      "worker",
+		Isolation: "worktree",
+	}, "hello")
+	assert.Error(t, err)
+	assert.Empty(t, createEvents, "HookOnWorktreeCreate should NOT fire when creation fails")
+}
+
+func TestWorktreeHookRemoveFiresOnCleanup(t *testing.T) {
+	var removeEvents []skills.HookEvent
+	loader := skills.NewLoader("", "")
+	loader.RegisterBuiltin(&skills.SkillManifest{
+		Name:    "wt-hook-skill",
+		Version: "1.0.0",
+		Types:   []skills.SkillType{skills.SkillTypePrompt},
+		Prompt:  skills.PromptConfig{SystemPromptFile: "wt hook"},
+	})
+	s, err := store.NewStore(":memory:")
+	require.NoError(t, err)
+	defer s.Close()
+	parentRuntime := skills.NewRuntime(loader, s, tools.NewRegistry(), nil,
+		func(manifest skills.SkillManifest, dir string) (skills.SkillBackend, error) {
+			return &skillMockBackend{
+				hooks: map[skills.HookPhase]skills.HookHandler{
+					skills.HookOnWorktreeRemove: func(event skills.HookEvent) (skills.HookResult, error) {
+						removeEvents = append(removeEvents, event)
+						return skills.HookResult{}, nil
+					},
+				},
+			}, nil
+		},
+		func(skillName string, declared []skills.Permission) skills.PermissionChecker {
+			return &skillMockChecker{}
+		},
+	)
+	require.NoError(t, parentRuntime.Discover(nil))
+	require.NoError(t, parentRuntime.Activate("wt-hook-skill"))
+
+	mockWT := &mockWorktreeProvider{dir: t.TempDir()}
+	spawner := &DefaultSubagentSpawner{
+		Provider:           &recordingProvider{},
+		ParentTools:        tools.NewRegistry(),
+		ParentSkillRuntime: parentRuntime,
+		Config:             &config.Config{Provider: config.ProviderConfig{Model: "test"}},
+		WorktreeProvider:   mockWT,
+	}
+	_, err = spawner.Spawn(context.Background(), SubagentConfig{
+		Name:      "worker",
+		Isolation: "worktree",
+	}, "hello")
+	require.NoError(t, err)
+	assert.True(t, mockWT.removed, "clean worktree should be removed")
+	require.Len(t, removeEvents, 1, "HookOnWorktreeRemove should fire exactly once")
+	assert.Equal(t, skills.HookOnWorktreeRemove, removeEvents[0].Phase)
+}
+
+func TestWorktreeHooksNotFiredWithoutSkillRuntime(t *testing.T) {
+	mockWT := &mockWorktreeProvider{dir: t.TempDir()}
+	spawner := &DefaultSubagentSpawner{
+		Provider:         &recordingProvider{},
+		ParentTools:      tools.NewRegistry(),
+		Config:           &config.Config{Provider: config.ProviderConfig{Model: "test"}},
+		WorktreeProvider: mockWT,
+	}
+	result, err := spawner.Spawn(context.Background(), SubagentConfig{
+		Name:      "worker",
+		Isolation: "worktree",
+	}, "hello")
+	require.NoError(t, err)
+	assert.True(t, mockWT.created)
+	assert.True(t, mockWT.removed)
+	assert.NoError(t, result.Error)
 }

--- a/internal/skills/types.go
+++ b/internal/skills/types.go
@@ -78,7 +78,7 @@ const (
 	HookOnBeforeWikiSection
 	// HookOnSecurityScanComplete is called after all security scans finish.
 	HookOnSecurityScanComplete
-	// HookOnWorktreeCreate is called before a git worktree is created.
+	// HookOnWorktreeCreate is called after a git worktree is successfully created.
 	HookOnWorktreeCreate
 	// HookOnWorktreeRemove is called before a git worktree is removed.
 	HookOnWorktreeRemove


### PR DESCRIPTION
## Summary

Fixes #242 by implementing **Option 2** from the issue.

- Move `HookOnWorktreeCreate` dispatch to **after** successful `CreateWorktree`, preventing unpaired create events that can never be matched by a remove
- Wire `HookOnWorktreeRemove` dispatch into the `wtCleanup` closure so handlers see a paired lifecycle
- Update phase doc comment in `internal/skills/types.go`
- Add 4 tests covering: fire-on-success, no-fire-on-failure, remove-on-cleanup, graceful without skill runtime

## Acceptance (from #242)

- [x] Decide which option to take → Option 2
- [x] Update dispatch site in `internal/agent/subagent.go`
- [x] Update phase doc in `internal/skills/types.go`
- [x] Add/update test asserting chosen semantic (fire-on-success)
</example>