### PR TITLE
[BEHAVIORAL] Add max_output_tokens slot reservation: 8k default, 64k escalation

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -308,53 +308,54 @@ func WithACP() AgentOption {
 
 // Agent orchestrates the conversation loop between the user, LLM, and tools.
 type Agent struct {
-	provider          provider.LLMProvider
-	tools             *tools.Registry
-	conversation      *Conversation
-	context           *ContextManager
-	approve           ApprovalFunc
-	approvalChecker   ApprovalChecker
-	uiRequestHandler  UIRequestHandler
-	model             string
-	maxTurns          int
-	basePrompt        string
-	staticPrompts     []PromptSection
-	skillRuntime      *skills.Runtime
-	store             *store.Store
-	sessionID         string
-	resumeSessionID   string
-	agentMD           string
-	identityMD        string
-	soulMD            string
-	extraPrompts      []namedPrompt
-	summarizer        Summarizer
-	scratchpad        *Scratchpad
-	memoryStore       MemoryStore
-	knowledgeSelector kg.ContextSelector
-	customStrategies  bool
-	resultStore       *ResultStore
-	promptBuilder     *PromptBuilder
-	deferral          *tools.DeferralManager
-	diffTracker       *tools.DiffTracker
-	turnMu            sync.Mutex // serializes Turn() calls to prevent DiffTracker race
-	wakeManager       *WakeManager
-	pipeline          *toolexec.Pipeline
-	workingDir        string // override working directory (empty = os.Getwd)
-	parallelPolicy    ToolParallelPolicy
-	logger            Logger
-	mode              string
-	checkpointMgr     *checkpoint.Manager
-	userHookRunner    *hooks.UserHookRunner
-	turnNumber        atomic.Int32
-	generation        atomic.Int64
-	fallbackModel     string
-	rateLimiter       *SharedRateLimiter
-	capabilities      provider.ModelCapabilities
-	progress          *ProgressTracker
-	acpServer         *acp.Server             // ACP server instance (if enabled)
-	acpRegistry       *acp.CapabilityRegistry // Capability registry for ACP
-	useACP            bool                    // Enable ACP server
-	latches           *sessionLatches         // one-way ratchets for session-stable capability values
+	provider            provider.LLMProvider
+	tools               *tools.Registry
+	conversation        *Conversation
+	context             *ContextManager
+	approve             ApprovalFunc
+	approvalChecker     ApprovalChecker
+	uiRequestHandler    UIRequestHandler
+	model               string
+	maxTurns            int
+	basePrompt          string
+	staticPrompts       []PromptSection
+	skillRuntime        *skills.Runtime
+	store               *store.Store
+	sessionID           string
+	resumeSessionID     string
+	agentMD             string
+	identityMD          string
+	soulMD              string
+	extraPrompts        []namedPrompt
+	summarizer          Summarizer
+	scratchpad          *Scratchpad
+	memoryStore         MemoryStore
+	knowledgeSelector   kg.ContextSelector
+	customStrategies    bool
+	resultStore         *ResultStore
+	promptBuilder       *PromptBuilder
+	deferral            *tools.DeferralManager
+	diffTracker         *tools.DiffTracker
+	turnMu              sync.Mutex // serializes Turn() calls to prevent DiffTracker race
+	wakeManager         *WakeManager
+	pipeline            *toolexec.Pipeline
+	workingDir          string // override working directory (empty = os.Getwd)
+	parallelPolicy      ToolParallelPolicy
+	logger              Logger
+	mode                string
+	checkpointMgr       *checkpoint.Manager
+	userHookRunner      *hooks.UserHookRunner
+	turnNumber          atomic.Int32
+	generation          atomic.Int64
+	fallbackModel       string
+	rateLimiter         *SharedRateLimiter
+	capabilities        provider.ModelCapabilities
+	configuredMaxTokens int
+	progress            *ProgressTracker
+	acpServer           *acp.Server             // ACP server instance (if enabled)
+	acpRegistry         *acp.CapabilityRegistry // Capability registry for ACP
+	useACP              bool                    // Enable ACP server
+	latches             *sessionLatches         // one-way ratchets for session-stable capability values
 }
 
 const maxUIRequestInputBytes = 2048
@@ -365,18 +366,19 @@ const maxUIRequestInputBytes = 2048
 func New(p provider.LLMProvider, t *tools.Registry, approve ApprovalFunc, cfg *config.Config, opts ...AgentOption) *Agent {
 	systemPrompt := buildSystemPrompt(cfg)
 	a := &Agent{
-		provider:     p,
-		tools:        t,
-		basePrompt:   systemPrompt,
-		conversation: NewConversation(systemPrompt),
-		context:      newContextManagerFromConfig(cfg),
-		approve:      approve,
-		model:        cfg.Provider.Model,
-		maxTurns:     cfg.Agent.MaxTurns,
-		scratchpad:   NewScratchpad(),
-		progress:     NewProgressTracker(),
-		capabilities: agentsdk.DefaultCapabilities(),
-		latches:      newSessionLatches(),
+		provider:            p,
+		tools:               t,
+		basePrompt:          systemPrompt,
+		conversation:        NewConversation(systemPrompt),
+		context:             newContextManagerFromConfig(cfg),
+		approve:             approve,
+		model:               cfg.Provider.Model,
+		maxTurns:            cfg.Agent.MaxTurns,
+		configuredMaxTokens: cfg.Agent.MaxOutputTokens,
+		scratchpad:          NewScratchpad(),
+		progress:            NewProgressTracker(),
+		capabilities:        agentsdk.DefaultCapabilities(),
+		latches:             newSessionLatches(),
 	}
 	for _, opt := range opts {
 		opt(a)
@@ -844,6 +846,16 @@ func (a *Agent) persistMessage(role string, content []provider.ContentBlock) {
 	if err := a.store.AppendMessage(a.sessionID, role, content); err != nil {
 		a.logger.Warn("failed to persist message: %v", err)
 	}
+}
+
+func (a *Agent) effectiveMaxTokens(ls *loopState) int {
+	if ls.tokensEscalated {
+		return escalatedMaxOutputTokens
+	}
+	if a.configuredMaxTokens > 0 {
+		return a.configuredMaxTokens
+	}
+	return defaultMaxOutputTokens
 }
 
 // saveSnapshotIfNeeded persists the current conversation state as a
@@ -1382,7 +1394,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			System:           systemPrompt,
 			Messages:         normalizeMessages(a.conversation.Messages()),
 			Tools:            reqTools,
-			MaxTokens:        4096,
+			MaxTokens:        a.effectiveMaxTokens(ls),
 			CacheBreakpoints: cacheBreakpoints,
 		}
 		// Latch ReasoningEffort so a mid-session capability change cannot
@@ -1621,6 +1633,14 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			hasPendingTools := len(pendingTools) > 0 || currentTool != nil
 			if hasPendingTools {
 				a.logger.Warn("response hit output token limit with %d pending tool calls; tool arguments may be truncated", len(pendingTools))
+			} else if !ls.tokensEscalated {
+				prevMax := a.effectiveMaxTokens(ls)
+				ls.tokensEscalated = true
+				a.logger.Warn("output token limit hit; escalating max_tokens from %d to %d", prevMax, escalatedMaxOutputTokens)
+				a.emit(ctx, ch, TurnEvent{Type: "max_tokens_escalation"})
+				ls.turnCount--
+				ls.lastContinueReason = ContinueMaxTokensRecovery
+				continue
 			} else if ls.maxTokensRecoveryAttempts < maxOutputTokensRecoveryLimit {
 				ls.maxTokensRecoveryAttempts++
 				a.conversation.AddAssistant(blocks)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -848,14 +848,8 @@ func (a *Agent) persistMessage(role string, content []provider.ContentBlock) {
 	}
 }
 
-func (a *Agent) effectiveMaxTokens(ls *loopState) int {
-	if ls.tokensEscalated {
-		return escalatedMaxOutputTokens
-	}
-	if a.configuredMaxTokens > 0 {
-		return a.configuredMaxTokens
-	}
-	return defaultMaxOutputTokens
+func (a *Agent) escalateMaxTokens(ls *loopState) {
+	ls.maxOutputTokens = escalatedMaxOutputTokens
 }
 
 // saveSnapshotIfNeeded persists the current conversation state as a
@@ -1312,7 +1306,7 @@ func replaceAssistantText(blocks []provider.ContentBlock, newText string) []prov
 // runLoop iteratively processes LLM responses and tool calls.
 func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int, lastUserMessage string) {
 	var totalInputTokens, totalOutputTokens int
-	ls := newLoopState(a.maxTurns, turnCount)
+	ls := newLoopState(a.maxTurns, turnCount, a.configuredMaxTokens)
 	if a.skillRuntime != nil {
 		triggerCtx := a.buildSkillTriggerContext(lastUserMessage)
 		if err := a.skillRuntime.EvaluateAndActivate(triggerCtx); err != nil {
@@ -1394,7 +1388,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			System:           systemPrompt,
 			Messages:         normalizeMessages(a.conversation.Messages()),
 			Tools:            reqTools,
-			MaxTokens:        a.effectiveMaxTokens(ls),
+			MaxTokens:        ls.maxOutputTokens,
 			CacheBreakpoints: cacheBreakpoints,
 		}
 		// Latch ReasoningEffort so a mid-session capability change cannot
@@ -1633,10 +1627,9 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			hasPendingTools := len(pendingTools) > 0 || currentTool != nil
 			if hasPendingTools {
 				a.logger.Warn("response hit output token limit with %d pending tool calls; tool arguments may be truncated", len(pendingTools))
-			} else if !ls.tokensEscalated {
-				prevMax := a.effectiveMaxTokens(ls)
-				ls.tokensEscalated = true
-				a.logger.Warn("output token limit hit; escalating max_tokens from %d to %d", prevMax, escalatedMaxOutputTokens)
+			} else if ls.maxOutputTokens < escalatedMaxOutputTokens {
+				a.logger.Warn("output token limit hit; escalating max_tokens from %d to %d", ls.maxOutputTokens, escalatedMaxOutputTokens)
+				a.escalateMaxTokens(ls)
 				a.emit(ctx, ch, TurnEvent{Type: "max_tokens_escalation"})
 				ls.turnCount--
 				ls.lastContinueReason = ContinueMaxTokensRecovery

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1128,7 +1128,7 @@ func (m *maxTokensProvider) Stream(_ context.Context, _ provider.CompletionReque
 }
 
 func TestRunLoop_MaxTokens_RetriesWithContinuation(t *testing.T) {
-	prov := &maxTokensProvider{maxCalls: 3}
+	prov := &maxTokensProvider{maxCalls: 4}
 	reg := tools.NewRegistry()
 	cfg := config.DefaultConfig()
 	agent := New(prov, reg, autoApprove, cfg)
@@ -1139,6 +1139,7 @@ func TestRunLoop_MaxTokens_RetriesWithContinuation(t *testing.T) {
 	var exitReason agentsdk.TurnExitReason
 	var output string
 	var recoveryEvents int
+	var escalationEvents int
 	for evt := range ch {
 		if evt.Type == "text_delta" {
 			output += evt.Text
@@ -1149,11 +1150,15 @@ func TestRunLoop_MaxTokens_RetriesWithContinuation(t *testing.T) {
 		if evt.Type == "max_tokens_recovery" {
 			recoveryEvents++
 		}
+		if evt.Type == "max_tokens_escalation" {
+			escalationEvents++
+		}
 	}
 	assert.Equal(t, agentsdk.ExitCompleted, exitReason)
-	assert.Equal(t, 3, prov.callCount, "should retry on max_tokens until end_turn")
-	assert.Contains(t, output, "response_3")
-	assert.Equal(t, 2, recoveryEvents, "should emit 2 recovery events (attempts 1 and 2)")
+	assert.Equal(t, 4, prov.callCount, "should retry on max_tokens until end_turn")
+	assert.Contains(t, output, "response_4")
+	assert.Equal(t, 1, escalationEvents, "should emit 1 escalation event (first max_tokens hit)")
+	assert.Equal(t, 2, recoveryEvents, "should emit 2 recovery events (attempts after escalation)")
 }
 
 func TestRunLoop_MaxTokens_StopsAfterMaxRecovery(t *testing.T) {
@@ -1167,6 +1172,7 @@ func TestRunLoop_MaxTokens_StopsAfterMaxRecovery(t *testing.T) {
 
 	var exitReason agentsdk.TurnExitReason
 	var recoveryEvents int
+	var escalationEvents int
 	for evt := range ch {
 		if evt.Type == "done" {
 			exitReason = evt.ExitReason
@@ -1174,10 +1180,14 @@ func TestRunLoop_MaxTokens_StopsAfterMaxRecovery(t *testing.T) {
 		if evt.Type == "max_tokens_recovery" {
 			recoveryEvents++
 		}
+		if evt.Type == "max_tokens_escalation" {
+			escalationEvents++
+		}
 	}
 	assert.Equal(t, agentsdk.ExitCompleted, exitReason)
-	assert.Equal(t, maxOutputTokensRecoveryLimit, recoveryEvents, "should attempt exactly maxOutputTokensRecoveryLimit recoveries")
-	assert.Equal(t, maxOutputTokensRecoveryLimit+1, prov.callCount, "should stop after max recovery attempts + final call")
+	assert.Equal(t, 1, escalationEvents, "should escalate once")
+	assert.Equal(t, maxOutputTokensRecoveryLimit, recoveryEvents, "should attempt exactly maxOutputTokensRecoveryLimit recoveries after escalation")
+	assert.Equal(t, 1+maxOutputTokensRecoveryLimit+1, prov.callCount, "1 escalation + maxOutputTokensRecoveryLimit recovery + 1 final call")
 }
 
 func TestRunLoop_MaxTokens_WithToolCalls_DoesNotRetry(t *testing.T) {

--- a/internal/agent/context_test.go
+++ b/internal/agent/context_test.go
@@ -367,7 +367,7 @@ func TestContextManager_BudgetNudge_AboveCompactTrigger(t *testing.T) {
 }
 
 func TestBudgetNudge_NudgeEmittedOnce(t *testing.T) {
-	ls := newLoopState(50, 0)
+	ls := newLoopState(50, 0, 8192)
 	cm := NewContextManager(100, 0)
 	conv := NewConversation("short")
 	for i := 0; i < 4; i++ {

--- a/internal/agent/loopstate.go
+++ b/internal/agent/loopstate.go
@@ -14,6 +14,11 @@ const maxOutputTokensRecoveryLimit = 3
 // stay below this threshold the loop exits with ExitDiminishingReturns.
 const diminishingThreshold = 500
 
+const (
+	defaultMaxOutputTokens   = 8192
+	escalatedMaxOutputTokens = 65536
+)
+
 type ContinueReason int
 
 const (
@@ -52,6 +57,7 @@ type loopState struct {
 	lastGlobalOutputTokens    int
 	lastContinueReason        ContinueReason
 	nudgeEmitted              bool
+	tokensEscalated           bool
 }
 
 func newLoopState(maxTurns, turnCount int) *loopState {

--- a/internal/agent/loopstate.go
+++ b/internal/agent/loopstate.go
@@ -14,10 +14,7 @@ const maxOutputTokensRecoveryLimit = 3
 // stay below this threshold the loop exits with ExitDiminishingReturns.
 const diminishingThreshold = 500
 
-const (
-	defaultMaxOutputTokens   = 8192
-	escalatedMaxOutputTokens = 65536
-)
+const escalatedMaxOutputTokens = 65536
 
 type ContinueReason int
 
@@ -57,11 +54,11 @@ type loopState struct {
 	lastGlobalOutputTokens    int
 	lastContinueReason        ContinueReason
 	nudgeEmitted              bool
-	tokensEscalated           bool
+	maxOutputTokens           int
 }
 
-func newLoopState(maxTurns, turnCount int) *loopState {
-	return &loopState{maxTurns: maxTurns, turnCount: turnCount}
+func newLoopState(maxTurns, turnCount, maxOutputTokens int) *loopState {
+	return &loopState{maxTurns: maxTurns, turnCount: turnCount, maxOutputTokens: maxOutputTokens}
 }
 
 func (s *loopState) hasMoreTurns() bool {

--- a/internal/agent/loopstate_test.go
+++ b/internal/agent/loopstate_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestNewLoopState(t *testing.T) {
-	ls := newLoopState(10, 3)
+	ls := newLoopState(10, 3, 8192)
 	assert.Equal(t, 10, ls.maxTurns)
 	assert.Equal(t, 3, ls.turnCount)
 	assert.Equal(t, 0, ls.repeatedToolRounds)
@@ -16,7 +16,7 @@ func TestNewLoopState(t *testing.T) {
 }
 
 func TestLoopState_HasMoreTurns(t *testing.T) {
-	ls := newLoopState(5, 3)
+	ls := newLoopState(5, 3, 8192)
 	assert.True(t, ls.hasMoreTurns(), "turnCount=3, maxTurns=5: has more")
 
 	ls.turnCount = 4
@@ -27,7 +27,7 @@ func TestLoopState_HasMoreTurns(t *testing.T) {
 }
 
 func TestLoopState_ResetPerTurn(t *testing.T) {
-	ls := newLoopState(10, 0)
+	ls := newLoopState(10, 0, 8192)
 	ls.streamErr = true
 	ls.repeatedToolRounds = 2
 	ls.lastToolSignature = "read_file"
@@ -38,7 +38,7 @@ func TestLoopState_ResetPerTurn(t *testing.T) {
 }
 
 func TestLoopState_RecordToolSignature_NoProgress(t *testing.T) {
-	ls := newLoopState(10, 0)
+	ls := newLoopState(10, 0, 8192)
 
 	assert.False(t, ls.recordToolSignature("read_file", false), "first occurrence")
 	assert.False(t, ls.recordToolSignature("read_file", false), "second occurrence")
@@ -46,7 +46,7 @@ func TestLoopState_RecordToolSignature_NoProgress(t *testing.T) {
 }
 
 func TestLoopState_RecordToolSignature_ResetsOnNewSignature(t *testing.T) {
-	ls := newLoopState(10, 0)
+	ls := newLoopState(10, 0, 8192)
 
 	ls.recordToolSignature("read_file", false)
 	ls.recordToolSignature("read_file", false)
@@ -54,7 +54,7 @@ func TestLoopState_RecordToolSignature_ResetsOnNewSignature(t *testing.T) {
 }
 
 func TestLoopState_RecordToolSignature_ResetsOnTextContent(t *testing.T) {
-	ls := newLoopState(10, 0)
+	ls := newLoopState(10, 0, 8192)
 
 	ls.recordToolSignature("read_file", false)
 	ls.recordToolSignature("read_file", false)
@@ -62,7 +62,7 @@ func TestLoopState_RecordToolSignature_ResetsOnTextContent(t *testing.T) {
 }
 
 func TestLoopState_CheckDiminishingReturns_BelowThreshold(t *testing.T) {
-	ls := newLoopState(50, 0)
+	ls := newLoopState(50, 0, 8192)
 
 	assert.False(t, ls.checkDiminishingReturns(100), "turn 1: not enough continuations")
 	assert.False(t, ls.checkDiminishingReturns(200), "turn 2: not enough continuations")
@@ -71,7 +71,7 @@ func TestLoopState_CheckDiminishingReturns_BelowThreshold(t *testing.T) {
 }
 
 func TestLoopState_CheckDiminishingReturns_AboveThreshold(t *testing.T) {
-	ls := newLoopState(50, 0)
+	ls := newLoopState(50, 0, 8192)
 
 	assert.False(t, ls.checkDiminishingReturns(100))
 	assert.False(t, ls.checkDiminishingReturns(800))
@@ -81,7 +81,7 @@ func TestLoopState_CheckDiminishingReturns_AboveThreshold(t *testing.T) {
 }
 
 func TestLoopState_CheckDiminishingReturns_ResetsOnSpike(t *testing.T) {
-	ls := newLoopState(50, 0)
+	ls := newLoopState(50, 0, 8192)
 
 	assert.False(t, ls.checkDiminishingReturns(100))
 	assert.False(t, ls.checkDiminishingReturns(200))
@@ -94,7 +94,7 @@ func TestLoopState_CheckDiminishingReturns_ResetsOnSpike(t *testing.T) {
 }
 
 func TestLoopState_CheckDiminishingReturns_NegativeDeltaClamped(t *testing.T) {
-	ls := newLoopState(50, 0)
+	ls := newLoopState(50, 0, 8192)
 
 	ls.checkDiminishingReturns(1000)
 	assert.Equal(t, 1000, ls.lastGlobalOutputTokens)
@@ -106,7 +106,7 @@ func TestLoopState_CheckDiminishingReturns_NegativeDeltaClamped(t *testing.T) {
 }
 
 func TestLoopState_CheckDiminishingReturns_FirstCallZero(t *testing.T) {
-	ls := newLoopState(50, 0)
+	ls := newLoopState(50, 0, 8192)
 	assert.False(t, ls.checkDiminishingReturns(0))
 	assert.Equal(t, 1, ls.continuationCount)
 	assert.Equal(t, 0, ls.lastDeltaTokens)
@@ -130,8 +130,8 @@ func TestContinueReason_String(t *testing.T) {
 }
 
 func TestSlotReservation_EscalationFlag(t *testing.T) {
-	ls := newLoopState(50, 0)
-	assert.False(t, ls.tokensEscalated)
-	ls.tokensEscalated = true
-	assert.True(t, ls.tokensEscalated)
+	ls := newLoopState(50, 0, 8192)
+	assert.Equal(t, 8192, ls.maxOutputTokens)
+	ls.maxOutputTokens = escalatedMaxOutputTokens
+	assert.Equal(t, escalatedMaxOutputTokens, ls.maxOutputTokens)
 }

--- a/internal/agent/loopstate_test.go
+++ b/internal/agent/loopstate_test.go
@@ -128,3 +128,10 @@ func TestContinueReason_String(t *testing.T) {
 		assert.Equal(t, tt.want, tt.reason.String())
 	}
 }
+
+func TestSlotReservation_EscalationFlag(t *testing.T) {
+	ls := newLoopState(50, 0)
+	assert.False(t, ls.tokensEscalated)
+	ls.tokensEscalated = true
+	assert.True(t, ls.tokensEscalated)
+}

--- a/internal/agent/slot_reservation_test.go
+++ b/internal/agent/slot_reservation_test.go
@@ -6,28 +6,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEffectiveMaxTokens_Default(t *testing.T) {
-	a := &Agent{configuredMaxTokens: 0}
-	ls := newLoopState(50, 0)
-	assert.Equal(t, defaultMaxOutputTokens, a.effectiveMaxTokens(ls))
+func TestEffectiveMaxTokens_FromConfig(t *testing.T) {
+	ls := newLoopState(50, 0, 8192)
+	assert.Equal(t, 8192, ls.maxOutputTokens)
 }
 
-func TestEffectiveMaxTokens_Configured(t *testing.T) {
-	a := &Agent{configuredMaxTokens: 16384}
-	ls := newLoopState(50, 0)
-	assert.Equal(t, 16384, a.effectiveMaxTokens(ls))
+func TestEffectiveMaxTokens_CustomValue(t *testing.T) {
+	ls := newLoopState(50, 0, 16384)
+	assert.Equal(t, 16384, ls.maxOutputTokens)
 }
 
-func TestEffectiveMaxTokens_Escalated(t *testing.T) {
-	a := &Agent{configuredMaxTokens: 0}
-	ls := newLoopState(50, 0)
-	ls.tokensEscalated = true
-	assert.Equal(t, escalatedMaxOutputTokens, a.effectiveMaxTokens(ls))
+func TestEscalateMaxTokens(t *testing.T) {
+	ls := newLoopState(50, 0, 8192)
+	a := &Agent{}
+	a.escalateMaxTokens(ls)
+	assert.Equal(t, escalatedMaxOutputTokens, ls.maxOutputTokens)
 }
 
-func TestEffectiveMaxTokens_EscalatedOverridesConfig(t *testing.T) {
-	a := &Agent{configuredMaxTokens: 4096}
-	ls := newLoopState(50, 0)
-	ls.tokensEscalated = true
-	assert.Equal(t, escalatedMaxOutputTokens, a.effectiveMaxTokens(ls))
+func TestEscalateMaxTokens_OnlyOnce(t *testing.T) {
+	ls := newLoopState(50, 0, 8192)
+	a := &Agent{}
+	a.escalateMaxTokens(ls)
+	assert.Equal(t, escalatedMaxOutputTokens, ls.maxOutputTokens)
+	a.escalateMaxTokens(ls)
+	assert.Equal(t, escalatedMaxOutputTokens, ls.maxOutputTokens, "escalation should be idempotent")
 }

--- a/internal/agent/slot_reservation_test.go
+++ b/internal/agent/slot_reservation_test.go
@@ -1,0 +1,33 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEffectiveMaxTokens_Default(t *testing.T) {
+	a := &Agent{configuredMaxTokens: 0}
+	ls := newLoopState(50, 0)
+	assert.Equal(t, defaultMaxOutputTokens, a.effectiveMaxTokens(ls))
+}
+
+func TestEffectiveMaxTokens_Configured(t *testing.T) {
+	a := &Agent{configuredMaxTokens: 16384}
+	ls := newLoopState(50, 0)
+	assert.Equal(t, 16384, a.effectiveMaxTokens(ls))
+}
+
+func TestEffectiveMaxTokens_Escalated(t *testing.T) {
+	a := &Agent{configuredMaxTokens: 0}
+	ls := newLoopState(50, 0)
+	ls.tokensEscalated = true
+	assert.Equal(t, escalatedMaxOutputTokens, a.effectiveMaxTokens(ls))
+}
+
+func TestEffectiveMaxTokens_EscalatedOverridesConfig(t *testing.T) {
+	a := &Agent{configuredMaxTokens: 4096}
+	ls := newLoopState(50, 0)
+	ls.tokensEscalated = true
+	assert.Equal(t, escalatedMaxOutputTokens, a.effectiveMaxTokens(ls))
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -411,7 +411,7 @@ func DefaultConfig() *Config {
 			MaxTurns:               50,
 			ApprovalMode:           "prompt",
 			ContextBudget:          100000,
-			MaxOutputTokens:        4096,
+			MaxOutputTokens:        8192,
 			CompactTrigger:         0.95,
 			HardBlock:              0.98,
 			ResultOffloadThreshold: 4096,


### PR DESCRIPTION
## Summary
- Default `MaxOutputTokens` updated from 4096 to 8192 (conservative; 99% of requests fit)
- On first `max_tokens` stop, escalates to 65536 (64k) and retries the same request
- If still truncated after escalation, falls through to existing continuation recovery (up to 3x)
- Escalation tracked via `loopState.tokensEscalated` flag (once per Turn)
- Emits `max_tokens_escalation` event for UI notification

## Test plan
- `TestEffectiveMaxTokens_Default/Configured/Escalated/EscalatedOverridesConfig` — unit tests
- `TestSlotReservation_EscalationFlag` — flag behavior
- Updated `TestRunLoop_MaxTokens_RetriesWithContinuation` — now expects escalation + recovery
- Updated `TestRunLoop_MaxTokens_StopsAfterMaxRecovery` — now expects 1 escalation + 3 recoveries
- All existing agent tests pass