### PR TITLE
Fix comment quality: explain WHY not WHAT

### DIFF
--- a/internal/agent/loopstate.go
+++ b/internal/agent/loopstate.go
@@ -19,11 +19,29 @@ const escalatedMaxOutputTokens = 65536
 type ContinueReason int
 
 const (
-	ContinueUnknown            ContinueReason = iota
-	ContinueNextTurn                          // normal tool-use continuation
-	ContinuePromptTooLongRetry                // reactive compact recovered context
-	ContinueMaxTokensRecovery                 // max_tokens continuation prompt
-	ContinueModelFallback                     // fell back to alternate model
+	// ContinueUnknown is the zero value before the loop determines why
+	// the current turn ended. It should never appear in telemetry.
+	ContinueUnknown ContinueReason = iota
+	// ContinueNextTurn is the standard path: the model emitted tool calls
+	// and the loop must execute them, append results, and start a new turn.
+	// Distinguished from other reasons so telemetry can measure "normal"
+	// turn frequency versus recovery-driven turns.
+	ContinueNextTurn
+	// ContinuePromptTooLongRetry triggers reactive compaction, which mutates
+	// the conversation by replacing old messages with summaries. Tracked
+	// separately because compaction changes context quality and should be
+	// visible in metrics as a distinct cost center.
+	ContinuePromptTooLongRetry
+	// ContinueMaxTokensRecovery means the model stopped mid-generation due
+	// to the output token limit. The loop sends a continuation prompt to
+	// resume from where the model left off. Tracked separately because
+	// it indicates the response was truncated and may need user review.
+	ContinueMaxTokensRecovery
+	// ContinueModelFallback means the primary provider failed with a
+	// retryable error (overloaded, 529, etc.) and the loop fell back to
+	// an alternate model. Tracked separately for provider reliability
+	// metrics and to flag potential quality differences between models.
+	ContinueModelFallback
 )
 
 func (r ContinueReason) String() string {

--- a/internal/agent/withheld_error.go
+++ b/internal/agent/withheld_error.go
@@ -19,30 +19,39 @@ type withheldErrorBuffer struct {
 	err *WithheldError
 }
 
-// Add stores a new recoverable error, replacing any previous one.
+// Add replaces any previous error so recovery always targets the latest
+// failure — stale errors from earlier attempts must not shadow new ones.
 func (b *withheldErrorBuffer) Add(class errorclass.ErrorClass, err error) {
 	b.err = &WithheldError{Class: class, Err: err}
 }
 
-// HasUnrecovered is true between Add and either MarkRecovered or Clear.
+// HasUnrecovered reports whether a recoverable error is still pending.
+// The loop uses this to decide whether to surface an error or attempt
+// another recovery round.
 func (b *withheldErrorBuffer) HasUnrecovered() bool {
 	return b.err != nil && !b.err.Recovered
 }
 
-// MarkRecovered marks the pending error as recovered so HasUnrecovered
-// returns false. The error remains in the buffer until Clear is called.
+// MarkRecovered acknowledges that the loop successfully recovered from
+// the given error class. The Recovered flag is checked by HasUnrecovered
+// to stop further recovery attempts; the error remains in the buffer
+// until Clear so the caller can inspect it for logging or telemetry.
 func (b *withheldErrorBuffer) MarkRecovered(class errorclass.ErrorClass) {
 	if b.err != nil && b.err.Class == class {
 		b.err.Recovered = true
 	}
 }
 
-// Clear discards the pending error so stale state doesn't leak across turns.
+// Clear discards the pending error so stale state doesn't leak across
+// recovery attempts. The caller must call this after recovery succeeds
+// or exhausts, before starting a new recovery cycle.
 func (b *withheldErrorBuffer) Clear() {
 	b.err = nil
 }
 
-// LastUnrecovered returns the pending error for surfacing after recovery exhausts.
+// LastUnrecovered returns the pending unrecovered error for surfacing
+// after recovery exhausts. Callers typically log or emit this so the
+// user sees the root cause rather than a generic retry-exhausted message.
 func (b *withheldErrorBuffer) LastUnrecovered() (WithheldError, bool) {
 	if b.err != nil && !b.err.Recovered {
 		return *b.err, true

--- a/internal/permissions/mode_checker.go
+++ b/internal/permissions/mode_checker.go
@@ -80,7 +80,11 @@ func (c *ModeAwareChecker) CheckApproval(tool string, input json.RawMessage) age
 	}
 }
 
-// Explain delegates to the underlying checker if it implements Explainer.
+// Explain forwards to the wrapped checker's Explainer so UI messages
+// show the original policy reason even when mode logic overrides the result.
+// The explainer is captured at construction (via type assertion) to avoid
+// repeated interface checks on every Explain call — this is a hot path
+// when rendering approval prompts in the TUI.
 func (c *ModeAwareChecker) Explain(tool string, input json.RawMessage) string {
 	if c.explainer != nil {
 		return c.explainer.Explain(tool, input)


### PR DESCRIPTION
## Summary

Replaces WHAT comments with WHY comments in recently-added code:

- `withheldErrorBuffer` methods: explain the loop's recovery semantics instead of restating method behavior
- `ContinueReason` constants: explain what each reason triggers in the loop
- `ModeAwareChecker.Explain`: explain why delegation matters for UI messages

## Changes

| File | Before | After |
|------|--------|-------|
| `internal/agent/withheld_error.go` | "Add stores a new recoverable error" | "replaces any previous error so recovery always targets the latest failure" |
| `internal/agent/loopstate.go` | "normal tool-use continuation" | "model requested tool calls; loop will execute them and start another turn" |
| `internal/permissions/mode_checker.go` | "delegates to underlying checker" | "forwards to wrapped checker so UI shows original policy reason" |

## Validation

- `go test ./internal/agent/... ./internal/permissions/...` — pass
- `gofmt` — clean