### PR TITLE
Retry on max_tokens stop reason with continuation messages

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1567,9 +1567,22 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			}
 		}
 
-		// Warn if the model hit the output token cap so operators know to raise MaxOutputTokens.
-		if stopReason == agentsdk.StopReasonMaxTokens {
-			a.logger.Warn("response truncated by output token limit (consider increasing max_output_tokens in config)")
+		// Handle max_tokens truncation: inject a continuation message and
+		// retry so the model can complete its response. Escalate once (to
+		// increase the output limit on the next call), then retry up to
+		// maxOutputTokensRecoveryLimit times with continuation prompts.
+		if stopReason == agentsdk.StopReasonMaxTokens && len(pendingTools) == 0 {
+			if ls.maxTokensRecoveryAttempts < maxOutputTokensRecoveryLimit {
+				ls.maxTokensRecoveryAttempts++
+				a.conversation.AddAssistant(blocks)
+				a.persistMessage("assistant", blocks)
+				a.conversation.AddUser(fmt.Sprintf(
+					"[max_output_tokens recovery %d/%d] Continue your response from where you left off.",
+					ls.maxTokensRecoveryAttempts, maxOutputTokensRecoveryLimit))
+				ls.turnCount--
+				continue
+			}
+			a.logger.Warn("response truncated by output token limit after %d recovery attempts", ls.maxTokensRecoveryAttempts)
 		}
 
 		// Capture accumulated text before finalizing, for text-based tool extraction.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1568,21 +1568,28 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		}
 
 		// Handle max_tokens truncation: inject a continuation message and
-		// retry so the model can complete its response. Escalate once (to
-		// increase the output limit on the next call), then retry up to
-		// maxOutputTokensRecoveryLimit times with continuation prompts.
-		if stopReason == agentsdk.StopReasonMaxTokens && len(pendingTools) == 0 {
-			if ls.maxTokensRecoveryAttempts < maxOutputTokensRecoveryLimit {
+		// retry so the model can complete its response, up to
+		// maxOutputTokensRecoveryLimit times. Only retry when there are no
+		// pending tool calls; otherwise the truncated-tool detection below
+		// handles it.
+		if stopReason == agentsdk.StopReasonMaxTokens {
+			hasPendingTools := len(pendingTools) > 0 || currentTool != nil
+			if hasPendingTools {
+				a.logger.Warn("response hit output token limit with %d pending tool calls; tool arguments may be truncated", len(pendingTools))
+			} else if ls.maxTokensRecoveryAttempts < maxOutputTokensRecoveryLimit {
 				ls.maxTokensRecoveryAttempts++
 				a.conversation.AddAssistant(blocks)
 				a.persistMessage("assistant", blocks)
 				a.conversation.AddUser(fmt.Sprintf(
 					"[max_output_tokens recovery %d/%d] Continue your response from where you left off.",
 					ls.maxTokensRecoveryAttempts, maxOutputTokensRecoveryLimit))
+				a.emit(ctx, ch, TurnEvent{Type: "max_tokens_recovery"})
+				a.saveSnapshotIfNeeded()
 				ls.turnCount--
 				continue
+			} else {
+				a.logger.Warn("response truncated by output token limit after %d recovery attempts", ls.maxTokensRecoveryAttempts)
 			}
-			a.logger.Warn("response truncated by output token limit after %d recovery attempts", ls.maxTokensRecoveryAttempts)
 		}
 
 		// Capture accumulated text before finalizing, for text-based tool extraction.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1109,6 +1109,67 @@ func TestRunLoop_PromptTooLong_ExhaustsRetries(t *testing.T) {
 	assert.GreaterOrEqual(t, overflowEvents, 1, "should attempt at least one recovery before giving up")
 }
 
+type maxTokensProvider struct {
+	callCount int
+	maxCalls  int
+}
+
+func (m *maxTokensProvider) Stream(_ context.Context, _ provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
+	m.callCount++
+	ch := make(chan provider.StreamEvent, 4)
+	ch <- provider.StreamEvent{Type: "text_delta", Text: fmt.Sprintf("response_%d", m.callCount)}
+	if m.callCount < m.maxCalls {
+		ch <- provider.StreamEvent{Type: "stop", StopReason: "max_tokens", InputTokens: 1, OutputTokens: 1}
+	} else {
+		ch <- provider.StreamEvent{Type: "stop", StopReason: "end_turn", InputTokens: 1, OutputTokens: 1}
+	}
+	close(ch)
+	return ch, nil
+}
+
+func TestRunLoop_MaxTokens_RetriesWithContinuation(t *testing.T) {
+	prov := &maxTokensProvider{maxCalls: 3}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	agent := New(prov, reg, autoApprove, cfg)
+
+	ch, err := agent.Turn(context.Background(), "hello")
+	require.NoError(t, err)
+
+	var exitReason agentsdk.TurnExitReason
+	var output string
+	for evt := range ch {
+		if evt.Type == "text_delta" {
+			output += evt.Text
+		}
+		if evt.Type == "done" {
+			exitReason = evt.ExitReason
+		}
+	}
+	assert.Equal(t, agentsdk.ExitCompleted, exitReason)
+	assert.Equal(t, 3, prov.callCount, "should retry on max_tokens until end_turn")
+	assert.Contains(t, output, "response_3")
+}
+
+func TestRunLoop_MaxTokens_StopsAfterMaxRecovery(t *testing.T) {
+	prov := &maxTokensProvider{maxCalls: 100}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	agent := New(prov, reg, autoApprove, cfg)
+
+	ch, err := agent.Turn(context.Background(), "hello")
+	require.NoError(t, err)
+
+	var exitReason agentsdk.TurnExitReason
+	for evt := range ch {
+		if evt.Type == "done" {
+			exitReason = evt.ExitReason
+		}
+	}
+	assert.Equal(t, agentsdk.ExitCompleted, exitReason)
+	assert.LessOrEqual(t, prov.callCount, maxOutputTokensRecoveryLimit+1, "should stop after max recovery attempts + 1")
+}
+
 func TestTurnWithApprovalError(t *testing.T) {
 	// The approval function returns an error
 	approvalErr := func(_ context.Context, _ string, _ json.RawMessage) (bool, error) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1138,6 +1138,7 @@ func TestRunLoop_MaxTokens_RetriesWithContinuation(t *testing.T) {
 
 	var exitReason agentsdk.TurnExitReason
 	var output string
+	var recoveryEvents int
 	for evt := range ch {
 		if evt.Type == "text_delta" {
 			output += evt.Text
@@ -1145,10 +1146,14 @@ func TestRunLoop_MaxTokens_RetriesWithContinuation(t *testing.T) {
 		if evt.Type == "done" {
 			exitReason = evt.ExitReason
 		}
+		if evt.Type == "max_tokens_recovery" {
+			recoveryEvents++
+		}
 	}
 	assert.Equal(t, agentsdk.ExitCompleted, exitReason)
 	assert.Equal(t, 3, prov.callCount, "should retry on max_tokens until end_turn")
 	assert.Contains(t, output, "response_3")
+	assert.Equal(t, 2, recoveryEvents, "should emit 2 recovery events (attempts 1 and 2)")
 }
 
 func TestRunLoop_MaxTokens_StopsAfterMaxRecovery(t *testing.T) {
@@ -1161,13 +1166,57 @@ func TestRunLoop_MaxTokens_StopsAfterMaxRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	var exitReason agentsdk.TurnExitReason
+	var recoveryEvents int
 	for evt := range ch {
 		if evt.Type == "done" {
 			exitReason = evt.ExitReason
 		}
+		if evt.Type == "max_tokens_recovery" {
+			recoveryEvents++
+		}
 	}
 	assert.Equal(t, agentsdk.ExitCompleted, exitReason)
-	assert.LessOrEqual(t, prov.callCount, maxOutputTokensRecoveryLimit+1, "should stop after max recovery attempts + 1")
+	assert.Equal(t, maxOutputTokensRecoveryLimit, recoveryEvents, "should attempt exactly maxOutputTokensRecoveryLimit recoveries")
+	assert.Equal(t, maxOutputTokensRecoveryLimit+1, prov.callCount, "should stop after max recovery attempts + final call")
+}
+
+func TestRunLoop_MaxTokens_WithToolCalls_DoesNotRetry(t *testing.T) {
+	prov := &maxTokensWithToolProvider{}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	agent := New(prov, reg, autoApprove, cfg)
+
+	ch, err := agent.Turn(context.Background(), "hello")
+	require.NoError(t, err)
+
+	var recoveryEvents int
+	for evt := range ch {
+		if evt.Type == "max_tokens_recovery" {
+			recoveryEvents++
+		}
+	}
+	assert.Equal(t, 0, recoveryEvents, "should not emit recovery events when max_tokens has tool calls")
+}
+
+type maxTokensWithToolProvider struct {
+	callCount int
+}
+
+func (m *maxTokensWithToolProvider) Stream(_ context.Context, _ provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
+	m.callCount++
+	ch := make(chan provider.StreamEvent, 4)
+	ch <- provider.StreamEvent{Type: "text_delta", Text: "partial response"}
+	ch <- provider.StreamEvent{
+		Type: "tool_use",
+		ToolUse: &provider.ToolUseBlock{
+			ID:    "tu_1",
+			Name:  "read_file",
+			Input: json.RawMessage(`{"path": "/etc/hosts"}`),
+		},
+	}
+	ch <- provider.StreamEvent{Type: "stop", StopReason: "max_tokens", InputTokens: 1, OutputTokens: 1}
+	close(ch)
+	return ch, nil
 }
 
 func TestTurnWithApprovalError(t *testing.T) {

--- a/internal/agent/loopstate.go
+++ b/internal/agent/loopstate.go
@@ -28,7 +28,8 @@ func (s *loopState) hasMoreTurns() bool {
 }
 
 // resetPerTurn clears per-iteration state. Cross-turn fields
-// (repeatedToolRounds, lastToolSignature) are intentionally preserved.
+// (repeatedToolRounds, lastToolSignature, maxTokensRecoveryAttempts)
+// are intentionally preserved across sub-turns within a single Turn().
 func (s *loopState) resetPerTurn() {
 	s.streamErr = false
 }

--- a/internal/agent/loopstate.go
+++ b/internal/agent/loopstate.go
@@ -5,13 +5,18 @@ package agent
 // provider still rejected the request.
 const maxPromptTooLongRetries = 3
 
+// maxOutputTokensRecoveryLimit caps continuation retries when the model
+// hits the output token limit on every attempt.
+const maxOutputTokensRecoveryLimit = 3
+
 type loopState struct {
-	maxTurns              int
-	turnCount             int
-	repeatedToolRounds    int
-	lastToolSignature     string
-	streamErr             bool
-	promptTooLongAttempts int
+	maxTurns                  int
+	turnCount                 int
+	repeatedToolRounds        int
+	lastToolSignature         string
+	streamErr                 bool
+	promptTooLongAttempts     int
+	maxTokensRecoveryAttempts int
 }
 
 func newLoopState(maxTurns, turnCount int) *loopState {


### PR DESCRIPTION
## Summary
- When the model returns `stop_reason=max_tokens` with no pending tool calls, the loop now persists the partial assistant response, injects a continuation user message, and retries the same turn (up to 3 attempts)
- After `maxOutputTokensRecoveryLimit` (3) attempts, falls through to normal completion with a warning
- Adds `maxTokensRecoveryAttempts` field to `loopState` and `maxOutputTokensRecoveryLimit` constant

## Test plan
- [x] `TestRunLoop_MaxTokens_RetriesWithContinuation` — provider returns max_tokens twice, then end_turn; verifies 3 calls and output contains final response
- [x] `TestRunLoop_MaxTokens_StopsAfterMaxRecovery` — provider always returns max_tokens; verifies it stops after 4 calls (3 recovery + 1 final)
- [x] `go test ./internal/agent/... -count=1` — full suite passes
- [x] `gofmt -l` — clean

## Context
Plan C from the query-loop improvements roadmap. Depends on Plans A (error classifier) and D (loopState), both merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent now automatically recovers from token limit interruptions instead of only emitting warnings, with safeguards to prevent recovery during pending tool operations and a maximum recovery attempt limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->