### PR TITLE
Extract loopState struct from runLoop inline vars

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1287,8 +1287,8 @@ func replaceAssistantText(blocks []provider.ContentBlock, newText string) []prov
 // runLoop iteratively processes LLM responses and tool calls.
 func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int, lastUserMessage string) {
 	var totalInputTokens, totalOutputTokens int
-	var lastPendingToolSignature string
-	repeatedPendingToolRounds := 0
+	ls := newLoopState(a.maxTurns)
+	ls.turnCount = turnCount
 	if a.skillRuntime != nil {
 		triggerCtx := a.buildSkillTriggerContext(lastUserMessage)
 		if err := a.skillRuntime.EvaluateAndActivate(triggerCtx); err != nil {
@@ -1297,9 +1297,9 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			return
 		}
 	}
-	for ; turnCount < a.maxTurns; turnCount++ {
+	for ; !ls.shouldExit(); ls.turnCount++ {
 		// Track turn number for checkpoint middleware.
-		a.turnNumber.Store(int32(turnCount))
+		a.turnNumber.Store(int32(ls.turnCount))
 
 		if ctx.Err() != nil {
 			a.emit(ctx, ch, TurnEvent{Type: "error", Error: ctx.Err()})
@@ -1417,7 +1417,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		var blocks []provider.ContentBlock
 		var pendingTools []provider.ToolUseBlock
 		var currentTextBuf string
-		var streamErr bool
+		ls.streamErr = false
 		var currentTool *provider.ToolUseBlock
 		var toolInputBuf string
 		var thinkingBuf string
@@ -1534,7 +1534,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 				finalizeTool()
 
 			case "error":
-				streamErr = true
+				ls.streamErr = true
 				a.emit(ctx, ch, TurnEvent{Type: "error", Error: event.Error})
 
 			case "stop":
@@ -1578,7 +1578,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// event channel. executeSingleTool emits tool_progress events as
 		// the tool runs; if we don't also emit a matching tool_call +
 		// tool_result, the UI sees orphan progress with no terminal event.
-		if streamErr {
+		if ls.streamErr {
 			if unmatched := surfaceStreamedResults(ctx, a, ch, pendingTools, execStream.Drain()); unmatched > 0 {
 				// Invariant broken: every dispatched tool should have been
 				// appended to pendingTools before Dispatch ran. If this
@@ -1669,14 +1669,14 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		}
 
 		signature := pendingToolSignature(pendingTools)
-		if !hasTextContent(blocks) && signature == lastPendingToolSignature {
-			repeatedPendingToolRounds++
+		if !hasTextContent(blocks) && signature == ls.lastToolSignature {
+			ls.repeatedToolRounds++
 		} else {
-			lastPendingToolSignature = signature
-			repeatedPendingToolRounds = 1
+			ls.lastToolSignature = signature
+			ls.repeatedToolRounds = 1
 		}
-		if repeatedPendingToolRounds >= maxRepeatedPendingToolRounds {
-			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("detected no progress after %d repeated tool-only rounds", repeatedPendingToolRounds)})
+		if ls.repeatedToolRounds >= maxRepeatedPendingToolRounds {
+			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("detected no progress after %d repeated tool-only rounds", ls.repeatedToolRounds)})
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitNoProgress))
 			return
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1287,8 +1287,7 @@ func replaceAssistantText(blocks []provider.ContentBlock, newText string) []prov
 // runLoop iteratively processes LLM responses and tool calls.
 func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int, lastUserMessage string) {
 	var totalInputTokens, totalOutputTokens int
-	ls := newLoopState(a.maxTurns)
-	ls.turnCount = turnCount
+	ls := newLoopState(a.maxTurns, turnCount)
 	if a.skillRuntime != nil {
 		triggerCtx := a.buildSkillTriggerContext(lastUserMessage)
 		if err := a.skillRuntime.EvaluateAndActivate(triggerCtx); err != nil {
@@ -1297,7 +1296,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			return
 		}
 	}
-	for ; !ls.shouldExit(); ls.turnCount++ {
+	for ; ls.hasMoreTurns(); ls.turnCount++ {
 		// Track turn number for checkpoint middleware.
 		a.turnNumber.Store(int32(ls.turnCount))
 
@@ -1417,7 +1416,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		var blocks []provider.ContentBlock
 		var pendingTools []provider.ToolUseBlock
 		var currentTextBuf string
-		ls.streamErr = false
+		ls.resetPerTurn()
 		var currentTool *provider.ToolUseBlock
 		var toolInputBuf string
 		var thinkingBuf string

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1668,13 +1668,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		}
 
 		signature := pendingToolSignature(pendingTools)
-		if !hasTextContent(blocks) && signature == ls.lastToolSignature {
-			ls.repeatedToolRounds++
-		} else {
-			ls.lastToolSignature = signature
-			ls.repeatedToolRounds = 1
-		}
-		if ls.repeatedToolRounds >= maxRepeatedPendingToolRounds {
+		if ls.recordToolSignature(signature, hasTextContent(blocks)) {
 			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("detected no progress after %d repeated tool-only rounds", ls.repeatedToolRounds)})
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitNoProgress))
 			return

--- a/internal/agent/loopstate.go
+++ b/internal/agent/loopstate.go
@@ -1,0 +1,28 @@
+package agent
+
+const maxOutputTokensRecoveryLimit = 3
+
+type loopState struct {
+	maxTurns                  int
+	turnCount                 int
+	maxTokensRecoveryAttempts int
+	repeatedToolRounds        int
+	lastToolSignature         string
+	streamErr                 bool
+}
+
+func newLoopState(maxTurns int) *loopState {
+	return &loopState{maxTurns: maxTurns}
+}
+
+func (s *loopState) canRecoverMaxTokens() bool {
+	return s.maxTokensRecoveryAttempts < maxOutputTokensRecoveryLimit
+}
+
+func (s *loopState) incrementMaxTokensRecovery() {
+	s.maxTokensRecoveryAttempts++
+}
+
+func (s *loopState) shouldExit() bool {
+	return s.turnCount >= s.maxTurns
+}

--- a/internal/agent/loopstate.go
+++ b/internal/agent/loopstate.go
@@ -1,32 +1,35 @@
 package agent
 
-const maxOutputTokensRecoveryLimit = 3
-
 type loopState struct {
-	maxTurns                  int
-	turnCount                 int
-	maxTokensRecoveryAttempts int
-	repeatedToolRounds        int
-	lastToolSignature         string
-	streamErr                 bool
+	maxTurns           int
+	turnCount          int
+	repeatedToolRounds int
+	lastToolSignature  string
+	streamErr          bool
 }
 
 func newLoopState(maxTurns, turnCount int) *loopState {
 	return &loopState{maxTurns: maxTurns, turnCount: turnCount}
 }
 
-func (s *loopState) canRecoverMaxTokens() bool {
-	return s.maxTokensRecoveryAttempts < maxOutputTokensRecoveryLimit
-}
-
-func (s *loopState) incrementMaxTokensRecovery() {
-	s.maxTokensRecoveryAttempts++
-}
-
 func (s *loopState) hasMoreTurns() bool {
 	return s.turnCount < s.maxTurns
 }
 
+// resetPerTurn clears per-iteration state. Cross-turn fields
+// (repeatedToolRounds, lastToolSignature) are intentionally preserved.
 func (s *loopState) resetPerTurn() {
 	s.streamErr = false
+}
+
+// recordToolSignature tracks consecutive identical tool-only rounds.
+// Returns true when the no-progress threshold is exceeded.
+func (s *loopState) recordToolSignature(sig string, hasText bool) bool {
+	if !hasText && sig == s.lastToolSignature {
+		s.repeatedToolRounds++
+	} else {
+		s.lastToolSignature = sig
+		s.repeatedToolRounds = 1
+	}
+	return s.repeatedToolRounds >= maxRepeatedPendingToolRounds
 }

--- a/internal/agent/loopstate.go
+++ b/internal/agent/loopstate.go
@@ -11,8 +11,8 @@ type loopState struct {
 	streamErr                 bool
 }
 
-func newLoopState(maxTurns int) *loopState {
-	return &loopState{maxTurns: maxTurns}
+func newLoopState(maxTurns, turnCount int) *loopState {
+	return &loopState{maxTurns: maxTurns, turnCount: turnCount}
 }
 
 func (s *loopState) canRecoverMaxTokens() bool {
@@ -23,6 +23,10 @@ func (s *loopState) incrementMaxTokensRecovery() {
 	s.maxTokensRecoveryAttempts++
 }
 
-func (s *loopState) shouldExit() bool {
-	return s.turnCount >= s.maxTurns
+func (s *loopState) hasMoreTurns() bool {
+	return s.turnCount < s.maxTurns
+}
+
+func (s *loopState) resetPerTurn() {
+	s.streamErr = false
 }

--- a/internal/agent/loopstate_test.go
+++ b/internal/agent/loopstate_test.go
@@ -1,0 +1,29 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoopState_CanRecoverMaxTokens(t *testing.T) {
+	ls := newLoopState(10)
+	assert.True(t, ls.canRecoverMaxTokens())
+	ls.maxTokensRecoveryAttempts = 3
+	assert.False(t, ls.canRecoverMaxTokens())
+}
+
+func TestLoopState_IncrementRecovery(t *testing.T) {
+	ls := newLoopState(10)
+	ls.incrementMaxTokensRecovery()
+	assert.Equal(t, 1, ls.maxTokensRecoveryAttempts)
+	ls.incrementMaxTokensRecovery()
+	assert.Equal(t, 2, ls.maxTokensRecoveryAttempts)
+}
+
+func TestLoopState_ShouldExit(t *testing.T) {
+	ls := newLoopState(2)
+	assert.False(t, ls.shouldExit())
+	ls.turnCount = 2
+	assert.True(t, ls.shouldExit())
+}

--- a/internal/agent/loopstate_test.go
+++ b/internal/agent/loopstate_test.go
@@ -7,23 +7,30 @@ import (
 )
 
 func TestLoopState_CanRecoverMaxTokens(t *testing.T) {
-	ls := newLoopState(10)
+	ls := newLoopState(10, 0)
 	assert.True(t, ls.canRecoverMaxTokens())
 	ls.maxTokensRecoveryAttempts = 3
 	assert.False(t, ls.canRecoverMaxTokens())
 }
 
 func TestLoopState_IncrementRecovery(t *testing.T) {
-	ls := newLoopState(10)
+	ls := newLoopState(10, 0)
 	ls.incrementMaxTokensRecovery()
 	assert.Equal(t, 1, ls.maxTokensRecoveryAttempts)
 	ls.incrementMaxTokensRecovery()
 	assert.Equal(t, 2, ls.maxTokensRecoveryAttempts)
 }
 
-func TestLoopState_ShouldExit(t *testing.T) {
-	ls := newLoopState(2)
-	assert.False(t, ls.shouldExit())
+func TestLoopState_HasMoreTurns(t *testing.T) {
+	ls := newLoopState(2, 0)
+	assert.True(t, ls.hasMoreTurns())
 	ls.turnCount = 2
-	assert.True(t, ls.shouldExit())
+	assert.False(t, ls.hasMoreTurns())
+}
+
+func TestLoopState_ResetPerTurn(t *testing.T) {
+	ls := newLoopState(10, 0)
+	ls.streamErr = true
+	ls.resetPerTurn()
+	assert.False(t, ls.streamErr)
 }

--- a/internal/agent/loopstate_test.go
+++ b/internal/agent/loopstate_test.go
@@ -6,31 +6,57 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLoopState_CanRecoverMaxTokens(t *testing.T) {
-	ls := newLoopState(10, 0)
-	assert.True(t, ls.canRecoverMaxTokens())
-	ls.maxTokensRecoveryAttempts = 3
-	assert.False(t, ls.canRecoverMaxTokens())
-}
-
-func TestLoopState_IncrementRecovery(t *testing.T) {
-	ls := newLoopState(10, 0)
-	ls.incrementMaxTokensRecovery()
-	assert.Equal(t, 1, ls.maxTokensRecoveryAttempts)
-	ls.incrementMaxTokensRecovery()
-	assert.Equal(t, 2, ls.maxTokensRecoveryAttempts)
+func TestNewLoopState(t *testing.T) {
+	ls := newLoopState(10, 3)
+	assert.Equal(t, 10, ls.maxTurns)
+	assert.Equal(t, 3, ls.turnCount)
+	assert.Equal(t, 0, ls.repeatedToolRounds)
+	assert.Equal(t, "", ls.lastToolSignature)
+	assert.False(t, ls.streamErr)
 }
 
 func TestLoopState_HasMoreTurns(t *testing.T) {
-	ls := newLoopState(2, 0)
-	assert.True(t, ls.hasMoreTurns())
-	ls.turnCount = 2
-	assert.False(t, ls.hasMoreTurns())
+	ls := newLoopState(5, 3)
+	assert.True(t, ls.hasMoreTurns(), "turnCount=3, maxTurns=5: has more")
+
+	ls.turnCount = 4
+	assert.True(t, ls.hasMoreTurns(), "turnCount=4, maxTurns=5: one turn remains")
+
+	ls.turnCount = 5
+	assert.False(t, ls.hasMoreTurns(), "turnCount=5, maxTurns=5: no more turns")
 }
 
 func TestLoopState_ResetPerTurn(t *testing.T) {
 	ls := newLoopState(10, 0)
 	ls.streamErr = true
+	ls.repeatedToolRounds = 2
+	ls.lastToolSignature = "read_file"
 	ls.resetPerTurn()
-	assert.False(t, ls.streamErr)
+	assert.False(t, ls.streamErr, "streamErr should be cleared")
+	assert.Equal(t, 2, ls.repeatedToolRounds, "cross-turn fields preserved")
+	assert.Equal(t, "read_file", ls.lastToolSignature, "cross-turn fields preserved")
+}
+
+func TestLoopState_RecordToolSignature_NoProgress(t *testing.T) {
+	ls := newLoopState(10, 0)
+
+	assert.False(t, ls.recordToolSignature("read_file", false), "first occurrence")
+	assert.False(t, ls.recordToolSignature("read_file", false), "second occurrence")
+	assert.True(t, ls.recordToolSignature("read_file", false), "third occurrence triggers no-progress")
+}
+
+func TestLoopState_RecordToolSignature_ResetsOnNewSignature(t *testing.T) {
+	ls := newLoopState(10, 0)
+
+	ls.recordToolSignature("read_file", false)
+	ls.recordToolSignature("read_file", false)
+	assert.False(t, ls.recordToolSignature("write_file", false), "new signature resets counter")
+}
+
+func TestLoopState_RecordToolSignature_ResetsOnTextContent(t *testing.T) {
+	ls := newLoopState(10, 0)
+
+	ls.recordToolSignature("read_file", false)
+	ls.recordToolSignature("read_file", false)
+	assert.False(t, ls.recordToolSignature("read_file", true), "text content resets counter")
 }


### PR DESCRIPTION
## Summary
- New `internal/agent/loopstate.go` with `loopState` struct holding turn counter, max_tokens recovery attempts, repeated tool round tracking, stream error flag, and last tool signature
- Replaces 4 inline variables in `runLoop` with a single `ls *loopState` — `lastPendingToolSignature`, `repeatedPendingToolRounds`, `streamErr`, and the for-loop `turnCount`
- Adds `canRecoverMaxTokens()`, `incrementMaxTokensRecovery()`, `shouldExit()` methods with tests

## Test plan
- [x] `go test ./internal/agent/... -run TestLoopState -v` — 3 tests pass
- [x] `go test ./internal/agent/... -count=1` — full agent suite passes (no behavioral change)
- [x] `gofmt -l` — clean

## Context
Plan D from the query-loop improvements roadmap. This is a prerequisite for Plans B (reactive compaction) and C (max_tokens recovery) which will add recovery logic to the loop using `loopState` methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal agent loop control and state management for improved organization.

* **Tests**
  * Added tests for agent loop state management to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->