### PR TITLE
[STRUCTURAL] Add InputConcurrencySafeTool for per-invocation concurrency safety

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1524,7 +1524,13 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 				// the approval scan entirely — approval can be expensive
 				// when a security scanner is wired in.
 				if tool, ok := a.tools.Get(currentTool.Name); ok {
-					if cs, csok := tool.(agentsdk.ConcurrencySafeTool); csok && cs.IsConcurrencySafe() {
+					if ic, icok := tool.(agentsdk.InputConcurrencySafeTool); icok && ic.IsConcurrencySafeForInput(currentTool.Input) {
+						approval := a.approvalResultForTool(*currentTool)
+						if approval == AutoApproved || approval == TrustRuleApproved {
+							execStream.Dispatch(ctx, *currentTool)
+							currentTool = nil
+						}
+					} else if cs, csok := tool.(agentsdk.ConcurrencySafeTool); csok && cs.IsConcurrencySafe() {
 						approval := a.approvalResultForTool(*currentTool)
 						if approval == AutoApproved || approval == TrustRuleApproved {
 							// Dispatch in background; executeTools

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1524,11 +1524,13 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 				// the approval scan entirely — approval can be expensive
 				// when a security scanner is wired in.
 				if tool, ok := a.tools.Get(currentTool.Name); ok {
-					if ic, icok := tool.(agentsdk.InputConcurrencySafeTool); icok && ic.IsConcurrencySafeForInput(currentTool.Input) {
-						approval := a.approvalResultForTool(*currentTool)
-						if approval == AutoApproved || approval == TrustRuleApproved {
-							execStream.Dispatch(ctx, *currentTool)
-							currentTool = nil
+					if ic, icok := tool.(agentsdk.InputConcurrencySafeTool); icok {
+						if ic.IsConcurrencySafeForInput(currentTool.Input) {
+							approval := a.approvalResultForTool(*currentTool)
+							if approval == AutoApproved || approval == TrustRuleApproved {
+								execStream.Dispatch(ctx, *currentTool)
+								currentTool = nil
+							}
 						}
 					} else if cs, csok := tool.(agentsdk.ConcurrencySafeTool); csok && cs.IsConcurrencySafe() {
 						approval := a.approvalResultForTool(*currentTool)

--- a/pkg/agentsdk/tool_caps.go
+++ b/pkg/agentsdk/tool_caps.go
@@ -1,5 +1,7 @@
 package agentsdk
 
+import "encoding/json"
+
 // ResultCapped is an optional extension interface for tools that want
 // the agent to truncate their output before it enters the conversation.
 //
@@ -56,4 +58,17 @@ type ResultCapped interface {
 // contents are already in memory."
 type ConcurrencySafeTool interface {
 	IsConcurrencySafe() bool
+}
+
+// InputConcurrencySafeTool is an optional extension that allows tools to
+// declare per-invocation safety based on the tool input. Tools like shell
+// can return true for read-only commands (cat, grep, ls) and false for
+// mutating commands (rm, write, mkdir).
+//
+// When both ConcurrencySafeTool and InputConcurrencySafeTool are
+// implemented, the agent calls IsConcurrencySafeForInput first. If it
+// returns true, the tool is dispatched during streaming. Otherwise the
+// static IsConcurrencySafe() is used as fallback.
+type InputConcurrencySafeTool interface {
+	IsConcurrencySafeForInput(input json.RawMessage) bool
 }

--- a/pkg/agentsdk/tool_caps_test.go
+++ b/pkg/agentsdk/tool_caps_test.go
@@ -1,0 +1,42 @@
+package agentsdk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockInputSafeTool struct {
+	staticSafe bool
+	inputSafe  func(json.RawMessage) bool
+}
+
+func (m *mockInputSafeTool) IsConcurrencySafe() bool { return m.staticSafe }
+func (m *mockInputSafeTool) IsConcurrencySafeForInput(input json.RawMessage) bool {
+	if m.inputSafe != nil {
+		return m.inputSafe(input)
+	}
+	return false
+}
+
+func TestInputConcurrencySafeTool_Interface(t *testing.T) {
+	var _ InputConcurrencySafeTool = &mockInputSafeTool{}
+}
+
+func TestInputConcurrencySafeTool_OverridesStatic(t *testing.T) {
+	tool := &mockInputSafeTool{
+		staticSafe: true,
+		inputSafe: func(input json.RawMessage) bool {
+			return string(input) == `{"cmd":"cat file"}`
+		},
+	}
+	assert.True(t, tool.IsConcurrencySafeForInput(json.RawMessage(`{"cmd":"cat file"}`)))
+	assert.False(t, tool.IsConcurrencySafeForInput(json.RawMessage(`{"cmd":"rm file"}`)))
+	assert.True(t, tool.IsConcurrencySafe(), "static safety should still be true")
+}
+
+func TestInputConcurrencySafeTool_NilFunc(t *testing.T) {
+	tool := &mockInputSafeTool{staticSafe: true}
+	assert.False(t, tool.IsConcurrencySafeForInput(json.RawMessage(`{}`)))
+}


### PR DESCRIPTION
## Summary
- New `InputConcurrencySafeTool` interface: `IsConcurrencySafeForInput(input json.RawMessage) bool`
- Checked before the static `ConcurrencySafeTool.IsConcurrencySafe()` in the streaming dispatch path
- Enables tools like bash to declare `cat file` as safe (dispatch during stream) and `rm file` as unsafe (wait for stream end)
- Backward-compatible: existing tools that don't implement the new interface are unaffected

## Test plan
- `TestInputConcurrencySafeTool_Interface` — compile-time interface satisfaction
- `TestInputConcurrencySafeTool_OverridesStatic` — input check overrides static
- `TestInputConcurrencySafeTool_NilFunc` — nil func returns false
- All existing agent tests pass