### PR TITLE
Recover from prompt_too_long via reactive compaction and retry

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1409,26 +1409,14 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			class := errorclass.Classify(err)
 			a.logger.Warn("provider error classified as %s: %v", class, err)
 
-			if class == errorclass.ClassPromptTooLong && ls.promptTooLongAttempts < maxPromptTooLongRetries {
-				ls.promptTooLongAttempts++
-				result := reactiveCompact(ctx, a.context, a.conversation)
-				if result.compacted {
-					a.saveSnapshotIfNeeded()
-					ls.turnCount--
-					continue
-				}
-				drained := contextCollapseDrain(a.conversation.Messages(), 2)
-				if len(drained) < a.conversation.Len() {
-					a.conversation.LoadFromMessages(drained)
-					a.saveSnapshotIfNeeded()
-					ls.turnCount--
-					continue
-				}
-				ls.turnCount--
-				continue
-			}
-
 			if class == errorclass.ClassPromptTooLong {
+				if ls.promptTooLongAttempts < maxPromptTooLongRetries &&
+					(reactiveCompact(ctx, a.context, a.conversation) || a.conversation.DrainMessages(minDrainPairs)) {
+					ls.promptTooLongAttempts++
+					a.saveSnapshotIfNeeded()
+					ls.turnCount--
+					continue
+				}
 				a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream: %w", err)})
 				a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitContextOverflow))
 				return

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1406,7 +1406,34 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			return a.provider.Stream(ctx, req)
 		}, onRetry)
 		if err != nil {
-			a.logger.Warn("provider error classified as %s: %v", errorclass.Classify(err), err)
+			class := errorclass.Classify(err)
+			a.logger.Warn("provider error classified as %s: %v", class, err)
+
+			if class == errorclass.ClassPromptTooLong && ls.promptTooLongAttempts < maxPromptTooLongRetries {
+				ls.promptTooLongAttempts++
+				result := reactiveCompact(ctx, a.context, a.conversation)
+				if result.compacted {
+					a.saveSnapshotIfNeeded()
+					ls.turnCount--
+					continue
+				}
+				drained := contextCollapseDrain(a.conversation.Messages(), 2)
+				if len(drained) < a.conversation.Len() {
+					a.conversation.LoadFromMessages(drained)
+					a.saveSnapshotIfNeeded()
+					ls.turnCount--
+					continue
+				}
+				ls.turnCount--
+				continue
+			}
+
+			if class == errorclass.ClassPromptTooLong {
+				a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream: %w", err)})
+				a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitContextOverflow))
+				return
+			}
+
 			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream: %w", err)})
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError))
 			return

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1410,9 +1410,17 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			a.logger.Warn("provider error classified as %s: %v", class, err)
 
 			if class == errorclass.ClassPromptTooLong {
-				if ls.promptTooLongAttempts < maxPromptTooLongRetries &&
-					(reactiveCompact(ctx, a.context, a.conversation) || a.conversation.DrainMessages(minDrainPairs)) {
+				compacted := reactiveCompact(ctx, a.context, a.conversation)
+				drained := false
+				if !compacted {
+					drained = a.conversation.DrainMessages(minDrainPairs)
+					if drained {
+						a.logger.Warn("forceCompact did not reduce; fell back to DrainMessages")
+					}
+				}
+				if ls.promptTooLongAttempts < maxPromptTooLongRetries && (compacted || drained) {
 					ls.promptTooLongAttempts++
+					a.emit(ctx, ch, TurnEvent{Type: "context_overflow"})
 					a.saveSnapshotIfNeeded()
 					ls.turnCount--
 					continue

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1018,7 +1018,7 @@ func TestTurnWithStreamInitError(t *testing.T) {
 	assert.Equal(t, "done", events[len(events)-1].Type)
 }
 
-func TestRunLoop_PromptTooLong_ExitsWithProviderError(t *testing.T) {
+func TestRunLoop_PromptTooLong_ExitsWithContextOverflowAfterRetries(t *testing.T) {
 	errProvider := &errorProvider{err: fmt.Errorf("prompt is too long: 300000 tokens")}
 	reg := tools.NewRegistry()
 	cfg := config.DefaultConfig()
@@ -1033,7 +1033,43 @@ func TestRunLoop_PromptTooLong_ExitsWithProviderError(t *testing.T) {
 			exitReason = evt.ExitReason
 		}
 	}
-	assert.Equal(t, agentsdk.ExitProviderError, exitReason)
+	assert.Equal(t, agentsdk.ExitContextOverflow, exitReason)
+}
+
+type retryAfterErrorProvider struct {
+	err       error
+	callCount int
+}
+
+func (r *retryAfterErrorProvider) Stream(_ context.Context, _ provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
+	r.callCount++
+	if r.callCount == 1 {
+		return nil, r.err
+	}
+	ch := make(chan provider.StreamEvent, 2)
+	ch <- provider.StreamEvent{Type: "text_delta", Text: "recovered"}
+	ch <- provider.StreamEvent{Type: "done", InputTokens: 1, OutputTokens: 1}
+	close(ch)
+	return ch, nil
+}
+
+func TestRunLoop_PromptTooLong_RecoversWithCompaction(t *testing.T) {
+	prov := &retryAfterErrorProvider{err: fmt.Errorf("prompt is too long: 300000 tokens")}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	agent := New(prov, reg, autoApprove, cfg)
+
+	ch, err := agent.Turn(context.Background(), "hello")
+	require.NoError(t, err)
+
+	var exitReason agentsdk.TurnExitReason
+	for evt := range ch {
+		if evt.Type == "done" {
+			exitReason = evt.ExitReason
+		}
+	}
+	assert.Equal(t, agentsdk.ExitCompleted, exitReason, "should recover after reactive compaction")
+	assert.Equal(t, 2, prov.callCount, "should retry after reactive compaction")
 }
 
 func TestTurnWithApprovalError(t *testing.T) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1016,9 +1016,10 @@ func TestTurnWithStreamInitError(t *testing.T) {
 	}
 	assert.True(t, hasError, "should have error event from Stream() failure")
 	assert.Equal(t, "done", events[len(events)-1].Type)
+	assert.Equal(t, agentsdk.ExitProviderError, events[len(events)-1].ExitReason)
 }
 
-func TestRunLoop_PromptTooLong_ExitsWithContextOverflowAfterRetries(t *testing.T) {
+func TestRunLoop_PromptTooLong_SmallConversation_ExitsImmediately(t *testing.T) {
 	errProvider := &errorProvider{err: fmt.Errorf("prompt is too long: 300000 tokens")}
 	reg := tools.NewRegistry()
 	cfg := config.DefaultConfig()
@@ -1053,7 +1054,7 @@ func (r *retryAfterErrorProvider) Stream(_ context.Context, _ provider.Completio
 	return ch, nil
 }
 
-func TestRunLoop_PromptTooLong_RecoversWithCompaction(t *testing.T) {
+func TestRunLoop_PromptTooLong_RecoversViaDrain(t *testing.T) {
 	prov := &retryAfterErrorProvider{err: fmt.Errorf("prompt is too long: 300000 tokens")}
 	reg := tools.NewRegistry()
 	cfg := config.DefaultConfig()
@@ -1067,13 +1068,45 @@ func TestRunLoop_PromptTooLong_RecoversWithCompaction(t *testing.T) {
 	require.NoError(t, err)
 
 	var exitReason agentsdk.TurnExitReason
+	var sawOverflowEvent bool
 	for evt := range ch {
 		if evt.Type == "done" {
 			exitReason = evt.ExitReason
 		}
+		if evt.Type == "context_overflow" {
+			sawOverflowEvent = true
+		}
 	}
-	assert.Equal(t, agentsdk.ExitCompleted, exitReason, "should recover after reactive compaction")
-	assert.Equal(t, 2, prov.callCount, "should retry after reactive compaction")
+	assert.Equal(t, agentsdk.ExitCompleted, exitReason, "should recover after drain")
+	assert.True(t, sawOverflowEvent, "should emit context_overflow event on recovery")
+	assert.Equal(t, 2, prov.callCount, "should retry after drain")
+}
+
+func TestRunLoop_PromptTooLong_ExhaustsRetries(t *testing.T) {
+	prov := &errorProvider{err: fmt.Errorf("prompt is too long: 300000 tokens")}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	agent := New(prov, reg, autoApprove, cfg)
+	for i := 0; i < 20; i++ {
+		agent.conversation.AddUser(fmt.Sprintf("prior message %d", i))
+		agent.conversation.AddAssistant([]provider.ContentBlock{{Type: "text", Text: fmt.Sprintf("response %d", i)}})
+	}
+
+	ch, err := agent.Turn(context.Background(), "hello")
+	require.NoError(t, err)
+
+	var exitReason agentsdk.TurnExitReason
+	var overflowEvents int
+	for evt := range ch {
+		if evt.Type == "done" {
+			exitReason = evt.ExitReason
+		}
+		if evt.Type == "context_overflow" {
+			overflowEvents++
+		}
+	}
+	assert.Equal(t, agentsdk.ExitContextOverflow, exitReason, "should exhaust retries and exit")
+	assert.GreaterOrEqual(t, overflowEvents, 1, "should attempt at least one recovery before giving up")
 }
 
 func TestTurnWithApprovalError(t *testing.T) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1058,6 +1058,10 @@ func TestRunLoop_PromptTooLong_RecoversWithCompaction(t *testing.T) {
 	reg := tools.NewRegistry()
 	cfg := config.DefaultConfig()
 	agent := New(prov, reg, autoApprove, cfg)
+	for i := 0; i < 10; i++ {
+		agent.conversation.AddUser(fmt.Sprintf("prior message %d", i))
+		agent.conversation.AddAssistant([]provider.ContentBlock{{Type: "text", Text: fmt.Sprintf("response %d", i)}})
+	}
 
 	ch, err := agent.Turn(context.Background(), "hello")
 	require.NoError(t, err)

--- a/internal/agent/conversation.go
+++ b/internal/agent/conversation.go
@@ -58,21 +58,26 @@ func (c *Conversation) LoadFromMessages(msgs []provider.Message) {
 }
 
 // DrainMessages removes the oldest message pairs until only minPairsToKeep
-// remain. Returns true if any messages were removed. Operates in-place
-// without allocating a copy.
+// remain. Returns true if any messages were removed. Copies into a fresh
+// slice to avoid retaining the drained messages in the backing array.
+// Ensures the kept slice starts on a non-tool_result boundary.
 func (c *Conversation) DrainMessages(minPairsToKeep int) bool {
 	if len(c.messages) <= minPairsToKeep*2 {
 		return false
 	}
-	pairsToRemove := (len(c.messages) - minPairsToKeep*2) / 2
-	if pairsToRemove <= 0 {
+	cutoff := len(c.messages) - minPairsToKeep*2
+	if cutoff <= 0 {
 		return false
 	}
-	cutoff := pairsToRemove * 2
+	for cutoff < len(c.messages) && cutoff > 0 && c.messages[cutoff].Role == "tool_result" {
+		cutoff++
+	}
 	if cutoff >= len(c.messages) {
 		return false
 	}
-	c.messages = c.messages[cutoff:]
+	kept := make([]provider.Message, len(c.messages)-cutoff)
+	copy(kept, c.messages[cutoff:])
+	c.messages = kept
 	return true
 }
 

--- a/internal/agent/conversation.go
+++ b/internal/agent/conversation.go
@@ -57,6 +57,25 @@ func (c *Conversation) LoadFromMessages(msgs []provider.Message) {
 	copy(c.messages, msgs)
 }
 
+// DrainMessages removes the oldest message pairs until only minPairsToKeep
+// remain. Returns true if any messages were removed. Operates in-place
+// without allocating a copy.
+func (c *Conversation) DrainMessages(minPairsToKeep int) bool {
+	if len(c.messages) <= minPairsToKeep*2 {
+		return false
+	}
+	pairsToRemove := (len(c.messages) - minPairsToKeep*2) / 2
+	if pairsToRemove <= 0 {
+		return false
+	}
+	cutoff := pairsToRemove * 2
+	if cutoff >= len(c.messages) {
+		return false
+	}
+	c.messages = c.messages[cutoff:]
+	return true
+}
+
 // Clear removes all messages but preserves the system prompt.
 func (c *Conversation) Clear() {
 	c.messages = nil

--- a/internal/agent/loopstate.go
+++ b/internal/agent/loopstate.go
@@ -1,11 +1,17 @@
 package agent
 
+// maxPromptTooLongRetries caps total reactive-compaction rounds within a
+// single Turn() call, including rounds where compaction succeeded but the
+// provider still rejected the request.
+const maxPromptTooLongRetries = 3
+
 type loopState struct {
-	maxTurns           int
-	turnCount          int
-	repeatedToolRounds int
-	lastToolSignature  string
-	streamErr          bool
+	maxTurns              int
+	turnCount             int
+	repeatedToolRounds    int
+	lastToolSignature     string
+	streamErr             bool
+	promptTooLongAttempts int
 }
 
 func newLoopState(maxTurns, turnCount int) *loopState {

--- a/internal/agent/reactive_compact.go
+++ b/internal/agent/reactive_compact.go
@@ -2,32 +2,12 @@ package agent
 
 import "context"
 
-type reactiveResult struct {
-	compacted bool
-}
-
-func reactiveCompact(ctx context.Context, cm *ContextManager, conv *Conversation) reactiveResult {
+func reactiveCompact(ctx context.Context, cm *ContextManager, conv *Conversation) bool {
 	if conv.Len() == 0 {
-		return reactiveResult{}
+		return false
 	}
 	result := cm.ForceCompact(ctx, conv)
-	if result.AfterMsgCount < result.BeforeMsgCount && result.AfterMsgCount > 0 {
-		return reactiveResult{compacted: true}
-	}
-	return reactiveResult{}
+	return result.AfterMsgCount < result.BeforeMsgCount && result.AfterMsgCount > 0
 }
 
-func contextCollapseDrain[T any](messages []T, minPairsToKeep int) []T {
-	if len(messages) <= minPairsToKeep*2 {
-		return messages
-	}
-	pairsToRemove := (len(messages) - minPairsToKeep*2) / 2
-	if pairsToRemove <= 0 {
-		return messages
-	}
-	cutoff := pairsToRemove * 2
-	if cutoff >= len(messages) {
-		return messages
-	}
-	return messages[cutoff:]
-}
+const minDrainPairs = 2

--- a/internal/agent/reactive_compact.go
+++ b/internal/agent/reactive_compact.go
@@ -1,0 +1,33 @@
+package agent
+
+import "context"
+
+type reactiveResult struct {
+	compacted bool
+}
+
+func reactiveCompact(ctx context.Context, cm *ContextManager, conv *Conversation) reactiveResult {
+	if conv.Len() == 0 {
+		return reactiveResult{}
+	}
+	result := cm.ForceCompact(ctx, conv)
+	if result.AfterMsgCount < result.BeforeMsgCount && result.AfterMsgCount > 0 {
+		return reactiveResult{compacted: true}
+	}
+	return reactiveResult{}
+}
+
+func contextCollapseDrain[T any](messages []T, minPairsToKeep int) []T {
+	if len(messages) <= minPairsToKeep*2 {
+		return messages
+	}
+	pairsToRemove := (len(messages) - minPairsToKeep*2) / 2
+	if pairsToRemove <= 0 {
+		return messages
+	}
+	cutoff := pairsToRemove * 2
+	if cutoff >= len(messages) {
+		return messages
+	}
+	return messages[cutoff:]
+}

--- a/internal/agent/reactive_compact_test.go
+++ b/internal/agent/reactive_compact_test.go
@@ -20,7 +20,7 @@ func TestReactiveCompact_ReducesMessages(t *testing.T) {
 	initialLen := conv.Len()
 
 	result := reactiveCompact(context.Background(), cm, conv)
-	assert.True(t, result.compacted, "should have compacted")
+	assert.True(t, result, "should have compacted")
 	assert.Less(t, conv.Len(), initialLen, "messages should be reduced")
 }
 
@@ -29,7 +29,7 @@ func TestReactiveCompact_EmptyConversation(t *testing.T) {
 	conv := NewConversation("system")
 
 	result := reactiveCompact(context.Background(), cm, conv)
-	assert.False(t, result.compacted, "empty conversation should not compact")
+	assert.False(t, result, "empty conversation should not compact")
 }
 
 func TestReactiveCompact_NoReduction(t *testing.T) {
@@ -41,23 +41,31 @@ func TestReactiveCompact_NoReduction(t *testing.T) {
 	conv.AddAssistant([]provider.ContentBlock{{Type: "text", Text: "hi"}})
 
 	result := reactiveCompact(context.Background(), cm, conv)
-	assert.False(t, result.compacted, "strategy that doesn't reduce should return false")
+	assert.False(t, result, "strategy that doesn't reduce should return false")
 }
 
-func TestContextCollapseDrain(t *testing.T) {
-	msgs := make([]int, 20)
-	drained := contextCollapseDrain(msgs, 5)
-	assert.Equal(t, 10, len(drained), "should keep 5 pairs = 10 messages")
+func TestDrainMessages(t *testing.T) {
+	conv := NewConversation("system")
+	for i := 0; i < 20; i++ {
+		conv.AddUser("msg")
+		conv.AddAssistant([]provider.ContentBlock{{Type: "text", Text: "resp"}})
+	}
+	assert.True(t, conv.DrainMessages(5))
+	assert.Equal(t, 10, conv.Len(), "should keep 5 pairs = 10 messages")
 }
 
-func TestContextCollapseDrain_SmallInput(t *testing.T) {
-	msgs := make([]int, 8)
-	drained := contextCollapseDrain(msgs, 5)
-	assert.Equal(t, 8, len(drained), "should keep all when below minPairs")
+func TestDrainMessages_SmallConversation(t *testing.T) {
+	conv := NewConversation("system")
+	conv.AddUser("hello")
+	conv.AddAssistant([]provider.ContentBlock{{Type: "text", Text: "hi"}})
+	assert.False(t, conv.DrainMessages(5), "should not drain small conversation")
 }
 
-func TestContextCollapseDrain_ZeroMinPairs(t *testing.T) {
-	msgs := make([]int, 20)
-	drained := contextCollapseDrain(msgs, 0)
-	assert.Equal(t, 20, len(drained), "zero minPairs keeps all")
+func TestDrainMessages_ExactBoundary(t *testing.T) {
+	conv := NewConversation("system")
+	conv.AddUser("msg")
+	conv.AddAssistant([]provider.ContentBlock{{Type: "text", Text: "resp"}})
+	conv.AddUser("msg2")
+	conv.AddAssistant([]provider.ContentBlock{{Type: "text", Text: "resp2"}})
+	assert.False(t, conv.DrainMessages(2), "4 messages = exactly 2 pairs, should not drain")
 }

--- a/internal/agent/reactive_compact_test.go
+++ b/internal/agent/reactive_compact_test.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReactiveCompact_ReducesMessages(t *testing.T) {
+	cm := NewContextManager(30, 0)
+	cm.SetStrategies([]CompactionStrategy{&mockStrategy{name: "test", removeN: 10}})
+
+	conv := NewConversation("system")
+	for i := 0; i < 20; i++ {
+		conv.AddUser("message with enough content to have tokens")
+		conv.AddAssistant([]provider.ContentBlock{{Type: "text", Text: "response"}})
+	}
+	initialLen := conv.Len()
+
+	result := reactiveCompact(context.Background(), cm, conv)
+	assert.True(t, result.compacted, "should have compacted")
+	assert.Less(t, conv.Len(), initialLen, "messages should be reduced")
+}
+
+func TestReactiveCompact_EmptyConversation(t *testing.T) {
+	cm := NewContextManager(30, 0)
+	conv := NewConversation("system")
+
+	result := reactiveCompact(context.Background(), cm, conv)
+	assert.False(t, result.compacted, "empty conversation should not compact")
+}
+
+func TestReactiveCompact_NoReduction(t *testing.T) {
+	cm := NewContextManager(30000, 0)
+	cm.SetStrategies([]CompactionStrategy{&mockStrategy{name: "noop"}})
+
+	conv := NewConversation("system")
+	conv.AddUser("hello")
+	conv.AddAssistant([]provider.ContentBlock{{Type: "text", Text: "hi"}})
+
+	result := reactiveCompact(context.Background(), cm, conv)
+	assert.False(t, result.compacted, "strategy that doesn't reduce should return false")
+}
+
+func TestContextCollapseDrain(t *testing.T) {
+	msgs := make([]int, 20)
+	drained := contextCollapseDrain(msgs, 5)
+	assert.Equal(t, 10, len(drained), "should keep 5 pairs = 10 messages")
+}
+
+func TestContextCollapseDrain_SmallInput(t *testing.T) {
+	msgs := make([]int, 8)
+	drained := contextCollapseDrain(msgs, 5)
+	assert.Equal(t, 8, len(drained), "should keep all when below minPairs")
+}
+
+func TestContextCollapseDrain_ZeroMinPairs(t *testing.T) {
+	msgs := make([]int, 20)
+	drained := contextCollapseDrain(msgs, 0)
+	assert.Equal(t, 20, len(drained), "zero minPairs keeps all")
+}

--- a/internal/agent/reactive_compact_test.go
+++ b/internal/agent/reactive_compact_test.go
@@ -69,3 +69,14 @@ func TestDrainMessages_ExactBoundary(t *testing.T) {
 	conv.AddAssistant([]provider.ContentBlock{{Type: "text", Text: "resp2"}})
 	assert.False(t, conv.DrainMessages(2), "4 messages = exactly 2 pairs, should not drain")
 }
+
+func TestDrainMessages_SkipsLeadingToolResult(t *testing.T) {
+	conv := NewConversation("system")
+	for i := 0; i < 10; i++ {
+		conv.AddUser("msg")
+		conv.AddAssistant([]provider.ContentBlock{{Type: "text", Text: "resp"}})
+	}
+	conv.AddToolResult("tool-1", "result", false)
+	assert.True(t, conv.DrainMessages(2))
+	assert.NotEqual(t, "tool_result", conv.messages[0].Role, "should not start with tool_result")
+}

--- a/pkg/agentsdk/exit_reason.go
+++ b/pkg/agentsdk/exit_reason.go
@@ -48,6 +48,10 @@ const (
 	// repeated no-shrink attempts.
 	ExitCompactionFailed
 
+	// ExitContextOverflow: context exceeded provider limits and reactive
+	// compaction could not recover enough space to retry.
+	ExitContextOverflow
+
 	// ExitPanic: a panic was recovered in Turn's deferred handler.
 	ExitPanic
 )
@@ -75,6 +79,8 @@ func (r TurnExitReason) String() string {
 		return "empty_response"
 	case ExitCompactionFailed:
 		return "compaction_failed"
+	case ExitContextOverflow:
+		return "context_overflow"
 	case ExitPanic:
 		return "panic"
 	default:


### PR DESCRIPTION
## Summary
- When the provider returns `prompt_too_long`/`context_length_exceeded`, the loop now runs `ForceCompact` and retries the same turn instead of terminating
- Falls back to `contextCollapseDrain` (head removal) if compaction doesn't reduce message count
- After 3 failed recovery attempts, exits with `ExitContextOverflow` (new exit reason) instead of `ExitProviderError`
- New files: `reactive_compact.go` (helper + generic drain), `reactive_compact_test.go` (6 tests)

## Test plan
- [x] `go test ./internal/agent/... -count=1` — full suite passes
- [x] `TestRunLoop_PromptTooLong_RecoversWithCompaction` — provider fails first call, succeeds on retry
- [x] `TestRunLoop_PromptTooLong_ExitsWithContextOverflowAfterRetries` — persistent errors exhaust retries
- [x] `TestReactiveCompact_ReducesMessages` / `_EmptyConversation` / `_NoReduction`
- [x] `TestContextCollapseDrain` / `_SmallInput` / `_ZeroMinPairs`
- [x] `gofmt -l` — clean

## Context
Plan B from the query-loop improvements roadmap. Depends on Plan A (error classifier) and Plan D (loopState), both merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The agent now automatically attempts to recover from context overflow errors by optimizing message history before terminating a conversation turn.
  * New "context overflow" exit status provides clearer error classification when recovery attempts are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->