### PR TITLE
Mark query loop improvements complete in plan index

### DIFF
--- a/docs/superpowers/plans/2026-04-27-query-loop-improvements-index.md
+++ b/docs/superpowers/plans/2026-04-27-query-loop-improvements-index.md
@@ -53,11 +53,13 @@ Plans D and E can be executed in any order. Plans B, C, F depend on A.
 | — | Head/tail snip | #256 | Preserve first 1/3 + last 2/3 during compaction |
 | — | InputConcurrencySafe | #257 | Per-invocation concurrency safety check |
 
-## In Progress
+## Completed (all query loop improvements done)
 
-| # | Plan | File | Status |
-|---|------|------|--------|
-| 2.8 | Write-barrier streaming executor | `2026-05-01-write-barrier-streaming-executor.md` | Planned |
+| # | Plan | PR | Description |
+|---|------|-----|-------------|
+| — | Write-barrier executor | #259 | Streaming executor with Barrier primitive |
+| — | Error withholding | #263 | Multi-stage recovery with withheld error buffer |
+| — | Permission modes | #264 | plan, auto, fullAuto, bypass modes |
 
 ## Out of Scope (future plans)
 


### PR DESCRIPTION
## Summary

Updates the query loop improvements plan index to reflect completed work:

- Mark Batch 2.8 (Write-barrier streaming executor, PR #259) as complete
- Add PR #263 (Error withholding with multi-stage recovery)
- Add PR #264 (Permission modes: plan, auto, fullAuto, bypass)
- Remove stale \"In Progress\" section

All query loop improvements from the ccgo/Claude Code research are now done.