### PR TITLE
[STRUCTURAL] Add RetryContext to HTTP retry layer for background/foreground differentiation

### DIFF
--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -20,14 +20,55 @@ var (
 	retryMaxDelay  = 2 * time.Second
 )
 
+// RetryContext distinguishes foreground from background retry behavior.
+type RetryContext int
+
+const (
+	RetryForeground RetryContext = iota // full retries for user-facing ops
+	RetryBackground                     // fail fast for auxiliary ops
+)
+
+// RetryConfig configures HTTP-level retry behavior.
+type RetryConfig struct {
+	MaxAttempts int
+	BaseDelay   time.Duration
+	MaxDelay    time.Duration
+	Context     RetryContext
+}
+
+func (c RetryConfig) maxAttempts() int {
+	if c.MaxAttempts > 0 {
+		return c.MaxAttempts
+	}
+	if c.Context == RetryBackground {
+		return 1
+	}
+	return defaultMaxAttempts
+}
+
 // DoWithRetry executes an HTTP request with bounded exponential backoff for
 // transient API failures.
 func DoWithRetry(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
+	return DoWithRetryConfig(ctx, client, req, RetryConfig{})
+}
+
+// DoWithRetryConfig executes an HTTP request with configurable retry behavior.
+func DoWithRetryConfig(ctx context.Context, client *http.Client, req *http.Request, cfg RetryConfig) (*http.Response, error) {
 	if client == nil {
 		return nil, fmt.Errorf("http client is nil")
 	}
 
-	for attempt := 1; attempt <= defaultMaxAttempts; attempt++ {
+	maxAttempts := cfg.maxAttempts()
+	baseDelay := cfg.BaseDelay
+	if baseDelay <= 0 {
+		baseDelay = retryBaseDelay
+	}
+	maxDelay := cfg.MaxDelay
+	if maxDelay <= 0 {
+		maxDelay = retryMaxDelay
+	}
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		attemptReq, err := cloneRequest(ctx, req)
 		if err != nil {
 			return nil, err
@@ -35,10 +76,10 @@ func DoWithRetry(ctx context.Context, client *http.Client, req *http.Request) (*
 
 		resp, err := client.Do(attemptReq)
 		if err == nil {
-			if !shouldRetryStatus(resp.StatusCode) || attempt == defaultMaxAttempts {
+			if !shouldRetryStatus(resp.StatusCode) || attempt == maxAttempts {
 				return resp, nil
 			}
-			delay := retryDelay(attempt)
+			delay := retryDelay(attempt, baseDelay, maxDelay)
 			if ra, ok := parseRetryAfter(resp.Header.Get("Retry-After")); ok {
 				delay = ra
 			}
@@ -50,10 +91,10 @@ func DoWithRetry(ctx context.Context, client *http.Client, req *http.Request) (*
 			continue
 		}
 
-		if !shouldRetryError(err) || attempt == defaultMaxAttempts {
+		if !shouldRetryError(err) || attempt == maxAttempts {
 			return nil, err
 		}
-		if waitErr := waitRetry(ctx, retryDelay(attempt)); waitErr != nil {
+		if waitErr := waitRetry(ctx, retryDelay(attempt, baseDelay, maxDelay)); waitErr != nil {
 			return nil, waitErr
 		}
 	}
@@ -106,12 +147,18 @@ func shouldRetryError(err error) bool {
 	return errors.As(err, &netErr)
 }
 
-func retryDelay(attempt int) time.Duration {
-	delay := retryBaseDelay
+func retryDelay(attempt int, baseDelay, maxDelay time.Duration) time.Duration {
+	if baseDelay <= 0 {
+		baseDelay = retryBaseDelay
+	}
+	if maxDelay <= 0 {
+		maxDelay = retryMaxDelay
+	}
+	delay := baseDelay
 	for i := 1; i < attempt; i++ {
 		delay *= 2
-		if delay >= retryMaxDelay {
-			delay = retryMaxDelay
+		if delay >= maxDelay {
+			delay = maxDelay
 			break
 		}
 	}

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -148,12 +148,6 @@ func shouldRetryError(err error) bool {
 }
 
 func retryDelay(attempt int, baseDelay, maxDelay time.Duration) time.Duration {
-	if baseDelay <= 0 {
-		baseDelay = retryBaseDelay
-	}
-	if maxDelay <= 0 {
-		maxDelay = retryMaxDelay
-	}
 	delay := baseDelay
 	for i := 1; i < attempt; i++ {
 		delay *= 2

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -266,6 +267,42 @@ func TestDoWithRetryConfig_Foreground_Retries(t *testing.T) {
 	_, err := DoWithRetryConfig(context.Background(), client, req, RetryConfig{Context: RetryForeground})
 	require.Error(t, err)
 	assert.EqualValues(t, 3, calls.Load(), "foreground should retry")
+}
+
+func TestDoWithRetryConfig_CustomMaxAttempts(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return nil, &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+		}),
+	}
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	_, err := DoWithRetryConfig(context.Background(), client, req, RetryConfig{MaxAttempts: 5})
+	require.Error(t, err)
+	assert.EqualValues(t, 5, calls.Load(), "custom max attempts should be respected")
+}
+
+func TestDoWithRetryConfig_CustomDelays(t *testing.T) {
+	var delays []time.Duration
+	var mu sync.Mutex
+	client := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return nil, &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+		}),
+	}
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	start := time.Now()
+	DoWithRetryConfig(context.Background(), client, req, RetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   50 * time.Millisecond,
+		MaxDelay:    100 * time.Millisecond,
+	})
+	elapsed := time.Since(start)
+	mu.Lock()
+	_ = delays
+	mu.Unlock()
+	assert.Less(t, elapsed, 500*time.Millisecond, "custom delays should be faster than default")
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -208,7 +208,7 @@ func TestRetryDelay_UsesJitter(t *testing.T) {
 
 	var delays []time.Duration
 	for i := 0; i < 20; i++ {
-		delays = append(delays, retryDelay(1))
+		delays = append(delays, retryDelay(1, retryBaseDelay, retryMaxDelay))
 	}
 	allSame := true
 	for i := 1; i < len(delays); i++ {
@@ -234,10 +234,38 @@ func TestRetryDelay_CappedAtMaxWithJitter(t *testing.T) {
 	})
 
 	for i := 0; i < 20; i++ {
-		d := retryDelay(5)
+		d := retryDelay(5, retryBaseDelay, retryMaxDelay)
 		assert.GreaterOrEqual(t, d, retryMaxDelay, "delay should be at least maxDelay, got %v", d)
 		assert.LessOrEqual(t, d, retryMaxDelay+retryMaxDelay/4, "delay should not exceed maxDelay + 25%% jitter, got %v", d)
 	}
+}
+
+func TestDoWithRetryConfig_Background_FailFast(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return nil, &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+		}),
+	}
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	_, err := DoWithRetryConfig(context.Background(), client, req, RetryConfig{Context: RetryBackground})
+	require.Error(t, err)
+	assert.EqualValues(t, 1, calls.Load(), "background should not retry")
+}
+
+func TestDoWithRetryConfig_Foreground_Retries(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return nil, &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+		}),
+	}
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	_, err := DoWithRetryConfig(context.Background(), client, req, RetryConfig{Context: RetryForeground})
+	require.Error(t, err)
+	assert.EqualValues(t, 3, calls.Load(), "foreground should retry")
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)


### PR DESCRIPTION
## Summary
- New `DoWithRetryConfig` with `RetryContext`: `RetryForeground` (3 attempts, default) vs `RetryBackground` (1 attempt, fail fast)
- Background ops (wiki generation, knowledge graph ingestion, skill evaluation) can use `RetryBackground` to avoid amplifying gateway errors
- `DoWithRetry` remains unchanged for backward compatibility
- `retryDelay` now accepts configurable base/max delay parameters

## Test plan
- `TestDoWithRetryConfig_Background_FailFast` — background fails after 1 attempt
- `TestDoWithRetryConfig_Foreground_Retries` — foreground retries 3 times
- All existing provider retry tests pass
- All agent tests pass