### PR TITLE
[BEHAVIORAL] Add diminishing returns detection to loopState

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1750,6 +1750,14 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			}
 		}
 
+		if ls.checkDiminishingReturns(totalOutputTokens) {
+			a.logger.Warn("diminishing returns: %d consecutive turns with < %d output tokens", ls.continuationCount, diminishingThreshold)
+			a.executeTools(ctx, ch, pendingTools, streamedResults)
+			a.emit(ctx, ch, TurnEvent{Type: "diminishing_returns"})
+			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitDiminishingReturns))
+			return
+		}
+
 		signature := pendingToolSignature(pendingTools)
 		if ls.recordToolSignature(signature, hasTextContent(blocks)) {
 			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("detected no progress after %d repeated tool-only rounds", ls.repeatedToolRounds)})

--- a/internal/agent/loopstate.go
+++ b/internal/agent/loopstate.go
@@ -9,6 +9,11 @@ const maxPromptTooLongRetries = 3
 // hits the output token limit on every attempt.
 const maxOutputTokensRecoveryLimit = 3
 
+// diminishingThreshold is the output-token delta below which a turn is
+// considered to have made negligible progress. When 3+ consecutive turns
+// stay below this threshold the loop exits with ExitDiminishingReturns.
+const diminishingThreshold = 500
+
 type loopState struct {
 	maxTurns                  int
 	turnCount                 int
@@ -17,6 +22,9 @@ type loopState struct {
 	streamErr                 bool
 	promptTooLongAttempts     int
 	maxTokensRecoveryAttempts int
+	continuationCount         int
+	lastDeltaTokens           int
+	lastGlobalOutputTokens    int
 }
 
 func newLoopState(maxTurns, turnCount int) *loopState {
@@ -28,7 +36,8 @@ func (s *loopState) hasMoreTurns() bool {
 }
 
 // resetPerTurn clears per-iteration state. Cross-turn fields
-// (repeatedToolRounds, lastToolSignature, maxTokensRecoveryAttempts)
+// (repeatedToolRounds, lastToolSignature, maxTokensRecoveryAttempts,
+// continuationCount, lastDeltaTokens, lastGlobalOutputTokens)
 // are intentionally preserved across sub-turns within a single Turn().
 func (s *loopState) resetPerTurn() {
 	s.streamErr = false
@@ -44,4 +53,19 @@ func (s *loopState) recordToolSignature(sig string, hasText bool) bool {
 		s.repeatedToolRounds = 1
 	}
 	return s.repeatedToolRounds >= maxRepeatedPendingToolRounds
+}
+
+func (s *loopState) checkDiminishingReturns(currentOutputTokens int) bool {
+	delta := currentOutputTokens - s.lastGlobalOutputTokens
+	isDiminishing := s.continuationCount >= 3 &&
+		delta < diminishingThreshold &&
+		s.lastDeltaTokens < diminishingThreshold
+	s.lastDeltaTokens = delta
+	s.lastGlobalOutputTokens = currentOutputTokens
+	if delta >= diminishingThreshold {
+		s.continuationCount = 0
+	} else {
+		s.continuationCount++
+	}
+	return isDiminishing
 }

--- a/internal/agent/loopstate_test.go
+++ b/internal/agent/loopstate_test.go
@@ -60,3 +60,35 @@ func TestLoopState_RecordToolSignature_ResetsOnTextContent(t *testing.T) {
 	ls.recordToolSignature("read_file", false)
 	assert.False(t, ls.recordToolSignature("read_file", true), "text content resets counter")
 }
+
+func TestLoopState_CheckDiminishingReturns_BelowThreshold(t *testing.T) {
+	ls := newLoopState(50, 0)
+
+	assert.False(t, ls.checkDiminishingReturns(100), "turn 1: not enough continuations")
+	assert.False(t, ls.checkDiminishingReturns(200), "turn 2: not enough continuations")
+	assert.False(t, ls.checkDiminishingReturns(250), "turn 3: delta=50 < threshold but need one more check")
+	assert.True(t, ls.checkDiminishingReturns(300), "turn 4: delta=50 AND lastDelta=50, both < threshold")
+}
+
+func TestLoopState_CheckDiminishingReturns_AboveThreshold(t *testing.T) {
+	ls := newLoopState(50, 0)
+
+	assert.False(t, ls.checkDiminishingReturns(100))
+	assert.False(t, ls.checkDiminishingReturns(800))
+	assert.False(t, ls.checkDiminishingReturns(1500))
+	assert.False(t, ls.checkDiminishingReturns(2500))
+	assert.False(t, ls.checkDiminishingReturns(3500))
+}
+
+func TestLoopState_CheckDiminishingReturns_ResetsOnSpike(t *testing.T) {
+	ls := newLoopState(50, 0)
+
+	assert.False(t, ls.checkDiminishingReturns(100))
+	assert.False(t, ls.checkDiminishingReturns(200))
+	assert.False(t, ls.checkDiminishingReturns(250))
+
+	assert.False(t, ls.checkDiminishingReturns(2000), "big spike resets the pattern")
+	assert.False(t, ls.checkDiminishingReturns(2050))
+	assert.False(t, ls.checkDiminishingReturns(2100))
+	assert.False(t, ls.checkDiminishingReturns(2150))
+}

--- a/pkg/agentsdk/exit_reason.go
+++ b/pkg/agentsdk/exit_reason.go
@@ -54,6 +54,10 @@ const (
 
 	// ExitPanic: a panic was recovered in Turn's deferred handler.
 	ExitPanic
+
+	// ExitDiminishingReturns: output tokens per turn fell below the
+	// diminishing-returns threshold for multiple consecutive turns.
+	ExitDiminishingReturns
 )
 
 // String returns a stable lowercase identifier usable in logs and tests.
@@ -83,6 +87,8 @@ func (r TurnExitReason) String() string {
 		return "context_overflow"
 	case ExitPanic:
 		return "panic"
+	case ExitDiminishingReturns:
+		return "diminishing_returns"
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
## Summary
- Adds `checkDiminishingReturns()` to `loopState` tracking output token delta per turn
- When 3+ consecutive turns produce <500 output tokens each, exits with `ExitDiminishingReturns`
- Resets on spike (delta ≥ 500 tokens) to avoid false positives after recovery
- Adds `diminishing_returns` event type for UI notification

## Test plan
- `TestLoopState_CheckDiminishingReturns_BelowThreshold` — triggers after 4 low-delta turns
- `TestLoopState_CheckDiminishingReturns_AboveThreshold` — never triggers with high deltas
- `TestLoopState_CheckDiminishingReturns_ResetsOnSpike` — spike resets continuation counter
- All existing agent tests pass