### PR TITLE
[BEHAVIORAL] Add jitter to retry backoff in TurnRetry and DoWithRetry

### DIFF
--- a/internal/agent/turnretry.go
+++ b/internal/agent/turnretry.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"time"
 
 	"github.com/julianshen/rubichan/internal/provider"
@@ -93,13 +94,14 @@ func TurnRetry(ctx context.Context, cfg TurnRetryConfig, fn StreamFunc, onRetry 
 
 	for attempt := 1; attempt <= cfg.maxAttempts(); attempt++ {
 		if attempt > 1 {
+			jittered := addJitter(delay)
 			if onRetry != nil {
-				onRetry(attempt, delay, lastErr)
+				onRetry(attempt, jittered, lastErr)
 			}
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
-			case <-time.After(delay):
+			case <-time.After(jittered):
 			}
 			delay *= 2
 			if delay > cfg.maxDelay() {
@@ -155,4 +157,9 @@ func isRetryableProviderError(err error) bool {
 		return pe.IsRetryable()
 	}
 	return false
+}
+
+func addJitter(d time.Duration) time.Duration {
+	jitter := time.Duration(rand.Float64() * 0.25 * float64(d))
+	return d + jitter
 }

--- a/internal/agent/turnretry_test.go
+++ b/internal/agent/turnretry_test.go
@@ -221,6 +221,82 @@ func TestTurnRetry_NonStreamFallbackError(t *testing.T) {
 
 // Without a NonStreamFallback, TurnRetry must preserve its original
 // behavior: return the last stream error after exhausting attempts.
+func TestTurnRetry_JitterProducesVariableDelays(t *testing.T) {
+	var delays []time.Duration
+	cfg := TurnRetryConfig{
+		MaxAttempts: 5,
+		BaseDelay:   50 * time.Millisecond,
+		MaxDelay:    500 * time.Millisecond,
+	}
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		return nil, &provider.ProviderError{Kind: provider.ErrRateLimited, Message: "429"}
+	}
+	onRetry := func(attempt int, delay time.Duration, cause error) {
+		delays = append(delays, delay)
+	}
+
+	_, _ = TurnRetry(context.Background(), cfg, fn, onRetry)
+	require.Len(t, delays, 4, "should have 4 retry callbacks for 5 attempts")
+
+	allSame := true
+	for i := 1; i < len(delays); i++ {
+		if delays[i] != delays[0] {
+			allSame = false
+			break
+		}
+	}
+	assert.False(t, allSame, "jitter should produce different delays across retries, got %v", delays)
+
+	for _, d := range delays {
+		assert.Greater(t, d, time.Duration(0), "delay must be positive")
+	}
+}
+
+func TestTurnRetry_JitterAppliedToBaseDelay(t *testing.T) {
+	base := 100 * time.Millisecond
+	var firstDelay time.Duration
+	cfg := TurnRetryConfig{
+		MaxAttempts: 2,
+		BaseDelay:   base,
+		MaxDelay:    10 * time.Second,
+	}
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		return nil, &provider.ProviderError{Kind: provider.ErrRateLimited, Message: "429"}
+	}
+	onRetry := func(attempt int, delay time.Duration, cause error) {
+		if attempt == 2 {
+			firstDelay = delay
+		}
+	}
+
+	_, _ = TurnRetry(context.Background(), cfg, fn, onRetry)
+	assert.Greater(t, firstDelay, time.Duration(0))
+	assert.LessOrEqual(t, firstDelay, base+base/4, "first retry delay should be base + up to 25%% jitter, got %v", firstDelay)
+}
+
+func TestTurnRetry_JitterStaysWithinBounds(t *testing.T) {
+	base := 100 * time.Millisecond
+	maxD := 2 * time.Second
+	var delays []time.Duration
+	cfg := TurnRetryConfig{
+		MaxAttempts: 8,
+		BaseDelay:   base,
+		MaxDelay:    maxD,
+	}
+	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		return nil, &provider.ProviderError{Kind: provider.ErrRateLimited, Message: "429"}
+	}
+	onRetry := func(attempt int, delay time.Duration, cause error) {
+		delays = append(delays, delay)
+	}
+
+	_, _ = TurnRetry(context.Background(), cfg, fn, onRetry)
+	for _, d := range delays {
+		assert.Greater(t, d, time.Duration(0))
+		assert.LessOrEqual(t, d, maxD+maxD/4, "delay with jitter should not exceed maxDelay + 25%%")
+	}
+}
+
 func TestTurnRetry_NoFallbackConfigured(t *testing.T) {
 	attempts := 0
 	fn := func(ctx context.Context) (<-chan provider.StreamEvent, error) {

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"net/http"
 	"strconv"
@@ -113,7 +114,8 @@ func retryDelay(attempt int) time.Duration {
 			return retryMaxDelay
 		}
 	}
-	return delay
+	jitter := time.Duration(rand.Float64() * 0.25 * float64(delay))
+	return delay + jitter
 }
 
 func parseRetryAfter(v string) (time.Duration, bool) {

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -199,6 +199,32 @@ func TestDoWithRetry_SkipsRetryOnContextOverflow(t *testing.T) {
 	assert.EqualValues(t, 1, calls.Load(), "should not retry context overflow")
 }
 
+func TestRetryDelay_UsesJitter(t *testing.T) {
+	oldBase, oldMax := retryBaseDelay, retryMaxDelay
+	retryBaseDelay, retryMaxDelay = 100*time.Millisecond, 10*time.Second
+	t.Cleanup(func() {
+		retryBaseDelay, retryMaxDelay = oldBase, oldMax
+	})
+
+	var delays []time.Duration
+	for i := 0; i < 20; i++ {
+		delays = append(delays, retryDelay(1))
+	}
+	allSame := true
+	for i := 1; i < len(delays); i++ {
+		if delays[i] != delays[0] {
+			allSame = false
+			break
+		}
+	}
+	assert.False(t, allSame, "jitter should produce different delays across calls, got %v", delays)
+
+	for _, d := range delays {
+		assert.Greater(t, d, time.Duration(0))
+		assert.LessOrEqual(t, d, retryBaseDelay+retryBaseDelay/4, "delay should be base + up to 25%% jitter")
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Summary
- Adds 0-25% random jitter to exponential backoff in both `TurnRetry` and `DoWithRetry`
- Prevents thundering herd when multiple instances retry in lockstep

## Test plan
- `TestRetryDelay_UsesJitter` — verifies jitter produces non-deterministic delays
- `TestTurnRetry_JitterProducesVariableDelays` — verifies variable delays across retries
- `TestTurnRetry_JitterAppliedToBaseDelay` — verifies delay stays within base + 25%
- `TestTurnRetry_JitterStaysWithinBounds` — verifies delays don't exceed maxDelay + 25%
- All existing retry tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved retry resilience by adding randomized jitter (up to 25%) to backoff delays across retry mechanisms, reducing synchronized retries and enhancing system stability during recovery from transient failures.

* **Tests**
  * Added comprehensive unit tests to validate jitter implementation, confirming that delays vary appropriately across consecutive retries and remain within expected bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->