### PR TITLE
[STRUCTURAL] Add head/tail snip compaction strategy

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -409,6 +409,7 @@ func New(p provider.LLMProvider, t *tools.Registry, approve ApprovalFunc, cfg *c
 	if a.summarizer != nil && !a.customStrategies {
 		a.context.SetStrategies([]CompactionStrategy{
 			NewToolResultClearingStrategy(),
+			NewHeadTailSnipStrategy(),
 			NewSummarizationStrategy(a.summarizer),
 			&truncateStrategy{},
 		})

--- a/internal/agent/compaction_snip.go
+++ b/internal/agent/compaction_snip.go
@@ -16,25 +16,25 @@ func (s *headTailSnipStrategy) Name() string { return "head_tail_snip" }
 
 func (s *headTailSnipStrategy) Compact(_ context.Context, messages []agentsdk.Message, budget int) ([]agentsdk.Message, error) {
 	for estimateMessageTokens(messages) > budget && len(messages) > 4 {
-		headSize := len(messages) / 3
-		if headSize < 1 {
-			headSize = 1
-		}
-		tailStart := headSize + 2
-		if tailStart >= len(messages) {
+		prevLen := len(messages)
+		cutStart := len(messages) / 3
+		cutEnd := cutStart + 2
+
+		if cutEnd >= len(messages) {
 			break
 		}
-		if hasToolUse(messages[headSize]) {
-			tailStart++
-			if tailStart >= len(messages) {
-				break
-			}
+		if hasToolUse(messages[cutStart]) || hasToolResult(messages[cutStart]) {
+			cutEnd++
 		}
-		head := messages[:headSize]
-		tail := messages[tailStart:]
-		messages = make([]agentsdk.Message, 0, len(head)+len(tail))
-		messages = append(messages, head...)
-		messages = append(messages, tail...)
+		if cutEnd >= len(messages) {
+			break
+		}
+
+		messages = append(messages[:cutStart:cutStart], messages[cutEnd:]...)
+
+		if len(messages) == prevLen {
+			break
+		}
 	}
 	return messages, nil
 }

--- a/internal/agent/compaction_snip.go
+++ b/internal/agent/compaction_snip.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+type headTailSnipStrategy struct{}
+
+func NewHeadTailSnipStrategy() agentsdk.CompactionStrategy {
+	return &headTailSnipStrategy{}
+}
+
+func (s *headTailSnipStrategy) Name() string { return "head_tail_snip" }
+
+func (s *headTailSnipStrategy) Compact(_ context.Context, messages []agentsdk.Message, budget int) ([]agentsdk.Message, error) {
+	for estimateMessageTokens(messages) > budget && len(messages) > 4 {
+		headSize := len(messages) / 3
+		if headSize < 1 {
+			headSize = 1
+		}
+		tailStart := headSize + 2
+		if tailStart >= len(messages) {
+			break
+		}
+		if hasToolUse(messages[headSize]) {
+			tailStart++
+			if tailStart >= len(messages) {
+				break
+			}
+		}
+		head := messages[:headSize]
+		tail := messages[tailStart:]
+		messages = make([]agentsdk.Message, 0, len(head)+len(tail))
+		messages = append(messages, head...)
+		messages = append(messages, tail...)
+	}
+	return messages, nil
+}

--- a/internal/agent/compaction_snip_test.go
+++ b/internal/agent/compaction_snip_test.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeadTailSnip_PreservesHeadAndTail(t *testing.T) {
+	s := NewHeadTailSnipStrategy()
+	msgs := makeMessages(9)
+	result, err := s.Compact(context.Background(), msgs, 1)
+	assert.NoError(t, err)
+	assert.Less(t, len(result), len(msgs), "should reduce message count")
+	assert.Equal(t, msgs[0].Content[0].Text, result[0].Content[0].Text, "should preserve first message (head)")
+	assert.Equal(t, msgs[len(msgs)-1].Content[0].Text, result[len(result)-1].Content[0].Text, "should preserve last message (tail)")
+}
+
+func TestHeadTailSnip_DoesNotOverShrink(t *testing.T) {
+	s := NewHeadTailSnipStrategy()
+	msgs := makeMessages(9)
+	result, err := s.Compact(context.Background(), msgs, estimateMessageTokens(msgs)+1000)
+	assert.NoError(t, err)
+	assert.Equal(t, msgs, result, "should not remove messages when within budget")
+}
+
+func TestHeadTailSnip_MinimumMessages(t *testing.T) {
+	s := NewHeadTailSnipStrategy()
+	msgs := makeMessages(4)
+	result, err := s.Compact(context.Background(), msgs, 1)
+	assert.NoError(t, err)
+	assert.LessOrEqual(t, len(result), 4)
+}
+
+func TestHeadTailSnip_SkipsToolUseBoundary(t *testing.T) {
+	s := NewHeadTailSnipStrategy()
+	msgs := makeMessages(9)
+	msgs[3] = agentsdk.Message{Role: "assistant", Content: []agentsdk.ContentBlock{
+		{Type: "tool_use", ID: "tu1", Name: "read_file"},
+	}}
+	result, err := s.Compact(context.Background(), msgs, 1)
+	assert.NoError(t, err)
+	for _, m := range result {
+		if m.Role == "assistant" {
+			for _, b := range m.Content {
+				if b.Type == "tool_use" {
+					hasResult := false
+					for _, m2 := range result {
+						for _, b2 := range m2.Content {
+							if b2.Type == "tool_result" && b2.ToolUseID == b.ID {
+								hasResult = true
+							}
+						}
+					}
+					assert.True(t, hasResult, "tool_use should have matching tool_result")
+				}
+			}
+		}
+	}
+}
+
+func makeMessages(n int) []agentsdk.Message {
+	msgs := make([]agentsdk.Message, n)
+	for i := 0; i < n; i++ {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		msgs[i] = agentsdk.Message{
+			Role: role,
+			Content: []agentsdk.ContentBlock{
+				{Type: "text", Text: string(rune('a' + i))},
+			},
+		}
+	}
+	return msgs
+}


### PR DESCRIPTION
## Summary
- New `headTailSnipStrategy` compaction strategy: preserves first 1/3 and last 2/3 of messages, drops the middle
- Skips tool_use boundaries to avoid orphaning tool_use/result pairs
- Inserted in strategy chain: tool clearing → **head/tail snip** → summarization → truncate

## Test plan
- `TestHeadTailSnip_PreservesHeadAndTail` — verifies head and tail preserved
- `TestHeadTailSnip_DoesNotOverShrink` — no-op when within budget
- `TestHeadTailSnip_MinimumMessages` — handles small conversations
- `TestHeadTailSnip_SkipsToolUseBoundary` — avoids orphaning tool_use blocks
- All existing compaction and agent tests pass