### PR TITLE
Add typed error classifier for provider errors

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -20,6 +20,7 @@ import (
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 
 	"github.com/julianshen/rubichan/internal/acp"
+	"github.com/julianshen/rubichan/internal/agent/errorclass"
 	"github.com/julianshen/rubichan/internal/checkpoint"
 	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/evaluator"
@@ -1406,6 +1407,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			return a.provider.Stream(ctx, req)
 		}, onRetry)
 		if err != nil {
+			a.logger.Warn("provider error classified as %s: %v", errorclass.Classify(err), err)
 			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream: %w", err)})
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError))
 			return

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1018,6 +1018,24 @@ func TestTurnWithStreamInitError(t *testing.T) {
 	assert.Equal(t, "done", events[len(events)-1].Type)
 }
 
+func TestRunLoop_PromptTooLong_ExitsWithProviderError(t *testing.T) {
+	errProvider := &errorProvider{err: fmt.Errorf("prompt is too long: 300000 tokens")}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	agent := New(errProvider, reg, autoApprove, cfg)
+
+	ch, err := agent.Turn(context.Background(), "hello")
+	require.NoError(t, err)
+
+	var exitReason agentsdk.TurnExitReason
+	for evt := range ch {
+		if evt.Type == "done" {
+			exitReason = evt.ExitReason
+		}
+	}
+	assert.Equal(t, agentsdk.ExitProviderError, exitReason)
+}
+
 func TestTurnWithApprovalError(t *testing.T) {
 	// The approval function returns an error
 	approvalErr := func(_ context.Context, _ string, _ json.RawMessage) (bool, error) {

--- a/internal/agent/errorclass/classifier.go
+++ b/internal/agent/errorclass/classifier.go
@@ -1,6 +1,8 @@
 package errorclass
 
-import "strings"
+import (
+	"strings"
+)
 
 type ErrorClass int
 
@@ -12,23 +14,37 @@ const (
 	ClassMediaSize
 )
 
+func (c ErrorClass) String() string {
+	switch c {
+	case ClassPromptTooLong:
+		return "prompt_too_long"
+	case ClassModelOverloaded:
+		return "model_overloaded"
+	case ClassMaxOutputTokens:
+		return "max_output_tokens"
+	case ClassMediaSize:
+		return "media_size"
+	default:
+		return "unknown"
+	}
+}
+
 func Classify(err error) ErrorClass {
 	if err == nil {
 		return ClassUnknown
 	}
-	msg := err.Error()
-	msgLower := strings.ToLower(msg)
+	msg := strings.ToLower(err.Error())
 
-	if isPromptTooLong(msg, msgLower) {
+	if isPromptTooLong(msg) {
 		return ClassPromptTooLong
 	}
-	if isMaxOutputTokens(msg, msgLower) {
+	if isMaxOutputTokens(msg) {
 		return ClassMaxOutputTokens
 	}
-	if isMediaSize(msgLower) {
+	if isMediaSize(msg) {
 		return ClassMediaSize
 	}
-	if isModelOverloaded(msg, msgLower) {
+	if isModelOverloaded(msg) {
 		return ClassModelOverloaded
 	}
 	return ClassUnknown
@@ -38,27 +54,48 @@ func IsRetryable(class ErrorClass) bool {
 	return class == ClassModelOverloaded
 }
 
-func isPromptTooLong(msg, msgLower string) bool {
+func isPromptTooLong(msg string) bool {
 	return strings.Contains(msg, "prompt is too long") ||
 		strings.Contains(msg, "context_length_exceeded") ||
-		strings.Contains(msg, "413") ||
-		strings.Contains(msgLower, "too many tokens")
+		containsStatusCode(msg, "413") ||
+		strings.Contains(msg, "too many tokens")
 }
 
-func isModelOverloaded(msg, msgLower string) bool {
-	return strings.Contains(msg, "Overloaded") ||
-		strings.Contains(msg, "529") ||
-		strings.Contains(msg, "503") ||
-		strings.Contains(msgLower, "capacity")
+func isModelOverloaded(msg string) bool {
+	return strings.Contains(msg, "overloaded") ||
+		containsStatusCode(msg, "529") ||
+		containsStatusCode(msg, "503") ||
+		strings.Contains(msg, "insufficient capacity")
 }
 
-func isMaxOutputTokens(msg, msgLower string) bool {
+func isMaxOutputTokens(msg string) bool {
 	return strings.Contains(msg, "max_output_tokens") ||
-		strings.Contains(msgLower, "max output tokens exceeded")
+		strings.Contains(msg, "max output tokens exceeded")
 }
 
-func isMediaSize(msgLower string) bool {
-	return strings.Contains(msgLower, "media_size_error") ||
-		strings.Contains(msgLower, "image too large") ||
-		strings.Contains(msgLower, "file too large")
+func isMediaSize(msg string) bool {
+	return strings.Contains(msg, "media_size_error") ||
+		strings.Contains(msg, "image too large") ||
+		strings.Contains(msg, "file too large")
+}
+
+func containsStatusCode(msg, code string) bool {
+	idx := strings.Index(msg, code)
+	for idx >= 0 {
+		before := idx == 0 || !isDigit(msg[idx-1])
+		after := idx+len(code) >= len(msg) || !isDigit(msg[idx+len(code)])
+		if before && after {
+			return true
+		}
+		next := strings.Index(msg[idx+1:], code)
+		if next < 0 {
+			break
+		}
+		idx += 1 + next
+	}
+	return false
+}
+
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
 }

--- a/internal/agent/errorclass/classifier.go
+++ b/internal/agent/errorclass/classifier.go
@@ -1,0 +1,64 @@
+package errorclass
+
+import "strings"
+
+type ErrorClass int
+
+const (
+	ClassUnknown ErrorClass = iota
+	ClassPromptTooLong
+	ClassModelOverloaded
+	ClassMaxOutputTokens
+	ClassMediaSize
+)
+
+func Classify(err error) ErrorClass {
+	if err == nil {
+		return ClassUnknown
+	}
+	msg := err.Error()
+	msgLower := strings.ToLower(msg)
+
+	if isPromptTooLong(msg, msgLower) {
+		return ClassPromptTooLong
+	}
+	if isMaxOutputTokens(msg, msgLower) {
+		return ClassMaxOutputTokens
+	}
+	if isMediaSize(msgLower) {
+		return ClassMediaSize
+	}
+	if isModelOverloaded(msg, msgLower) {
+		return ClassModelOverloaded
+	}
+	return ClassUnknown
+}
+
+func IsRetryable(class ErrorClass) bool {
+	return class == ClassModelOverloaded
+}
+
+func isPromptTooLong(msg, msgLower string) bool {
+	return strings.Contains(msg, "prompt is too long") ||
+		strings.Contains(msg, "context_length_exceeded") ||
+		strings.Contains(msg, "413") ||
+		strings.Contains(msgLower, "too many tokens")
+}
+
+func isModelOverloaded(msg, msgLower string) bool {
+	return strings.Contains(msg, "Overloaded") ||
+		strings.Contains(msg, "529") ||
+		strings.Contains(msg, "503") ||
+		strings.Contains(msgLower, "capacity")
+}
+
+func isMaxOutputTokens(msg, msgLower string) bool {
+	return strings.Contains(msg, "max_output_tokens") ||
+		strings.Contains(msgLower, "max output tokens exceeded")
+}
+
+func isMediaSize(msgLower string) bool {
+	return strings.Contains(msgLower, "media_size_error") ||
+		strings.Contains(msgLower, "image too large") ||
+		strings.Contains(msgLower, "file too large")
+}

--- a/internal/agent/errorclass/classifier_test.go
+++ b/internal/agent/errorclass/classifier_test.go
@@ -13,6 +13,10 @@ func TestClassifyPromptTooLong(t *testing.T) {
 		"Error: context_length_exceeded",
 		"Request too large: 413",
 		"too many tokens in request",
+		"PROMPT IS TOO LONG: exceeded",
+		"Context_Length_Exceeded",
+		"HTTP 413 Payload Too Large",
+		"error 413: request entity too large",
 	}
 	for _, msg := range cases {
 		t.Run(msg, func(t *testing.T) {
@@ -24,9 +28,15 @@ func TestClassifyPromptTooLong(t *testing.T) {
 func TestClassifyModelOverloaded(t *testing.T) {
 	cases := []string{
 		"Overloaded",
+		"overloaded",
+		"OVERLOADED",
 		"APIError 529: ",
+		"error 529: service unavailable",
 		"ServiceUnavailable 503",
+		"error 503: backend unavailable",
+		"HTTP 503 Service Unavailable",
 		"insufficient capacity",
+		"529 ",
 	}
 	for _, msg := range cases {
 		t.Run(msg, func(t *testing.T) {
@@ -39,6 +49,7 @@ func TestClassifyMaxOutputTokens(t *testing.T) {
 	cases := []string{
 		"max_output_tokens exceeded",
 		"Max output tokens exceeded: response was truncated",
+		"MAX_OUTPUT_TOKENS: hit limit",
 	}
 	for _, msg := range cases {
 		t.Run(msg, func(t *testing.T) {
@@ -51,6 +62,8 @@ func TestClassifyMediaSize(t *testing.T) {
 	cases := []string{
 		"media_size_error: image too large",
 		"file too large for processing",
+		"IMAGE TOO LARGE: exceeds 20MB",
+		"File Too Large for upload",
 	}
 	for _, msg := range cases {
 		t.Run(msg, func(t *testing.T) {
@@ -62,10 +75,47 @@ func TestClassifyMediaSize(t *testing.T) {
 func TestClassifyUnknown(t *testing.T) {
 	assert.Equal(t, ClassUnknown, Classify(errors.New("something unexpected")))
 	assert.Equal(t, ClassUnknown, Classify(nil))
+	assert.Equal(t, ClassUnknown, Classify(errors.New("")))
+}
+
+func TestClassifyFalsePositives(t *testing.T) {
+	cases := []struct {
+		msg    string
+		reason string
+	}{
+		{"error code 4130 is unknown", `"4130" should not match 413`},
+		{"failed to load config from port 5032", `"5032" should not match 503`},
+		{"error code 5290 is unknown", `"5290" should not match 529`},
+		{"connection to port 5032 refused", `"5032" in port should not match`},
+		{"phone number 14135551234", `"4135" should not match 413`},
+		{"chunk 1413 of 5000 uploaded", `"1413" should not match 413`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.msg, func(t *testing.T) {
+			assert.Equal(t, ClassUnknown, Classify(errors.New(tc.msg)), tc.reason)
+		})
+	}
+}
+
+func TestClassifyPriorityOrder(t *testing.T) {
+	assert.Equal(t, ClassPromptTooLong, Classify(errors.New("error 413: file too large")),
+		"prompt_too_long checked before media_size")
+	assert.Equal(t, ClassMaxOutputTokens, Classify(errors.New("max_output_tokens error: overloaded")),
+		"max_output_tokens checked before model_overloaded")
 }
 
 func TestClassifyIsRetryable(t *testing.T) {
 	assert.True(t, IsRetryable(ClassModelOverloaded))
 	assert.False(t, IsRetryable(ClassPromptTooLong))
 	assert.False(t, IsRetryable(ClassUnknown))
+	assert.False(t, IsRetryable(ClassMaxOutputTokens))
+	assert.False(t, IsRetryable(ClassMediaSize))
+}
+
+func TestErrorClassString(t *testing.T) {
+	assert.Equal(t, "unknown", ClassUnknown.String())
+	assert.Equal(t, "prompt_too_long", ClassPromptTooLong.String())
+	assert.Equal(t, "model_overloaded", ClassModelOverloaded.String())
+	assert.Equal(t, "max_output_tokens", ClassMaxOutputTokens.String())
+	assert.Equal(t, "media_size", ClassMediaSize.String())
 }

--- a/internal/agent/errorclass/classifier_test.go
+++ b/internal/agent/errorclass/classifier_test.go
@@ -1,0 +1,71 @@
+package errorclass
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyPromptTooLong(t *testing.T) {
+	cases := []string{
+		"prompt is too long: 204857 tokens > 200000 maximum",
+		"Error: context_length_exceeded",
+		"Request too large: 413",
+		"too many tokens in request",
+	}
+	for _, msg := range cases {
+		t.Run(msg, func(t *testing.T) {
+			assert.Equal(t, ClassPromptTooLong, Classify(errors.New(msg)))
+		})
+	}
+}
+
+func TestClassifyModelOverloaded(t *testing.T) {
+	cases := []string{
+		"Overloaded",
+		"APIError 529: ",
+		"ServiceUnavailable 503",
+		"insufficient capacity",
+	}
+	for _, msg := range cases {
+		t.Run(msg, func(t *testing.T) {
+			assert.Equal(t, ClassModelOverloaded, Classify(errors.New(msg)))
+		})
+	}
+}
+
+func TestClassifyMaxOutputTokens(t *testing.T) {
+	cases := []string{
+		"max_output_tokens exceeded",
+		"Max output tokens exceeded: response was truncated",
+	}
+	for _, msg := range cases {
+		t.Run(msg, func(t *testing.T) {
+			assert.Equal(t, ClassMaxOutputTokens, Classify(errors.New(msg)))
+		})
+	}
+}
+
+func TestClassifyMediaSize(t *testing.T) {
+	cases := []string{
+		"media_size_error: image too large",
+		"file too large for processing",
+	}
+	for _, msg := range cases {
+		t.Run(msg, func(t *testing.T) {
+			assert.Equal(t, ClassMediaSize, Classify(errors.New(msg)))
+		})
+	}
+}
+
+func TestClassifyUnknown(t *testing.T) {
+	assert.Equal(t, ClassUnknown, Classify(errors.New("something unexpected")))
+	assert.Equal(t, ClassUnknown, Classify(nil))
+}
+
+func TestClassifyIsRetryable(t *testing.T) {
+	assert.True(t, IsRetryable(ClassModelOverloaded))
+	assert.False(t, IsRetryable(ClassPromptTooLong))
+	assert.False(t, IsRetryable(ClassUnknown))
+}


### PR DESCRIPTION
## Summary
- New `internal/agent/errorclass/` package with `ErrorClass` enum (5 categories: `Unknown`, `PromptTooLong`, `ModelOverloaded`, `MaxOutputTokens`, `MediaSize`) and `Classify()`/`IsRetryable()` functions
- Wires classifier into the runLoop provider error path with a classified log line (`a.logger.Warn("provider error classified as %s: %v", ...)`)
- Adds characterization test locking in current behavior: `prompt_too_long` errors exit with `ExitProviderError`

## Test plan
- [x] `go test ./internal/agent/errorclass/... -v` — all 6 test functions pass
- [x] `go test ./internal/agent/... -v -count=1` — full agent suite passes
- [x] `gofmt -l` — clean

## Context
Plan A from the query-loop improvements roadmap (`docs/superpowers/plans/2026-04-27-query-loop-error-classifier.md`). This is the foundation for Plans B (reactive compaction), C (max_tokens recovery), and F (model fallback).