### PR TITLE
[BEHAVIORAL] Add write-barrier to streaming executor

### DIFF
--- a/.kilocode/rules/rtk-rules.md
+++ b/.kilocode/rules/rtk-rules.md
@@ -1,0 +1,32 @@
+# RTK - Rust Token Killer (Kilo Code)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk` to minimize token consumption.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk ls src/
+rtk grep "pattern" src/
+rtk find "*.rs" .
+rtk docker ps
+rtk gh pr list
+```
+
+## Meta Commands
+
+```bash
+rtk gain              # Show token savings
+rtk gain --history    # Command history with savings
+rtk discover          # Find missed RTK opportunities
+rtk proxy <cmd>       # Run raw (no filtering, for debugging)
+```
+
+## Why
+
+RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.

--- a/docs/superpowers/plans/2026-04-27-query-loop-improvements-index.md
+++ b/docs/superpowers/plans/2026-04-27-query-loop-improvements-index.md
@@ -40,9 +40,27 @@ Plans D and E can be executed in any order. Plans B, C, F depend on A.
 5. **E** (generation counter) — prevents stale cleanup corruption
 6. **F** (model fallback) — resilience against provider overload
 
+## Completed (since index created)
+
+| # | Plan | PR | Description |
+|---|------|-----|-------------|
+| — | Retry jitter | #250 | 0-25% jitter in TurnRetry and DoWithRetry |
+| — | Diminishing returns | #251 | Exit when 4+ turns produce <500 output tokens |
+| — | Budget nudge | #252 | Inject budget awareness message at 70-95% usage |
+| — | ContinueReason | #253 | Structured enum for loop observability |
+| — | Review fixes | #254 | Nudge dedup, negative delta clamp, ContinueReason logging |
+| — | Slot reservation | #255 | 8k→64k max_output_tokens escalation |
+| — | Head/tail snip | #256 | Preserve first 1/3 + last 2/3 during compaction |
+| — | InputConcurrencySafe | #257 | Per-invocation concurrency safety check |
+
+## In Progress
+
+| # | Plan | File | Status |
+|---|------|------|--------|
+| 2.8 | Write-barrier streaming executor | `2026-05-01-write-barrier-streaming-executor.md` | Planned |
+
 ## Out of Scope (future plans)
 
 - Async memory/skill prefetch — requires deeper skill runtime changes
 - Stop hooks with continuation control — requires hook system redesign
-- Token budget diminishing-returns detection — requires budget tracker refactor
 - Streaming tombstone pattern — requires SDK message layer changes

--- a/docs/superpowers/plans/2026-05-01-write-barrier-streaming-executor.md
+++ b/docs/superpowers/plans/2026-05-01-write-barrier-streaming-executor.md
@@ -1,0 +1,204 @@
+# Query Loop Improvements: Batch 2.8 — Write-Barrier in Streaming Executor
+
+> **Status:** Planned, not started.  
+> **Depends on:** 2.7 (InputConcurrencySafeTool) — done.  
+> **Goal:** Ensure ordering correctness when the model emits mixed read/write tool sequences during streaming.
+
+## Background
+
+The streaming tool executor (`internal/agent/stream_tool_exec.go`) dispatches concurrency-safe tools as soon as their `tool_use` block finalizes during the model's streaming response. This overlaps slow I/O with the remaining stream, saving 1-3s per turn.
+
+The current design assumes all concurrency-safe tools are **commutative** — their execution order doesn't matter. This is true for pure reads (read_file, grep, ls) but breaks when a write operation is followed by a read that depends on it.
+
+### The Problem
+
+Consider this tool sequence from the model:
+
+```
+1. write_file(path="/tmp/config.json", content="...")
+2. read_file(path="/tmp/config.json")
+3. grep(pattern="foo", path="/tmp")
+```
+
+With the current executor:
+- `write_file` is NOT concurrency-safe → queued for post-stream execution
+- `read_file` IS concurrency-safe → dispatched immediately during stream
+- `grep` IS concurrency-safe → dispatched immediately during stream
+
+**Race condition:** `read_file` and `grep` may execute *before* `write_file` completes, reading stale or missing data.
+
+This is the **write-barrier** problem: a write operation acts as an ordering barrier. All subsequent tools (even concurrency-safe ones) must wait for the write to complete before executing.
+
+## Reference: ccgo's Approach
+
+ccgo solves this via `PartitionToolCalls` in `execution/executor.go`:
+
+1. Each tool declares `IsConcurrencySafe(input)` — checked per invocation
+2. Tools are partitioned into **batches** where each batch contains only safe tools
+3. An **unsafe tool acts as a barrier** — the next batch starts after it completes
+4. Safe batches run concurrently with a semaphore; unsafe batches run sequentially
+
+```go
+// ccgo execution/executor.go
+func (e *ToolExecutor) PartitionToolCalls(toolUses []ToolUseBlock) []ToolBatch {
+    var batches []ToolBatch
+    var currentBatch ToolBatch
+    for _, tu := range toolUses {
+        t := FindToolByName(e.tools, tu.Name)
+        isSafe := t.IsConcurrencySafe(tu.Input)
+        if isSafe {
+            currentBatch = append(currentBatch, tu)
+        } else {
+            if len(currentBatch) > 0 {
+                batches = append(batches, currentBatch)
+                currentBatch = nil
+            }
+            batches = append(batches, ToolBatch{tu}) // unsafe = singleton batch
+        }
+    }
+    if len(currentBatch) > 0 {
+        batches = append(batches, currentBatch)
+    }
+    return batches
+}
+```
+
+## Design for rubichan
+
+### Option A: Barrier-aware streaming executor (recommended)
+
+Extend `streamingToolExecutor` to track pending barriers:
+
+1. When an **unsafe** tool is finalized during streaming, mark it as a pending barrier
+2. When a **safe** tool is finalized, check if any barrier is pending:
+   - If no barrier: dispatch immediately (current behavior)
+   - If barrier pending: queue the safe tool; dispatch after barrier completes
+3. Post-stream `executeTools` processes barriers in order, then drains queued safe tools
+
+```go
+type streamingToolExecutor struct {
+    sem       chan struct{}
+    run       toolExecFn
+    mu        sync.Mutex
+    futures   []*toolFuture
+    wg        sync.WaitGroup
+    barriers  []string           // tool_use IDs of pending write barriers
+    queued    []*toolFuture      // safe tools queued behind a barrier
+}
+```
+
+### Option B: Two-phase dispatch (simpler, less overlap)
+
+1. During streaming: only dispatch safe tools that appear **before** any unsafe tool
+2. All tools after the first unsafe tool are queued for post-stream execution
+3. Post-stream: execute barriers sequentially, then safe tools concurrently
+
+This loses some parallelism (safe tools after a barrier wait for post-stream) but is simpler to implement correctly.
+
+### Option C: Full batch partitioning (ccgo-style)
+
+Replace the streaming executor with a batch-based approach:
+1. Collect all tool_use blocks during streaming (don't dispatch any)
+2. After stream ends, partition into batches
+3. Execute safe batches concurrently, unsafe batches sequentially
+
+This loses the streaming overlap benefit entirely — safe tools don't start until the stream ends.
+
+## Recommendation: Option A
+
+Option A preserves maximum parallelism while ensuring correctness. The key insight: we don't need to partition upfront — we can dispatch eagerly and retroactively queue when a barrier appears.
+
+## Implementation Plan
+
+### Task 1: Add `IsWriteOperation` to tool interface
+
+Add an optional marker interface for tools that mutate state:
+
+```go
+// pkg/agentsdk/tool_caps.go
+type WriteTool interface {
+    IsWriteOperation() bool
+}
+```
+
+Tools that implement this and return `true` act as barriers.
+
+### Task 2: Extend streamingToolExecutor with barrier tracking
+
+```go
+// internal/agent/stream_tool_exec.go
+
+// barrierFuture tracks a write barrier and the safe tools queued behind it.
+type barrierFuture struct {
+    barrierToolUseID string
+    barrierDone      chan struct{}
+    queued           []*toolFuture
+}
+
+func (e *streamingToolExecutor) Dispatch(ctx context.Context, tc provider.ToolUseBlock, isBarrier bool) {
+    if isBarrier {
+        e.dispatchBarrier(ctx, tc)
+        return
+    }
+    e.dispatchSafe(ctx, tc)
+}
+```
+
+### Task 3: Wire barrier detection into finalizeTool
+
+In `agent.go:finalizeTool`, check if the tool is a write operation:
+
+```go
+isBarrier := false
+if wt, ok := tool.(agentsdk.WriteTool); ok && wt.IsWriteOperation() {
+    isBarrier = true
+}
+
+if ic, ok := tool.(agentsdk.InputConcurrencySafeTool); ok {
+    safe := ic.IsConcurrencySafeForInput(currentTool.Input)
+    if safe && !isBarrier {
+        // dispatch immediately
+        execStream.Dispatch(ctx, *currentTool, false)
+    } else if safe && isBarrier {
+        // queue behind barrier
+        execStream.Dispatch(ctx, *currentTool, true)
+    }
+}
+```
+
+### Task 4: Post-stream barrier resolution
+
+In `executeTools`, process barriers in order:
+1. For each barrier, wait for it to complete
+2. Then dispatch all queued safe tools behind it
+3. Continue to next barrier
+
+### Task 5: Tests
+
+- `TestStreamingExecutor_BarrierBlocksSubsequentSafeTools`
+- `TestStreamingExecutor_SafeToolsBeforeBarrierDispatchImmediately`
+- `TestStreamingExecutor_MultipleBarriersInSequence`
+- `TestStreamingExecutor_BarrierWithNoQueuedTools`
+
+## Files to modify
+
+| File | Changes |
+|------|---------|
+| `pkg/agentsdk/tool_caps.go` | Add `WriteTool` interface |
+| `internal/agent/stream_tool_exec.go` | Add barrier tracking, `DispatchBarrier`, `DrainBarriers` |
+| `internal/agent/agent.go` | Wire `isBarrier` check into `finalizeTool` |
+| `internal/agent/stream_tool_exec_test.go` | Add barrier tests |
+
+## Risks
+
+- **Complexity**: The barrier logic adds state machine complexity to the executor
+- **Performance**: Queued safe tools lose the streaming overlap benefit
+- **Deadlock**: If a barrier tool panics, queued tools may never execute — need panic recovery
+
+## Acceptance Criteria
+
+- [ ] `write_file` followed by `read_file` in the same response executes in correct order
+- [ ] `read_file` before `write_file` still dispatches during streaming
+- [ ] Multiple barriers are processed sequentially
+- [ ] All existing streaming executor tests pass
+- [ ] New barrier tests cover edge cases

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1524,23 +1524,27 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 				// the approval scan entirely — approval can be expensive
 				// when a security scanner is wired in.
 				if tool, ok := a.tools.Get(currentTool.Name); ok {
+					dispatched := false
 					if ic, icok := tool.(agentsdk.InputConcurrencySafeTool); icok {
 						if ic.IsConcurrencySafeForInput(currentTool.Input) {
 							approval := a.approvalResultForTool(*currentTool)
 							if approval == AutoApproved || approval == TrustRuleApproved {
-								execStream.Dispatch(ctx, *currentTool)
-								currentTool = nil
+								dispatched = execStream.Dispatch(ctx, *currentTool)
 							}
 						}
 					} else if cs, csok := tool.(agentsdk.ConcurrencySafeTool); csok && cs.IsConcurrencySafe() {
 						approval := a.approvalResultForTool(*currentTool)
 						if approval == AutoApproved || approval == TrustRuleApproved {
-							// Dispatch in background; executeTools
-							// emits the tool_call event when it sees
-							// the cached result.
-							execStream.Dispatch(ctx, *currentTool)
+							dispatched = execStream.Dispatch(ctx, *currentTool)
 						}
 					}
+					if dispatched {
+						currentTool = nil
+					}
+				}
+
+				if currentTool != nil {
+					execStream.SetBarrier()
 				}
 
 				currentTool = nil

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1523,6 +1523,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 				// marker check comes first so non-eligible tools skip
 				// the approval scan entirely — approval can be expensive
 				// when a security scanner is wired in.
+				isUnsafe := true
 				if tool, ok := a.tools.Get(currentTool.Name); ok {
 					dispatched := false
 					if ic, icok := tool.(agentsdk.InputConcurrencySafeTool); icok {
@@ -1531,19 +1532,21 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 							if approval == AutoApproved || approval == TrustRuleApproved {
 								dispatched = execStream.Dispatch(ctx, *currentTool)
 							}
+							isUnsafe = false
 						}
 					} else if cs, csok := tool.(agentsdk.ConcurrencySafeTool); csok && cs.IsConcurrencySafe() {
 						approval := a.approvalResultForTool(*currentTool)
 						if approval == AutoApproved || approval == TrustRuleApproved {
 							dispatched = execStream.Dispatch(ctx, *currentTool)
 						}
+						isUnsafe = false
 					}
 					if dispatched {
 						currentTool = nil
 					}
 				}
 
-				if currentTool != nil {
+				if currentTool != nil && isUnsafe {
 					execStream.SetBarrier()
 				}
 

--- a/internal/agent/stream_tool_exec.go
+++ b/internal/agent/stream_tool_exec.go
@@ -39,11 +39,12 @@ type toolExecFn func(ctx context.Context, tc provider.ToolUseBlock) toolExecResu
 // streaming response, eliminating 1–3s of sequential wait time on
 // typical reason-then-read turns.
 type streamingToolExecutor struct {
-	sem     chan struct{}
-	run     toolExecFn
-	mu      sync.Mutex
-	futures []*toolFuture
-	wg      sync.WaitGroup
+	sem         chan struct{}
+	run         toolExecFn
+	mu          sync.Mutex
+	futures     []*toolFuture
+	wg          sync.WaitGroup
+	barrierSeen bool // set when an unsafe (write) tool is encountered; blocks subsequent Dispatch calls
 }
 
 // toolFuture holds the in-flight state of one dispatched tool call.
@@ -69,23 +70,32 @@ func newStreamingToolExecutor(maxParallel int, run toolExecFn) *streamingToolExe
 }
 
 // Dispatch starts execution of a concurrency-safe tool in the background.
+// If a barrier has already been seen in this response, the tool is NOT
+// dispatched — it will be executed later by executeTools. This prevents
+// read-after-write races when the model emits [write, read] in the same
+// response.
+//
 // If ctx is already cancelled, the future is completed immediately with
 // an error result — the tool is not executed. Dispatch is O(1); actual
 // execution runs in a background goroutine.
-func (e *streamingToolExecutor) Dispatch(ctx context.Context, tc provider.ToolUseBlock) {
+func (e *streamingToolExecutor) Dispatch(ctx context.Context, tc provider.ToolUseBlock) bool {
+	e.mu.Lock()
+	if e.barrierSeen {
+		e.mu.Unlock()
+		return false
+	}
 	f := &toolFuture{
 		toolUseID: tc.ID,
 		toolName:  tc.Name,
 		done:      make(chan struct{}),
 	}
-	e.mu.Lock()
 	e.futures = append(e.futures, f)
 	e.mu.Unlock()
 
 	if ctx.Err() != nil {
 		f.result = toolErrorResult(tc, "context cancelled before tool dispatch")
 		close(f.done)
-		return
+		return true
 	}
 
 	e.wg.Add(1)
@@ -104,6 +114,16 @@ func (e *streamingToolExecutor) Dispatch(ctx context.Context, tc provider.ToolUs
 		f.result = e.run(ctx, tc)
 		close(f.done)
 	}()
+	return true
+}
+
+// SetBarrier marks that an unsafe (write) tool has been encountered.
+// Subsequent Dispatch calls will return false, causing those tools to be
+// handled by the post-stream executeTools pipeline instead.
+func (e *streamingToolExecutor) SetBarrier() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.barrierSeen = true
 }
 
 // Barrier serializes a single tool call against every prior in-flight

--- a/internal/agent/stream_tool_exec_test.go
+++ b/internal/agent/stream_tool_exec_test.go
@@ -1058,3 +1058,57 @@ func TestStreamingExecutor_Barrier_ConsecutiveBarriers(t *testing.T) {
 	require.Equal(t, "first", results[0].content)
 	require.Equal(t, "second", results[1].content)
 }
+
+func TestStreamingExecutor_SetBarrierBlocksSubsequentDispatch(t *testing.T) {
+	var callOrder []string
+	var mu sync.Mutex
+	run := func(_ context.Context, tc provider.ToolUseBlock) toolExecResult {
+		mu.Lock()
+		callOrder = append(callOrder, tc.ID)
+		mu.Unlock()
+		return toolExecResult{toolUseID: tc.ID, content: tc.Name}
+	}
+	ex := newStreamingToolExecutor(2, run)
+
+	// Dispatch a safe tool first
+	ok1 := ex.Dispatch(context.Background(), provider.ToolUseBlock{ID: "r1", Name: "read"})
+	require.True(t, ok1, "first dispatch should succeed")
+
+	// Set barrier (simulating a write tool)
+	ex.SetBarrier()
+
+	// Subsequent dispatch should be rejected
+	ok2 := ex.Dispatch(context.Background(), provider.ToolUseBlock{ID: "r2", Name: "read"})
+	require.False(t, ok2, "dispatch after barrier should be rejected")
+
+	results := ex.Drain()
+	require.Len(t, results, 1, "only first dispatch should execute")
+	require.Equal(t, "r1", results[0].toolUseID)
+}
+
+func TestStreamingExecutor_SetBarrierIdempotent(t *testing.T) {
+	ex := newStreamingToolExecutor(1, func(_ context.Context, tc provider.ToolUseBlock) toolExecResult {
+		return toolExecResult{toolUseID: tc.ID}
+	})
+
+	ex.SetBarrier()
+	ex.SetBarrier()
+	ex.SetBarrier()
+
+	ok := ex.Dispatch(context.Background(), provider.ToolUseBlock{ID: "r1", Name: "read"})
+	require.False(t, ok, "dispatch should be rejected after barrier")
+}
+
+func TestStreamingExecutor_DispatchReturnValue(t *testing.T) {
+	ex := newStreamingToolExecutor(1, func(_ context.Context, tc provider.ToolUseBlock) toolExecResult {
+		return toolExecResult{toolUseID: tc.ID}
+	})
+
+	ok := ex.Dispatch(context.Background(), provider.ToolUseBlock{ID: "r1", Name: "read"})
+	require.True(t, ok, "dispatch should return true when accepted")
+
+	ex.SetBarrier()
+
+	ok = ex.Dispatch(context.Background(), provider.ToolUseBlock{ID: "r2", Name: "read"})
+	require.False(t, ok, "dispatch should return false when rejected by barrier")
+}


### PR DESCRIPTION
## Summary
- `streamingToolExecutor` now tracks `barrierSeen` flag
- `SetBarrier()` marks that an unsafe tool was encountered; subsequent `Dispatch()` calls return false
- Unsafe tools (not concurrency-safe) trigger `SetBarrier()` in `finalizeTool`
- Safe tools after a barrier are handled by post-stream `executeTools` instead of being dispatched during streaming
- Prevents read-after-write races: `[write_file, read_file]` executes in correct order

## Test plan
- `TestStreamingExecutor_SetBarrierBlocksSubsequentDispatch` — barrier rejects subsequent dispatches
- `TestStreamingExecutor_SetBarrierIdempotent` — multiple SetBarrier calls are safe
- `TestStreamingExecutor_DispatchReturnValue` — Dispatch returns true/false correctly
- All existing streaming executor and agent tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool execution ordering to correctly handle mixed read/write operation sequences during streaming.

* **Documentation**
  * Added planning documentation for query loop improvements and write-barrier streaming enhancements.

* **Tests**
  * Added test coverage for write-barrier behavior and tool execution sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->