### PR TITLE
[STRUCTURAL] Add ContinueReason enum for loop observability

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1436,6 +1436,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 					a.emit(ctx, ch, TurnEvent{Type: "context_overflow"})
 					a.saveSnapshotIfNeeded()
 					ls.turnCount--
+					ls.lastContinueReason = ContinuePromptTooLongRetry
 					continue
 				}
 				a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream: %w", err)})
@@ -1461,6 +1462,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 					return a.provider.Stream(ctx, fallbackReq)
 				}, onRetry)
 				if fallbackErr == nil {
+					ls.lastContinueReason = ContinueModelFallback
 					goto processStream
 				}
 				a.logger.Warn("fallback model also failed: %v", fallbackErr)
@@ -1626,6 +1628,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 				a.emit(ctx, ch, TurnEvent{Type: "max_tokens_recovery"})
 				a.saveSnapshotIfNeeded()
 				ls.turnCount--
+				ls.lastContinueReason = ContinueMaxTokensRecovery
 				continue
 			} else {
 				a.logger.Warn("response truncated by output token limit after %d recovery attempts", ls.maxTokensRecoveryAttempts)
@@ -1792,6 +1795,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		}
 
 		// Continue to the next turn after tool results.
+		ls.lastContinueReason = ContinueNextTurn
 	}
 
 	// Reached max turns.

--- a/internal/agent/loopstate.go
+++ b/internal/agent/loopstate.go
@@ -14,6 +14,31 @@ const maxOutputTokensRecoveryLimit = 3
 // stay below this threshold the loop exits with ExitDiminishingReturns.
 const diminishingThreshold = 500
 
+type ContinueReason int
+
+const (
+	ContinueUnknown            ContinueReason = iota
+	ContinueNextTurn                          // normal tool-use continuation
+	ContinuePromptTooLongRetry                // reactive compact recovered context
+	ContinueMaxTokensRecovery                 // max_tokens continuation prompt
+	ContinueModelFallback                     // fell back to alternate model
+)
+
+func (r ContinueReason) String() string {
+	switch r {
+	case ContinueNextTurn:
+		return "next_turn"
+	case ContinuePromptTooLongRetry:
+		return "prompt_too_long_retry"
+	case ContinueMaxTokensRecovery:
+		return "max_tokens_recovery"
+	case ContinueModelFallback:
+		return "model_fallback"
+	default:
+		return "unknown"
+	}
+}
+
 type loopState struct {
 	maxTurns                  int
 	turnCount                 int
@@ -25,6 +50,7 @@ type loopState struct {
 	continuationCount         int
 	lastDeltaTokens           int
 	lastGlobalOutputTokens    int
+	lastContinueReason        ContinueReason
 }
 
 func newLoopState(maxTurns, turnCount int) *loopState {

--- a/internal/agent/loopstate_test.go
+++ b/internal/agent/loopstate_test.go
@@ -92,3 +92,20 @@ func TestLoopState_CheckDiminishingReturns_ResetsOnSpike(t *testing.T) {
 	assert.False(t, ls.checkDiminishingReturns(2100))
 	assert.False(t, ls.checkDiminishingReturns(2150))
 }
+
+func TestContinueReason_String(t *testing.T) {
+	tests := []struct {
+		reason ContinueReason
+		want   string
+	}{
+		{ContinueNextTurn, "next_turn"},
+		{ContinuePromptTooLongRetry, "prompt_too_long_retry"},
+		{ContinueMaxTokensRecovery, "max_tokens_recovery"},
+		{ContinueModelFallback, "model_fallback"},
+		{ContinueUnknown, "unknown"},
+		{ContinueReason(99), "unknown"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, tt.reason.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `ContinueReason` enum: `next_turn`, `prompt_too_long_retry`, `max_tokens_recovery`, `model_fallback`
- Sets reason at each `continue`/`goto` point in runLoop
- Stored in `loopState.lastContinueReason` for logging and diagnostics

## Test plan
- `TestContinueReason_String` — verifies all reason strings
- All existing agent tests pass