### PR TITLE
[BEHAVIORAL] Add generation counter to Agent for stale-turn detection

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -854,7 +854,7 @@ func (a *Agent) saveSnapshotIfNeeded() {
 }
 
 // Generation returns the current generation counter, which increments once per
-// completed Turn. It is safe to call concurrently.
+// Turn when the turn goroutine begins executing. It is safe to call concurrently.
 func (a *Agent) Generation() int64 {
 	return a.generation.Load()
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -342,6 +342,7 @@ type Agent struct {
 	checkpointMgr     *checkpoint.Manager
 	userHookRunner    *hooks.UserHookRunner
 	turnNumber        atomic.Int32
+	generation        atomic.Int64
 	rateLimiter       *SharedRateLimiter
 	capabilities      provider.ModelCapabilities
 	progress          *ProgressTracker
@@ -852,6 +853,12 @@ func (a *Agent) saveSnapshotIfNeeded() {
 	}
 }
 
+// Generation returns the current generation counter, which increments once per
+// completed Turn. It is safe to call concurrently.
+func (a *Agent) Generation() int64 {
+	return a.generation.Load()
+}
+
 // Turn initiates a new agent turn with the given user message. It returns a
 // channel of TurnEvent that streams events as the agent processes the turn.
 // Concurrent calls are serialized to prevent DiffTracker race conditions.
@@ -882,6 +889,7 @@ func (a *Agent) Turn(ctx context.Context, userMessage string) (<-chan TurnEvent,
 
 	ch := make(chan TurnEvent, 64)
 	go func() {
+		a.generation.Add(1)
 		defer a.turnMu.Unlock()
 		defer close(ch)
 		defer func() {

--- a/internal/agent/generation_test.go
+++ b/internal/agent/generation_test.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/config"
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgent_GenerationIncrementsPerTurn(t *testing.T) {
+	prov := &dynamicMockProvider{
+		responses: [][]provider.StreamEvent{
+			{
+				{Type: "text_delta", Text: "hi"},
+				{Type: "stop", StopReason: "end_turn", InputTokens: 1, OutputTokens: 1},
+			},
+		},
+	}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	agent := New(prov, reg, autoApprove, cfg)
+
+	genBefore := agent.Generation()
+	ch, err := agent.Turn(context.Background(), "hello")
+	require.NoError(t, err)
+	for range ch {
+	}
+	assert.Equal(t, genBefore+1, agent.Generation(), "generation should increment after Turn")
+}
+
+func TestAgent_GenerationDifferentAcrossTurns(t *testing.T) {
+	prov := &dynamicMockProvider{
+		responses: [][]provider.StreamEvent{
+			{
+				{Type: "text_delta", Text: "first"},
+				{Type: "stop", StopReason: "end_turn", InputTokens: 1, OutputTokens: 1},
+			},
+			{
+				{Type: "text_delta", Text: "second"},
+				{Type: "stop", StopReason: "end_turn", InputTokens: 1, OutputTokens: 1},
+			},
+		},
+	}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	agent := New(prov, reg, autoApprove, cfg)
+
+	ch, err := agent.Turn(context.Background(), "first")
+	require.NoError(t, err)
+	for range ch {
+	}
+	gen1 := agent.Generation()
+
+	ch, err = agent.Turn(context.Background(), "second")
+	require.NoError(t, err)
+	for range ch {
+	}
+	gen2 := agent.Generation()
+
+	assert.Equal(t, gen1+1, gen2, "generation should increment across turns")
+}

--- a/internal/agent/generation_test.go
+++ b/internal/agent/generation_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAgent_GenerationStartsAtZero(t *testing.T) {
+	prov := &dynamicMockProvider{}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	agent := New(prov, reg, autoApprove, cfg)
+	assert.Equal(t, int64(0), agent.Generation(), "generation should start at 0")
+}
+
 func TestAgent_GenerationIncrementsPerTurn(t *testing.T) {
 	prov := &dynamicMockProvider{
 		responses: [][]provider.StreamEvent{


### PR DESCRIPTION
## Summary
- Adds `generation atomic.Int64` field to `Agent` struct, incremented once per `Turn()` invocation
- Exposes `Generation() int64` method for concurrent reads
- Enables callers to detect whether a turn is still current or has been superseded

## Test plan
- `TestAgent_GenerationIncrementsPerTurn` — verifies generation increments after a single turn
- `TestAgent_GenerationDifferentAcrossTurns` — verifies generation increments across two sequential turns
- All existing agent tests pass

Plan: `docs/superpowers/plans/2026-04-27-query-loop-generation-counter.md` (Plan E)