### PR TITLE
[STRUCTURAL] Add Barrier primitive to streamingToolExecutor

### DIFF
--- a/internal/agent/stream_tool_exec.go
+++ b/internal/agent/stream_tool_exec.go
@@ -111,20 +111,10 @@ func (e *streamingToolExecutor) Dispatch(ctx context.Context, tc provider.ToolUs
 // then runs the barrier tool synchronously, then appends its future to
 // the executor's results list so Drain() surfaces it in dispatch order.
 //
-// The intended use is mid-stream write-shaped tools: when a tool block
-// finalizes that mutates state (Edit, Write, side-effecting Bash), the
-// caller invokes Barrier instead of Dispatch. Subsequent Dispatch calls
-// resume normal parallel execution after Barrier returns.
-//
 // Concurrency contract: the stream-event loop in agent.runLoop is the
 // sole caller of Dispatch and Barrier on any one executor instance, so
 // no two of these calls overlap. Barrier therefore does not need to
 // guard against new Dispatches arriving during its wg.Wait().
-//
-// Cancellation: if ctx is already done when Barrier is called, the
-// barrier tool is NOT executed; an error future is recorded so Drain
-// surfaces a result for it. This mirrors Dispatch's pre-flight ctx
-// check and keeps the cancellation contract uniform.
 func (e *streamingToolExecutor) Barrier(ctx context.Context, tc provider.ToolUseBlock) toolExecResult {
 	e.wg.Wait()
 	f := &toolFuture{

--- a/internal/agent/stream_tool_exec.go
+++ b/internal/agent/stream_tool_exec.go
@@ -114,7 +114,11 @@ func (e *streamingToolExecutor) Dispatch(ctx context.Context, tc provider.ToolUs
 // Concurrency contract: the stream-event loop in agent.runLoop is the
 // sole caller of Dispatch and Barrier on any one executor instance, so
 // no two of these calls overlap. Barrier therefore does not need to
-// guard against new Dispatches arriving during its wg.Wait().
+// guard against new Dispatches arriving during its wg.Wait(). Violating
+// the contract — calling Dispatch concurrently with Barrier — would let
+// a new Dispatch escape the wg.Wait() snapshot (the barrier tool would
+// run alongside it instead of after it) and would race on the e.futures
+// append below.
 func (e *streamingToolExecutor) Barrier(ctx context.Context, tc provider.ToolUseBlock) toolExecResult {
 	e.wg.Wait()
 	f := &toolFuture{

--- a/internal/agent/stream_tool_exec.go
+++ b/internal/agent/stream_tool_exec.go
@@ -106,6 +106,44 @@ func (e *streamingToolExecutor) Dispatch(ctx context.Context, tc provider.ToolUs
 	}()
 }
 
+// Barrier serializes a single tool call against every prior in-flight
+// Dispatch. It waits for all currently-dispatched futures to complete,
+// then runs the barrier tool synchronously, then appends its future to
+// the executor's results list so Drain() surfaces it in dispatch order.
+//
+// The intended use is mid-stream write-shaped tools: when a tool block
+// finalizes that mutates state (Edit, Write, side-effecting Bash), the
+// caller invokes Barrier instead of Dispatch. Subsequent Dispatch calls
+// resume normal parallel execution after Barrier returns.
+//
+// Concurrency contract: the stream-event loop in agent.runLoop is the
+// sole caller of Dispatch and Barrier on any one executor instance, so
+// no two of these calls overlap. Barrier therefore does not need to
+// guard against new Dispatches arriving during its wg.Wait().
+//
+// Cancellation: if ctx is already done when Barrier is called, the
+// barrier tool is NOT executed; an error future is recorded so Drain
+// surfaces a result for it. This mirrors Dispatch's pre-flight ctx
+// check and keeps the cancellation contract uniform.
+func (e *streamingToolExecutor) Barrier(ctx context.Context, tc provider.ToolUseBlock) toolExecResult {
+	e.wg.Wait()
+	f := &toolFuture{
+		toolUseID: tc.ID,
+		toolName:  tc.Name,
+		done:      make(chan struct{}),
+	}
+	if ctx.Err() != nil {
+		f.result = toolErrorResult(tc, "context cancelled before barrier dispatch")
+	} else {
+		f.result = e.run(ctx, tc)
+	}
+	close(f.done)
+	e.mu.Lock()
+	e.futures = append(e.futures, f)
+	e.mu.Unlock()
+	return f.result
+}
+
 // Drain waits for every dispatched future to complete and returns
 // their results in dispatch order. Safe to call only once per executor
 // instance; subsequent calls return an empty slice.

--- a/internal/agent/stream_tool_exec_test.go
+++ b/internal/agent/stream_tool_exec_test.go
@@ -71,6 +71,16 @@ func runnerFromTool(tool agentsdk.Tool) toolExecFn {
 	}
 }
 
+// newExecutorWithTools wires a streamingToolExecutor whose run dispatches
+// to one of the given fakes by tool name — the common test fixture for
+// scenarios that exercise multiple tools in one executor.
+func newExecutorWithTools(maxParallel int, byName map[string]agentsdk.Tool) *streamingToolExecutor {
+	run := func(ctx context.Context, tc provider.ToolUseBlock) toolExecResult {
+		return runnerFromTool(byName[tc.Name])(ctx, tc)
+	}
+	return newStreamingToolExecutor(maxParallel, run)
+}
+
 func TestStreamingExecutorDispatchesSafeToolsInParallel(t *testing.T) {
 	t.Parallel()
 	// Two slow concurrency-safe tools. Sequential execution would take
@@ -108,11 +118,7 @@ func TestStreamingExecutorPreservesDispatchOrder(t *testing.T) {
 	// runner that dispatches to different fake tools based on tc.Name.
 	fast := &fakeConcurrencySafeTool{name: "fast", execDelay: 10 * time.Millisecond, returnText: "fast"}
 	slow := &fakeConcurrencySafeTool{name: "slow", execDelay: 80 * time.Millisecond, returnText: "slow"}
-	byName := map[string]agentsdk.Tool{"fast": fast, "slow": slow}
-	run := func(ctx context.Context, tc provider.ToolUseBlock) toolExecResult {
-		return runnerFromTool(byName[tc.Name])(ctx, tc)
-	}
-	ex := newStreamingToolExecutor(2, run)
+	ex := newExecutorWithTools(2, map[string]agentsdk.Tool{"fast": fast, "slow": slow})
 	ctx := context.Background()
 
 	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "first", Name: "slow"})
@@ -930,11 +936,6 @@ func TestRunLoopStreamErrorSurfacesStreamedToolResults(t *testing.T) {
 	}
 }
 
-// TestStreamingExecutor_Barrier_WaitsForInFlight verifies that Barrier
-// blocks until every previously-Dispatched future has completed before
-// the barrier tool's run function is invoked. This is the core
-// write-barrier guarantee: an unsafe (write) tool dispatched mid-stream
-// must observe a quiesced executor before it runs.
 func TestStreamingExecutor_Barrier_WaitsForInFlight(t *testing.T) {
 	t.Parallel()
 	var inFlightFinished atomic.Bool
@@ -954,11 +955,7 @@ func TestStreamingExecutor_Barrier_WaitsForInFlight(t *testing.T) {
 			}
 		},
 	}
-	byName := map[string]agentsdk.Tool{"slow_read": slow, "write": barrierTool}
-	run := func(ctx context.Context, tc provider.ToolUseBlock) toolExecResult {
-		return runnerFromTool(byName[tc.Name])(ctx, tc)
-	}
-	ex := newStreamingToolExecutor(4, run)
+	ex := newExecutorWithTools(4, map[string]agentsdk.Tool{"slow_read": slow, "write": barrierTool})
 	ctx := context.Background()
 
 	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "r1", Name: "slow_read"})
@@ -970,18 +967,11 @@ func TestStreamingExecutor_Barrier_WaitsForInFlight(t *testing.T) {
 	require.True(t, inFlightFinished.Load(), "barrier returned before in-flight tools finished")
 }
 
-// TestStreamingExecutor_Barrier_AppendedToFutures verifies that the
-// barrier's result is appended to the futures list and surfaces in
-// Drain() in dispatch order, just like a normal Dispatch.
 func TestStreamingExecutor_Barrier_AppendedToFutures(t *testing.T) {
 	t.Parallel()
 	read := &fakeConcurrencySafeTool{name: "read", execDelay: 5 * time.Millisecond, returnText: "r"}
 	write := &fakeConcurrencySafeTool{name: "write", execDelay: 5 * time.Millisecond, returnText: "w"}
-	byName := map[string]agentsdk.Tool{"read": read, "write": write}
-	run := func(ctx context.Context, tc provider.ToolUseBlock) toolExecResult {
-		return runnerFromTool(byName[tc.Name])(ctx, tc)
-	}
-	ex := newStreamingToolExecutor(4, run)
+	ex := newExecutorWithTools(4, map[string]agentsdk.Tool{"read": read, "write": write})
 	ctx := context.Background()
 
 	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "r1", Name: "read"})
@@ -995,20 +985,12 @@ func TestStreamingExecutor_Barrier_AppendedToFutures(t *testing.T) {
 	require.Equal(t, "w", results[1].content)
 }
 
-// TestStreamingExecutor_Barrier_PreservesOrderInMixedSequence verifies
-// that a sequence [safe, safe, barrier, safe, safe] surfaces in Drain
-// in exactly that dispatch order, even when individual tool wall times
-// differ.
 func TestStreamingExecutor_Barrier_PreservesOrderInMixedSequence(t *testing.T) {
 	t.Parallel()
 	fast := &fakeConcurrencySafeTool{name: "fast", execDelay: 10 * time.Millisecond, returnText: "f"}
 	slow := &fakeConcurrencySafeTool{name: "slow", execDelay: 60 * time.Millisecond, returnText: "s"}
 	write := &fakeConcurrencySafeTool{name: "write", execDelay: 10 * time.Millisecond, returnText: "w"}
-	byName := map[string]agentsdk.Tool{"fast": fast, "slow": slow, "write": write}
-	run := func(ctx context.Context, tc provider.ToolUseBlock) toolExecResult {
-		return runnerFromTool(byName[tc.Name])(ctx, tc)
-	}
-	ex := newStreamingToolExecutor(4, run)
+	ex := newExecutorWithTools(4, map[string]agentsdk.Tool{"fast": fast, "slow": slow, "write": write})
 	ctx := context.Background()
 
 	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "1", Name: "slow"})
@@ -1024,13 +1006,6 @@ func TestStreamingExecutor_Barrier_PreservesOrderInMixedSequence(t *testing.T) {
 	}
 }
 
-// TestStreamingExecutor_Barrier_ContextCancelled verifies behavior when
-// ctx is already cancelled at Barrier-call time. Mirrors Dispatch's
-// existing semantics (line 85 in stream_tool_exec.go): the tool is NOT
-// executed; an error result is recorded so Drain() can surface it.
-//
-// This keeps the cancellation contract uniform across Dispatch and
-// Barrier — callers don't have to learn two different rules.
 func TestStreamingExecutor_Barrier_ContextCancelled(t *testing.T) {
 	t.Parallel()
 	write := &fakeConcurrencySafeTool{name: "write", execDelay: 5 * time.Millisecond, returnText: "w"}

--- a/internal/agent/stream_tool_exec_test.go
+++ b/internal/agent/stream_tool_exec_test.go
@@ -929,3 +929,123 @@ func TestRunLoopStreamErrorSurfacesStreamedToolResults(t *testing.T) {
 		t.Fatalf("tool_call for call-1 (evIdx=%d) must arrive before tool_result (evIdx=%d)", ci, ri)
 	}
 }
+
+// TestStreamingExecutor_Barrier_WaitsForInFlight verifies that Barrier
+// blocks until every previously-Dispatched future has completed before
+// the barrier tool's run function is invoked. This is the core
+// write-barrier guarantee: an unsafe (write) tool dispatched mid-stream
+// must observe a quiesced executor before it runs.
+func TestStreamingExecutor_Barrier_WaitsForInFlight(t *testing.T) {
+	t.Parallel()
+	var inFlightFinished atomic.Bool
+	slow := &fakeConcurrencySafeTool{
+		name:       "slow_read",
+		execDelay:  150 * time.Millisecond,
+		returnText: "ok",
+		onFinish:   func() { inFlightFinished.Store(true) },
+	}
+	barrierTool := &fakeConcurrencySafeTool{
+		name:       "write",
+		execDelay:  10 * time.Millisecond,
+		returnText: "wrote",
+		onStart: func() {
+			if !inFlightFinished.Load() {
+				panic("barrier tool started before in-flight Dispatch finished")
+			}
+		},
+	}
+	byName := map[string]agentsdk.Tool{"slow_read": slow, "write": barrierTool}
+	run := func(ctx context.Context, tc provider.ToolUseBlock) toolExecResult {
+		return runnerFromTool(byName[tc.Name])(ctx, tc)
+	}
+	ex := newStreamingToolExecutor(4, run)
+	ctx := context.Background()
+
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "r1", Name: "slow_read"})
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "r2", Name: "slow_read"})
+	res := ex.Barrier(ctx, provider.ToolUseBlock{ID: "w1", Name: "write"})
+
+	require.Equal(t, "w1", res.toolUseID)
+	require.False(t, res.isError, "barrier result should not be an error")
+	require.True(t, inFlightFinished.Load(), "barrier returned before in-flight tools finished")
+}
+
+// TestStreamingExecutor_Barrier_AppendedToFutures verifies that the
+// barrier's result is appended to the futures list and surfaces in
+// Drain() in dispatch order, just like a normal Dispatch.
+func TestStreamingExecutor_Barrier_AppendedToFutures(t *testing.T) {
+	t.Parallel()
+	read := &fakeConcurrencySafeTool{name: "read", execDelay: 5 * time.Millisecond, returnText: "r"}
+	write := &fakeConcurrencySafeTool{name: "write", execDelay: 5 * time.Millisecond, returnText: "w"}
+	byName := map[string]agentsdk.Tool{"read": read, "write": write}
+	run := func(ctx context.Context, tc provider.ToolUseBlock) toolExecResult {
+		return runnerFromTool(byName[tc.Name])(ctx, tc)
+	}
+	ex := newStreamingToolExecutor(4, run)
+	ctx := context.Background()
+
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "r1", Name: "read"})
+	ex.Barrier(ctx, provider.ToolUseBlock{ID: "w1", Name: "write"})
+	results := ex.Drain()
+
+	require.Len(t, results, 2)
+	require.Equal(t, "r1", results[0].toolUseID)
+	require.Equal(t, "w1", results[1].toolUseID)
+	require.Equal(t, "r", results[0].content)
+	require.Equal(t, "w", results[1].content)
+}
+
+// TestStreamingExecutor_Barrier_PreservesOrderInMixedSequence verifies
+// that a sequence [safe, safe, barrier, safe, safe] surfaces in Drain
+// in exactly that dispatch order, even when individual tool wall times
+// differ.
+func TestStreamingExecutor_Barrier_PreservesOrderInMixedSequence(t *testing.T) {
+	t.Parallel()
+	fast := &fakeConcurrencySafeTool{name: "fast", execDelay: 10 * time.Millisecond, returnText: "f"}
+	slow := &fakeConcurrencySafeTool{name: "slow", execDelay: 60 * time.Millisecond, returnText: "s"}
+	write := &fakeConcurrencySafeTool{name: "write", execDelay: 10 * time.Millisecond, returnText: "w"}
+	byName := map[string]agentsdk.Tool{"fast": fast, "slow": slow, "write": write}
+	run := func(ctx context.Context, tc provider.ToolUseBlock) toolExecResult {
+		return runnerFromTool(byName[tc.Name])(ctx, tc)
+	}
+	ex := newStreamingToolExecutor(4, run)
+	ctx := context.Background()
+
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "1", Name: "slow"})
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "2", Name: "fast"})
+	ex.Barrier(ctx, provider.ToolUseBlock{ID: "3", Name: "write"})
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "4", Name: "fast"})
+	ex.Dispatch(ctx, provider.ToolUseBlock{ID: "5", Name: "slow"})
+	results := ex.Drain()
+
+	require.Len(t, results, 5)
+	for i, want := range []string{"1", "2", "3", "4", "5"} {
+		require.Equal(t, want, results[i].toolUseID, "result[%d]", i)
+	}
+}
+
+// TestStreamingExecutor_Barrier_ContextCancelled verifies behavior when
+// ctx is already cancelled at Barrier-call time. Mirrors Dispatch's
+// existing semantics (line 85 in stream_tool_exec.go): the tool is NOT
+// executed; an error result is recorded so Drain() can surface it.
+//
+// This keeps the cancellation contract uniform across Dispatch and
+// Barrier — callers don't have to learn two different rules.
+func TestStreamingExecutor_Barrier_ContextCancelled(t *testing.T) {
+	t.Parallel()
+	write := &fakeConcurrencySafeTool{name: "write", execDelay: 5 * time.Millisecond, returnText: "w"}
+	run := runnerFromTool(write)
+	ex := newStreamingToolExecutor(2, run)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res := ex.Barrier(ctx, provider.ToolUseBlock{ID: "w1", Name: "write"})
+
+	require.Equal(t, "w1", res.toolUseID)
+	require.True(t, res.isError, "Barrier with cancelled ctx should produce an error result")
+	require.Equal(t, int32(0), write.called.Load(), "tool should not have executed under cancelled ctx")
+
+	results := ex.Drain()
+	require.Len(t, results, 1, "barrier result must still appear in Drain")
+	require.Equal(t, "w1", results[0].toolUseID)
+}

--- a/internal/agent/stream_tool_exec_test.go
+++ b/internal/agent/stream_tool_exec_test.go
@@ -1024,3 +1024,37 @@ func TestStreamingExecutor_Barrier_ContextCancelled(t *testing.T) {
 	require.Len(t, results, 1, "barrier result must still appear in Drain")
 	require.Equal(t, "w1", results[0].toolUseID)
 }
+
+func TestStreamingExecutor_Barrier_FirstCallNoInFlight(t *testing.T) {
+	t.Parallel()
+	write := &fakeConcurrencySafeTool{name: "write", execDelay: 5 * time.Millisecond, returnText: "w"}
+	ex := newStreamingToolExecutor(2, runnerFromTool(write))
+
+	res := ex.Barrier(context.Background(), provider.ToolUseBlock{ID: "w1", Name: "write"})
+
+	require.Equal(t, "w1", res.toolUseID)
+	require.False(t, res.isError)
+	require.Equal(t, "w", res.content)
+
+	results := ex.Drain()
+	require.Len(t, results, 1)
+	require.Equal(t, "w1", results[0].toolUseID)
+}
+
+func TestStreamingExecutor_Barrier_ConsecutiveBarriers(t *testing.T) {
+	t.Parallel()
+	w1Tool := &fakeConcurrencySafeTool{name: "w1", execDelay: 5 * time.Millisecond, returnText: "first"}
+	w2Tool := &fakeConcurrencySafeTool{name: "w2", execDelay: 5 * time.Millisecond, returnText: "second"}
+	ex := newExecutorWithTools(2, map[string]agentsdk.Tool{"w1": w1Tool, "w2": w2Tool})
+	ctx := context.Background()
+
+	ex.Barrier(ctx, provider.ToolUseBlock{ID: "b1", Name: "w1"})
+	ex.Barrier(ctx, provider.ToolUseBlock{ID: "b2", Name: "w2"})
+
+	results := ex.Drain()
+	require.Len(t, results, 2)
+	require.Equal(t, "b1", results[0].toolUseID)
+	require.Equal(t, "b2", results[1].toolUseID)
+	require.Equal(t, "first", results[0].content)
+	require.Equal(t, "second", results[1].content)
+}


### PR DESCRIPTION
## Summary

Adds `streamingToolExecutor.Barrier(ctx, tc) toolExecResult` — a serialization point for mid-stream write-shaped tools.

`Barrier`:
1. Waits for all currently-dispatched in-flight futures (`wg.Wait()`)
2. Runs the barrier tool synchronously
3. Appends the future to the executor's results list so `Drain()` surfaces it in dispatch order

This is the executor-level primitive an unsafe-but-approved tool will use when it finalizes mid-stream — it quiesces the executor before the write runs, preserving read-write ordering against parallel reads. Subsequent `Dispatch` calls resume normal parallel execution after `Barrier` returns.

**No callers yet** — this PR is structural-only. The `agent.runLoop`/`finalizeTool` wiring is the behavioral follow-up. Splitting this way matches the recent batch's tidy-first cadence (#245 → #246, #244 → #249).

## Design notes

- **Concurrency contract**: the stream-event loop is the sole caller of `Dispatch` and `Barrier` on any one executor instance, so no two of these calls overlap. `Barrier` therefore does not need to guard against new `Dispatch`es arriving during its `wg.Wait()`.
- **Cancellation**: mirrors `Dispatch`'s pre-flight check — already-cancelled `ctx` skips execution and records an error future, so `Drain` still surfaces a result for the unmatched-id-check invariant in `surfaceStreamedResults`.
- Memory ordering relies on the same happens-before guarantee `Drain` documents — `wg.Wait()` synchronizes with every prior `f.result` write.

## Test plan

- [x] `TestStreamingExecutor_Barrier_WaitsForInFlight` — barrier tool's `onStart` panics if it fires before in-flight `Dispatch` finished
- [x] `TestStreamingExecutor_Barrier_AppendedToFutures` — `Drain` returns barrier result in dispatch order alongside `Dispatch` results
- [x] `TestStreamingExecutor_Barrier_PreservesOrderInMixedSequence` — `[safe, safe, barrier, safe, safe]` surfaces in exact dispatch order
- [x] `TestStreamingExecutor_Barrier_ContextCancelled` — already-cancelled `ctx` skips execution, records error future, `Drain` still includes it
- [x] `go test -race ./internal/agent/...` clean
- [x] `go test ./...` clean
- [x] `gofmt -l .` and `golangci-lint run` clean

## Follow-up

Behavioral PR will wire `Barrier` into `finalizeTool` in `internal/agent/agent.go` (~line 1526) — when a tool is auto-approved but **not** concurrency-safe-for-input, call `execStream.Barrier` instead of leaving it for end-of-stream `executeTools`. That extends streaming overlap to the "reason → read → edit → re-read" turn shape that's currently fully serial after the first write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal tool execution synchronization and ordering mechanism
  * Enhanced test coverage for tool execution coordination

<!-- end of auto-generated comment: release notes by coderabbit.ai -->