### PR TITLE
[BEHAVIORAL] Add budget nudge messages when context usage is 70-95%

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1787,6 +1787,10 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// Drain any pending wake events from background subagents.
 		a.drainWakeEvents(ctx, ch)
 
+		if nudge := a.context.BudgetNudge(a.conversation); nudge != "" {
+			a.conversation.AddUser(nudge)
+		}
+
 		// Continue to the next turn after tool results.
 	}
 

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -251,6 +251,23 @@ func (cm *ContextManager) ExceedsBudget(conv *Conversation) bool {
 	return cm.EstimateTokens(conv) > cm.budget.EffectiveWindow()
 }
 
+// BudgetNudge returns a budget awareness message if context usage is
+// between 70% and the compact trigger threshold. Returns empty string
+// when no nudge is needed (below 70% or already compacting).
+func (cm *ContextManager) BudgetNudge(conv *Conversation) string {
+	used := cm.EstimateTokens(conv)
+	window := cm.budget.EffectiveWindow()
+	if window <= 0 {
+		return ""
+	}
+	pct := float64(used) / float64(window)
+	if pct < 0.70 || pct >= cm.compactTrigger {
+		return ""
+	}
+	return fmt.Sprintf("Context usage: %d%% (%d/%d tokens). You have budget remaining — keep working but be mindful of context length.",
+		int(pct*100), used, window)
+}
+
 // Truncate removes the oldest messages until the conversation is within budget.
 // Deprecated: use Compact() which runs the full strategy chain.
 func (cm *ContextManager) Truncate(conv *Conversation) {

--- a/internal/agent/context_test.go
+++ b/internal/agent/context_test.go
@@ -339,6 +339,33 @@ func TestVerdictContextBlockMultipleTools(t *testing.T) {
 	assert.Contains(t, result, "100%")    // file success rate
 }
 
+func TestContextManager_BudgetNudge_BelowThreshold(t *testing.T) {
+	cm := NewContextManager(100000, 0)
+	conv := NewConversation("system prompt")
+	assert.Empty(t, cm.BudgetNudge(conv), "should not nudge when usage is low")
+}
+
+func TestContextManager_BudgetNudge_InRange(t *testing.T) {
+	cm := NewContextManager(100, 0)
+	conv := NewConversation("short")
+	for i := 0; i < 4; i++ {
+		conv.AddUser(strings.Repeat("x", 20))
+	}
+	nudge := cm.BudgetNudge(conv)
+	assert.NotEmpty(t, nudge, "should nudge when usage is 70-95%%")
+	assert.Contains(t, nudge, "Context usage:")
+}
+
+func TestContextManager_BudgetNudge_AboveCompactTrigger(t *testing.T) {
+	cm := NewContextManager(100, 0)
+	conv := NewConversation("short")
+	for i := 0; i < 30; i++ {
+		conv.AddUser(strings.Repeat("x", 20))
+	}
+	nudge := cm.BudgetNudge(conv)
+	assert.Empty(t, nudge, "should not nudge when usage is above compact trigger (compact handles it)")
+}
+
 func TestVerdictContextBlockAllFailures(t *testing.T) {
 	hist := session.NewVerdictHistory()
 	hist.Record(session.Verdict{


### PR DESCRIPTION
## Summary
- Adds `BudgetNudge()` to `ContextManager` — returns a budget awareness message when context usage is 70-95%
- Injects nudge as a user message in the runLoop after tool execution on tool-use turns
- Model self-regulates by knowing how much context budget remains before compaction triggers

## Test plan
- `TestContextManager_BudgetNudge_BelowThreshold` — no nudge when usage < 70%
- `TestContextManager_BudgetNudge_InRange` — nudge with percentage when 70-95%
- `TestContextManager_BudgetNudge_AboveCompactTrigger` — no nudge when ≥ 95% (compact handles it)
- All existing agent tests pass