### PR TITLE
[BEHAVIORAL] Add model fallback on overloaded errors with thinking block stripping

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1449,8 +1449,15 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 				fallbackReq := req
 				fallbackReq.Model = a.fallbackModel
 				fallbackReq.Messages = stripThinkingBlocks(req.Messages)
+				fallbackRetryCfg := TurnRetryConfig{}
+				if ns, ok := a.provider.(NonStreamer); ok {
+					fbReq := fallbackReq
+					fallbackRetryCfg.NonStreamFallback = func(ctx context.Context) ([]provider.StreamEvent, error) {
+						return ns.NonStream(ctx, fbReq)
+					}
+				}
 				var fallbackErr error
-				stream, fallbackErr = TurnRetry(ctx, retryCfg, func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+				stream, fallbackErr = TurnRetry(ctx, fallbackRetryCfg, func(ctx context.Context) (<-chan provider.StreamEvent, error) {
 					return a.provider.Stream(ctx, fallbackReq)
 				}, onRetry)
 				if fallbackErr == nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -187,6 +187,10 @@ func WithCapabilities(caps provider.ModelCapabilities) AgentOption {
 	return func(a *Agent) { a.capabilities = caps }
 }
 
+func WithFallbackModel(model string) AgentOption {
+	return func(a *Agent) { a.fallbackModel = model }
+}
+
 // WorkingDir returns the agent's effective working directory.
 // The value is frozen at construction time and never changes.
 func (a *Agent) WorkingDir() string {
@@ -343,6 +347,7 @@ type Agent struct {
 	userHookRunner    *hooks.UserHookRunner
 	turnNumber        atomic.Int32
 	generation        atomic.Int64
+	fallbackModel     string
 	rateLimiter       *SharedRateLimiter
 	capabilities      provider.ModelCapabilities
 	progress          *ProgressTracker
@@ -1438,11 +1443,31 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 				return
 			}
 
+			if class == errorclass.ClassModelOverloaded && a.fallbackModel != "" {
+				a.logger.Warn("primary model overloaded; retrying with fallback model %s", a.fallbackModel)
+				a.emit(ctx, ch, TurnEvent{Type: "model_fallback", Model: a.fallbackModel})
+				fallbackReq := req
+				fallbackReq.Model = a.fallbackModel
+				fallbackReq.Messages = stripThinkingBlocks(req.Messages)
+				var fallbackErr error
+				stream, fallbackErr = TurnRetry(ctx, retryCfg, func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+					return a.provider.Stream(ctx, fallbackReq)
+				}, onRetry)
+				if fallbackErr == nil {
+					goto processStream
+				}
+				a.logger.Warn("fallback model also failed: %v", fallbackErr)
+				a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream (fallback): %w", fallbackErr)})
+				a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError))
+				return
+			}
+
 			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream: %w", err)})
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError))
 			return
 		}
 
+	processStream:
 		// Accumulate assistant content blocks and track tool calls
 		var blocks []provider.ContentBlock
 		var pendingTools []provider.ToolUseBlock

--- a/internal/agent/fallback.go
+++ b/internal/agent/fallback.go
@@ -1,0 +1,22 @@
+package agent
+
+import "github.com/julianshen/rubichan/pkg/agentsdk"
+
+func stripThinkingBlocks(messages []agentsdk.Message) []agentsdk.Message {
+	result := make([]agentsdk.Message, 0, len(messages))
+	for _, msg := range messages {
+		var filtered []agentsdk.ContentBlock
+		for _, block := range msg.Content {
+			if block.Type != "thinking" && block.Type != "redacted_thinking" {
+				filtered = append(filtered, block)
+			}
+		}
+		if len(filtered) == 0 && len(msg.Content) > 0 {
+			continue
+		}
+		stripped := msg
+		stripped.Content = filtered
+		result = append(result, stripped)
+	}
+	return result
+}

--- a/internal/agent/fallback_test.go
+++ b/internal/agent/fallback_test.go
@@ -1,11 +1,36 @@
 package agent
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 
+	"github.com/julianshen/rubichan/internal/config"
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/tools"
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type overloadedThenSuccessProvider struct {
+	failCount atomic.Int32
+}
+
+func (p *overloadedThenSuccessProvider) Stream(_ context.Context, _ provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
+	if p.failCount.Add(1) <= 3 {
+		return nil, &provider.ProviderError{
+			Kind:      provider.ErrServerError,
+			Message:   "overloaded: server capacity reached",
+			Retryable: true,
+		}
+	}
+	ch := make(chan provider.StreamEvent, 2)
+	ch <- provider.StreamEvent{Type: "text_delta", Text: "fallback response"}
+	ch <- provider.StreamEvent{Type: "stop", StopReason: "end_turn", InputTokens: 1, OutputTokens: 1}
+	close(ch)
+	return ch, nil
+}
 
 func TestStripThinkingBlocks(t *testing.T) {
 	msgs := []agentsdk.Message{
@@ -50,4 +75,51 @@ func TestStripThinkingBlocks_PreservesNonThinkingMessages(t *testing.T) {
 	assert.Equal(t, 2, len(stripped))
 	assert.Equal(t, 1, len(stripped[0].Content))
 	assert.Equal(t, 1, len(stripped[1].Content))
+}
+
+func TestRunLoop_ModelOverloaded_FallsBack(t *testing.T) {
+	prov := &overloadedThenSuccessProvider{}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	agent := New(prov, reg, autoApprove, cfg, WithFallbackModel("claude-haiku-4"))
+
+	ch, err := agent.Turn(context.Background(), "hello")
+	require.NoError(t, err)
+
+	var output string
+	var exitReason agentsdk.TurnExitReason
+	var sawFallbackEvent bool
+	for evt := range ch {
+		if evt.Type == "text_delta" {
+			output += evt.Text
+		}
+		if evt.Type == "model_fallback" {
+			sawFallbackEvent = true
+			assert.Equal(t, "claude-haiku-4", evt.Model)
+		}
+		if evt.Type == "done" {
+			exitReason = evt.ExitReason
+		}
+	}
+	assert.True(t, sawFallbackEvent, "should emit model_fallback event")
+	assert.Contains(t, output, "fallback response")
+	assert.Equal(t, agentsdk.ExitCompleted, exitReason)
+}
+
+func TestRunLoop_ModelOverloaded_NoFallbackConfigured(t *testing.T) {
+	prov := &overloadedThenSuccessProvider{}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	agent := New(prov, reg, autoApprove, cfg)
+
+	ch, err := agent.Turn(context.Background(), "hello")
+	require.NoError(t, err)
+
+	var exitReason agentsdk.TurnExitReason
+	for evt := range ch {
+		if evt.Type == "done" {
+			exitReason = evt.ExitReason
+		}
+	}
+	assert.Equal(t, agentsdk.ExitProviderError, exitReason, "without fallback, should exit with provider error")
 }

--- a/internal/agent/fallback_test.go
+++ b/internal/agent/fallback_test.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripThinkingBlocks(t *testing.T) {
+	msgs := []agentsdk.Message{
+		{Role: "user", Content: []agentsdk.ContentBlock{
+			{Type: "text", Text: "hello"},
+		}},
+		{Role: "assistant", Content: []agentsdk.ContentBlock{
+			{Type: "thinking", Text: "let me think"},
+			{Type: "text", Text: "answer"},
+		}},
+		{Role: "assistant", Content: []agentsdk.ContentBlock{
+			{Type: "redacted_thinking"},
+			{Type: "text", Text: "more"},
+		}},
+	}
+	stripped := stripThinkingBlocks(msgs)
+	assert.Equal(t, 3, len(stripped), "should preserve non-thinking messages")
+	assert.Equal(t, 1, len(stripped[1].Content), "assistant msg should have thinking removed")
+	assert.Equal(t, "text", stripped[1].Content[0].Type)
+}
+
+func TestStripThinkingBlocks_RemovesAllThinking(t *testing.T) {
+	msgs := []agentsdk.Message{
+		{Role: "assistant", Content: []agentsdk.ContentBlock{
+			{Type: "thinking", Text: "deep thought"},
+		}},
+	}
+	stripped := stripThinkingBlocks(msgs)
+	assert.Equal(t, 0, len(stripped), "message with only thinking should be removed")
+}
+
+func TestStripThinkingBlocks_PreservesNonThinkingMessages(t *testing.T) {
+	msgs := []agentsdk.Message{
+		{Role: "user", Content: []agentsdk.ContentBlock{
+			{Type: "text", Text: "hello"},
+		}},
+		{Role: "assistant", Content: []agentsdk.ContentBlock{
+			{Type: "text", Text: "response"},
+		}},
+	}
+	stripped := stripThinkingBlocks(msgs)
+	assert.Equal(t, 2, len(stripped))
+	assert.Equal(t, 1, len(stripped[0].Content))
+	assert.Equal(t, 1, len(stripped[1].Content))
+}


### PR DESCRIPTION
## Summary
- `stripThinkingBlocks()` removes `thinking` and `redacted_thinking` content blocks from messages to reduce context before fallback
- `WithFallbackModel(model)` option configures a fallback model on the Agent
- When the primary model returns an overloaded error (after TurnRetry exhausts), the runLoop retries with the fallback model using stripped messages
- Emits `model_fallback` event with the fallback model name

## Test plan
- `TestStripThinkingBlocks` — verifies thinking blocks are stripped, non-thinking preserved
- `TestStripThinkingBlocks_RemovesAllThinking` — verifies messages with only thinking are dropped
- `TestStripThinkingBlocks_PreservesNonThinkingMessages` — verifies non-thinking messages are unchanged
- `TestRunLoop_ModelOverloaded_FallsBack` — integration test: overloaded primary falls back to configured model
- `TestRunLoop_ModelOverloaded_NoFallbackConfigured` — verifies provider error exit when no fallback configured
- All existing agent tests pass

Plan: `docs/superpowers/plans/2026-04-27-query-loop-model-fallback.md` (Plan F)