### PR TITLE
Revert direct main commits

### DIFF
--- a/docs/superpowers/plans/2026-04-27-query-loop-improvements-index.md
+++ b/docs/superpowers/plans/2026-04-27-query-loop-improvements-index.md
@@ -53,13 +53,11 @@ Plans D and E can be executed in any order. Plans B, C, F depend on A.
 | — | Head/tail snip | #256 | Preserve first 1/3 + last 2/3 during compaction |
 | — | InputConcurrencySafe | #257 | Per-invocation concurrency safety check |
 
-## Completed (all query loop improvements done)
+## In Progress
 
-| # | Plan | PR | Description |
-|---|------|-----|-------------|
-| — | Write-barrier executor | #259 | Streaming executor with Barrier primitive |
-| — | Error withholding | #263 | Multi-stage recovery with withheld error buffer |
-| — | Permission modes | #264 | plan, auto, fullAuto, bypass modes |
+| # | Plan | File | Status |
+|---|------|------|--------|
+| 2.8 | Write-barrier streaming executor | `2026-05-01-write-barrier-streaming-executor.md` | Planned |
 
 ## Out of Scope (future plans)
 

--- a/internal/agent/loopstate.go
+++ b/internal/agent/loopstate.go
@@ -19,19 +19,11 @@ const escalatedMaxOutputTokens = 65536
 type ContinueReason int
 
 const (
-	ContinueUnknown ContinueReason = iota
-	// ContinueNextTurn means the model requested tool calls; the loop
-	// will execute them and start another turn with the results.
-	ContinueNextTurn
-	// ContinuePromptTooLongRetry means the context was compacted after
-	// a prompt-too-long error; the loop retries the same request.
-	ContinuePromptTooLongRetry
-	// ContinueMaxTokensRecovery means the model hit its output limit;
-	// the loop sends a continuation prompt to resume generation.
-	ContinueMaxTokensRecovery
-	// ContinueModelFallback means the primary model failed (overloaded
-	// or unavailable) and the loop retried with a fallback model.
-	ContinueModelFallback
+	ContinueUnknown            ContinueReason = iota
+	ContinueNextTurn                          // normal tool-use continuation
+	ContinuePromptTooLongRetry                // reactive compact recovered context
+	ContinueMaxTokensRecovery                 // max_tokens continuation prompt
+	ContinueModelFallback                     // fell back to alternate model
 )
 
 func (r ContinueReason) String() string {

--- a/internal/agent/withheld_error.go
+++ b/internal/agent/withheld_error.go
@@ -19,37 +19,30 @@ type withheldErrorBuffer struct {
 	err *WithheldError
 }
 
-// Add replaces any previous error so recovery always targets the latest
-// failure — stale errors from earlier attempts must not shadow new ones.
+// Add stores a new recoverable error, replacing any previous one.
 func (b *withheldErrorBuffer) Add(class errorclass.ErrorClass, err error) {
 	b.err = &WithheldError{Class: class, Err: err}
 }
 
-// HasUnrecovered reports whether a recoverable error is still pending.
-// The loop uses this to decide whether to surface an error or attempt
-// another recovery round.
+// HasUnrecovered is true between Add and either MarkRecovered or Clear.
 func (b *withheldErrorBuffer) HasUnrecovered() bool {
 	return b.err != nil && !b.err.Recovered
 }
 
-// MarkRecovered acknowledges that the loop successfully recovered from
-// the given error class. The error stays in the buffer until Clear so
-// LastUnrecovered can still report it if a later check is needed.
+// MarkRecovered marks the pending error as recovered so HasUnrecovered
+// returns false. The error remains in the buffer until Clear is called.
 func (b *withheldErrorBuffer) MarkRecovered(class errorclass.ErrorClass) {
 	if b.err != nil && b.err.Class == class {
 		b.err.Recovered = true
 	}
 }
 
-// Clear resets the buffer before each new turn so a recovered error from
-// a previous turn is not mistakenly surfaced again.
+// Clear discards the pending error so stale state doesn't leak across turns.
 func (b *withheldErrorBuffer) Clear() {
 	b.err = nil
 }
 
-// LastUnrecovered surfaces the withheld error when recovery attempts are
-// exhausted. The caller emits this as the final error so the user sees
-// the root cause instead of a generic "retry exhausted" message.
+// LastUnrecovered returns the pending error for surfacing after recovery exhausts.
 func (b *withheldErrorBuffer) LastUnrecovered() (WithheldError, bool) {
 	if b.err != nil && !b.err.Recovered {
 		return *b.err, true

--- a/internal/permissions/mode_checker.go
+++ b/internal/permissions/mode_checker.go
@@ -80,8 +80,7 @@ func (c *ModeAwareChecker) CheckApproval(tool string, input json.RawMessage) age
 	}
 }
 
-// Explain forwards to the wrapped checker's Explainer so UI messages
-// show the original policy reason even when mode logic overrides the result.
+// Explain delegates to the underlying checker if it implements Explainer.
 func (c *ModeAwareChecker) Explain(tool string, input json.RawMessage) string {
 	if c.explainer != nil {
 		return c.explainer.Explain(tool, input)


### PR DESCRIPTION
## Summary

Reverts two commits that were incorrectly pushed directly to `main` instead of going through the PR workflow:

- `a9f3bad` — Comment quality fixes (plan index + withheld error buffer + ContinueReason + ModeAwareChecker)
- `8df0504` — Plan index update marking query loop improvements complete

These changes will be re-applied properly via feature branches and PRs after this revert is merged.

## Why

Per project rules, all work must go through feature branches and PR review. Direct commits to `main` bypass the required `/simplify` and `/pr-review` checks.