### PR TITLE
Implement tool batching with concurrency safety

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/sourcegraph/conc/pool"
 
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 
@@ -2086,28 +2085,56 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 		results[it.index] = a.approvalToolErrorResult(it.tc, "Tool call denied by user (deny-always).", nil)
 	}
 
-	// Execute auto-approved tools in parallel (hooks + execution, no approval).
+	// Execute auto-approved tools with batching: adjacent concurrency-safe
+	// tools run in parallel; unsafe tools run sequentially.
 	if len(autoApproved) > 0 {
 		if ctx.Err() != nil {
 			return true
 		}
 
-		maxG := len(autoApproved)
-		if maxG > maxParallelTools {
-			maxG = maxParallelTools
+		// Build 1:1 mapping from batch index to plannedToolCall to avoid
+		// O(n²) ID searches in the handler and result mapping.
+		batchCalls := make([]toolexec.ToolCall, len(autoApproved))
+		for i, it := range autoApproved {
+			batchCalls[i] = toolexec.ToolCall{
+				ID:    it.tc.ID,
+				Name:  it.tc.Name,
+				Input: it.tc.Input,
+			}
 		}
-		p := pool.New().WithMaxGoroutines(maxG)
-		var mu sync.Mutex
 
-		for _, it := range autoApproved {
-			p.Go(func() {
-				res := a.executeSingleTool(ctx, ch, it.tc)
-				mu.Lock()
-				results[it.index] = res
-				mu.Unlock()
-			})
+		// Handler indexes directly into autoApproved by batch position.
+		handler := func(ctx context.Context, tc toolexec.ToolCall) toolexec.Result {
+			// batchCalls and autoApproved are built in the same order,
+			// so we can find the original by scanning for the matching ID.
+			// This is O(n) per call worst-case, but n is small (typically < 10).
+			for _, it := range autoApproved {
+				if it.tc.ID == tc.ID {
+					res := a.executeSingleTool(ctx, ch, it.tc)
+					return toolexec.Result{
+						Content:        res.content,
+						DisplayContent: res.event.ToolResult.DisplayContent,
+						IsError:        res.isError,
+					}
+				}
+			}
+			return toolexec.Result{Content: "tool not found in batch", IsError: true}
 		}
-		p.Wait()
+
+		batchExec := toolexec.NewBatchExecutor(a.tools, handler, maxParallelTools)
+		batchResults := batchExec.Execute(ctx, batchCalls)
+
+		// Map batch results back to agent results by index (1:1 with autoApproved).
+		for i, it := range autoApproved {
+			br := batchResults[i]
+			results[it.index] = toolExecResult{
+				toolUseID: it.tc.ID,
+				content:   br.Content,
+				isError:   br.IsError,
+				event:     makeToolResultEvent(it.tc.ID, it.tc.Name, br.Content, br.DisplayContent, br.IsError),
+			}
+		}
+
 		if ctx.Err() != nil {
 			return true
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -350,6 +350,7 @@ type Agent struct {
 	rateLimiter         *SharedRateLimiter
 	capabilities        provider.ModelCapabilities
 	configuredMaxTokens int
+	resultBudget        int
 	progress            *ProgressTracker
 	acpServer           *acp.Server             // ACP server instance (if enabled)
 	acpRegistry         *acp.CapabilityRegistry // Capability registry for ACP
@@ -2156,6 +2157,19 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 		}
 		a.emit(ctx, ch, makeToolCallEvent(it.tc))
 		results[it.index] = a.executeSingleToolWithApproval(ctx, ch, it.tc, it.approvalResult)
+	}
+
+	// Apply aggregate result budget before emitting results.
+	enforcer := NewResultBudgetEnforcer(a.resultBudget, a.resultStore)
+	for i := range pendingTools {
+		r := results[i]
+		bounded, _ := enforcer.Enforce(pendingTools[i].Name, pendingTools[i].ID, agentsdk.ToolResult{
+			Content:        r.content,
+			DisplayContent: r.event.ToolResult.DisplayContent,
+			IsError:        r.isError,
+		})
+		r.content = bounded.Content
+		results[i] = r
 	}
 
 	// Emit all results and update conversation in original tool call order.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2175,12 +2175,18 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 		enforcer := NewResultBudgetEnforcer(a.resultBudget, a.resultStore)
 		for i := range pendingTools {
 			r := results[i]
-			bounded, _ := enforcer.Enforce(pendingTools[i].Name, pendingTools[i].ID, agentsdk.ToolResult{
+			bounded, err := enforcer.Enforce(pendingTools[i].Name, pendingTools[i].ID, agentsdk.ToolResult{
 				Content:        r.content,
 				DisplayContent: r.event.ToolResult.DisplayContent,
 				IsError:        r.isError,
 			})
+			if err != nil {
+				a.logger.Warn("result budget enforcement failed for %s: %v", pendingTools[i].Name, err)
+			}
+			// Rebuild the event with the (possibly truncated/offloaded) content
+			// so channel output matches conversation history.
 			r.content = bounded.Content
+			r.event = makeToolResultEvent(r.toolUseID, pendingTools[i].Name, bounded.Content, bounded.DisplayContent, bounded.IsError)
 			results[i] = r
 		}
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -351,6 +351,7 @@ type Agent struct {
 	capabilities        provider.ModelCapabilities
 	configuredMaxTokens int
 	resultBudget        int
+	fileCache           *tools.FileReadCache
 	progress            *ProgressTracker
 	acpServer           *acp.Server             // ACP server instance (if enabled)
 	acpRegistry         *acp.CapabilityRegistry // Capability registry for ACP
@@ -465,6 +466,15 @@ func New(p provider.LLMProvider, t *tools.Registry, approve ApprovalFunc, cfg *c
 			a.logger.Warn("failed to register read_result tool: %v", err)
 		}
 	}
+
+	// Initialize file read cache and inject into file tool if present.
+	a.fileCache = tools.NewFileReadCache()
+	if ft, ok := a.tools.Get("file"); ok {
+		if fileTool, ok := ft.(*tools.FileTool); ok {
+			fileTool.SetCache(a.fileCache)
+		}
+	}
+
 	a.promptBuilder = NewPromptBuilder()
 
 	// Ensure a pipeline is always available. When no pipeline is provided

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2114,22 +2114,25 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 			}
 		}
 
-		// Handler indexes directly into autoApproved by batch position.
+		// Build ID -> index map for O(1) lookup in the handler.
+		idToIndex := make(map[string]int, len(autoApproved))
+		for i, it := range autoApproved {
+			idToIndex[it.tc.ID] = i
+		}
+
+		// Handler looks up the original plannedToolCall by ID in O(1).
 		handler := func(ctx context.Context, tc toolexec.ToolCall) toolexec.Result {
-			// batchCalls and autoApproved are built in the same order,
-			// so we can find the original by scanning for the matching ID.
-			// This is O(n) per call worst-case, but n is small (typically < 10).
-			for _, it := range autoApproved {
-				if it.tc.ID == tc.ID {
-					res := a.executeSingleTool(ctx, ch, it.tc)
-					return toolexec.Result{
-						Content:        res.content,
-						DisplayContent: res.event.ToolResult.DisplayContent,
-						IsError:        res.isError,
-					}
-				}
+			idx, ok := idToIndex[tc.ID]
+			if !ok {
+				return toolexec.Result{Content: "tool not found in batch: " + tc.ID, IsError: true}
 			}
-			return toolexec.Result{Content: "tool not found in batch", IsError: true}
+			it := autoApproved[idx]
+			res := a.executeSingleTool(ctx, ch, it.tc)
+			return toolexec.Result{
+				Content:        res.content,
+				DisplayContent: res.event.ToolResult.DisplayContent,
+				IsError:        res.isError,
+			}
 		}
 
 		batchExec := toolexec.NewBatchExecutor(a.tools, handler, maxParallelTools)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2170,16 +2170,19 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 	}
 
 	// Apply aggregate result budget before emitting results.
-	enforcer := NewResultBudgetEnforcer(a.resultBudget, a.resultStore)
-	for i := range pendingTools {
-		r := results[i]
-		bounded, _ := enforcer.Enforce(pendingTools[i].Name, pendingTools[i].ID, agentsdk.ToolResult{
-			Content:        r.content,
-			DisplayContent: r.event.ToolResult.DisplayContent,
-			IsError:        r.isError,
-		})
-		r.content = bounded.Content
-		results[i] = r
+	// Skip enforcement when budget is unlimited (<=0) to avoid allocation.
+	if a.resultBudget > 0 {
+		enforcer := NewResultBudgetEnforcer(a.resultBudget, a.resultStore)
+		for i := range pendingTools {
+			r := results[i]
+			bounded, _ := enforcer.Enforce(pendingTools[i].Name, pendingTools[i].ID, agentsdk.ToolResult{
+				Content:        r.content,
+				DisplayContent: r.event.ToolResult.DisplayContent,
+				IsError:        r.isError,
+			})
+			r.content = bounded.Content
+			results[i] = r
+		}
 	}
 
 	// Emit all results and update conversation in original tool call order.

--- a/internal/agent/budget_enforcer.go
+++ b/internal/agent/budget_enforcer.go
@@ -58,63 +58,41 @@ func NewResultBudgetEnforcer(budget int, store *ResultStore) *ResultBudgetEnforc
 func (be *ResultBudgetEnforcer) Enforce(toolName, toolUseID string, res agentsdk.ToolResult) (agentsdk.ToolResult, error) {
 	size := len(res.Content)
 
-	// Check if this result alone exceeds the aggregate budget.
-	if size > be.budget {
-		// Single result exceeds entire budget — must offload or truncate.
+	// Check if adding this result would exceed the remaining budget.
+	remaining := be.budget - be.used
+	if remaining <= 0 {
+		// Budget exhausted — must offload or truncate to zero.
 		if be.store != nil {
 			return be.offload(toolName, toolUseID, res)
 		}
-		// No store: truncate in-place to budget size.
-		res.Content = be.truncate(res.Content, be.budget)
+		res.Content = be.truncate(res.Content, 0)
+		return res, nil
+	}
+
+	if size > remaining {
+		// Result exceeds remaining budget.
+		if be.store != nil {
+			return be.offload(toolName, toolUseID, res)
+		}
+		// No store: truncate to fit remaining budget.
+		res.Content = be.truncate(res.Content, remaining)
 		be.used += len(res.Content)
 		be.accepted = append(be.accepted, acceptedResult{toolName: toolName, toolUseID: toolUseID, size: len(res.Content)})
 		return res, nil
 	}
 
-	// Check if adding this result would exceed the aggregate budget.
-	if be.used+size > be.budget {
-		// Need to make room. Offload the largest previous results first.
-		be.makeRoom(size)
-	}
-
-	if be.used+size <= be.budget {
-		be.used += size
-		be.accepted = append(be.accepted, acceptedResult{toolName: toolName, toolUseID: toolUseID, size: size})
-		return res, nil
-	}
-
-	// Still doesn't fit after offloading — offload this result too.
-	if be.store != nil {
-		return be.offload(toolName, toolUseID, res)
-	}
-	res.Content = be.truncate(res.Content, be.budget-be.used)
-	be.used += len(res.Content)
-	be.accepted = append(be.accepted, acceptedResult{toolName: toolName, toolUseID: toolUseID, size: len(res.Content)})
+	// Result fits within remaining budget.
+	be.used += size
+	be.accepted = append(be.accepted, acceptedResult{toolName: toolName, toolUseID: toolUseID, size: size})
 	return res, nil
 }
 
-// makeRoom offloads previously accepted results until there's enough space.
-// Offloads largest results first (greedy) to minimize number of offloads.
+// makeRoom is no longer used — the simplified Enforce handles budget
+// exhaustion by checking remaining budget per result.
+// Kept for backward compatibility; will be removed in a follow-up.
 //
-// When no store is available, makeRoom cannot retroactively free space
-// from already-accepted results — it becomes a no-op and the caller
-// truncates the new result instead.
+//nolint:unused
 func (be *ResultBudgetEnforcer) makeRoom(needed int) {
-	if be.store == nil {
-		return
-	}
-	for be.used+needed > be.budget && len(be.accepted) > 0 {
-		maxIdx := 0
-		for i := 1; i < len(be.accepted); i++ {
-			if be.accepted[i].size > be.accepted[maxIdx].size {
-				maxIdx = i
-			}
-		}
-		largest := be.accepted[maxIdx]
-		be.used -= largest.size
-		be.accepted[maxIdx] = be.accepted[len(be.accepted)-1]
-		be.accepted = be.accepted[:len(be.accepted)-1]
-	}
 }
 
 // offload stores the result in ResultStore and replaces content with a

--- a/internal/agent/budget_enforcer.go
+++ b/internal/agent/budget_enforcer.go
@@ -1,0 +1,161 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// DefaultMaxResultCharsPerTool is the default per-tool result size limit.
+// Matches Claude Code's DEFAULT_MAX_RESULT_SIZE_CHARS=50_000.
+const DefaultMaxResultCharsPerTool = 50000
+
+// DefaultMaxResultsPerMessageChars is the aggregate budget for all tool
+// results within a single assistant message. When exceeded, the largest
+// fresh results are offloaded until the total fits.
+// Matches Claude Code's MAX_TOOL_RESULTS_PER_MESSAGE_CHARS=200_000.
+const DefaultMaxResultsPerMessageChars = 200000
+
+// ResultBudgetEnforcer tracks aggregate tool result size per message and
+// offloads results when the total would exceed the budget.
+//
+// The enforcer maintains a running total (used) and a list of accepted
+// results by size. When a new result would exceed the budget, the largest
+// previously accepted results are offloaded first (greedy eviction) to
+// minimize the number of offloads.
+type ResultBudgetEnforcer struct {
+	budget int
+	used   int
+	store  *ResultStore
+	// accepted tracks results that have been counted against the budget.
+	// Used for eviction when makeRoom needs to free space.
+	accepted []acceptedResult
+}
+
+// acceptedResult tracks a result that has been accepted into the budget.
+type acceptedResult struct {
+	toolName  string
+	toolUseID string
+	size      int
+}
+
+// NewResultBudgetEnforcer creates a budget enforcer with the given aggregate
+// budget in characters. If store is non-nil, oversized results are offloaded
+// to the store; otherwise they are truncated in-place.
+func NewResultBudgetEnforcer(budget int, store *ResultStore) *ResultBudgetEnforcer {
+	if budget <= 0 {
+		budget = DefaultMaxResultsPerMessageChars
+	}
+	return &ResultBudgetEnforcer{
+		budget: budget,
+		store:  store,
+	}
+}
+
+// Enforce applies the aggregate budget to a single tool result. If adding
+// this result would exceed the budget, it attempts to offload or truncate.
+// Returns the (possibly modified) result that should be added to the message.
+func (be *ResultBudgetEnforcer) Enforce(toolName, toolUseID string, res agentsdk.ToolResult) (agentsdk.ToolResult, error) {
+	size := len(res.Content)
+
+	// First, apply per-tool cap if the tool implements ResultBudgeted.
+	// (This would require the tool instance; for now we apply aggregate only.)
+
+	// Check if this result alone exceeds the aggregate budget.
+	if size > be.budget {
+		// Single result exceeds entire budget — must offload or truncate.
+		if be.store != nil {
+			return be.offload(toolName, toolUseID, res)
+		}
+		// No store: truncate in-place to budget size.
+		res.Content = be.truncate(res.Content, be.budget)
+		be.used += len(res.Content)
+		be.accepted = append(be.accepted, acceptedResult{toolName: toolName, toolUseID: toolUseID, size: len(res.Content)})
+		return res, nil
+	}
+
+	// Check if adding this result would exceed the aggregate budget.
+	if be.used+size > be.budget {
+		// Need to make room. Offload the largest previous results first.
+		be.makeRoom(size)
+	}
+
+	if be.used+size <= be.budget {
+		be.used += size
+		be.accepted = append(be.accepted, acceptedResult{toolName: toolName, toolUseID: toolUseID, size: size})
+		return res, nil
+	}
+
+	// Still doesn't fit after offloading — offload this result too.
+	if be.store != nil {
+		return be.offload(toolName, toolUseID, res)
+	}
+	res.Content = be.truncate(res.Content, be.budget-be.used)
+	be.used += len(res.Content)
+	be.accepted = append(be.accepted, acceptedResult{toolName: toolName, toolUseID: toolUseID, size: len(res.Content)})
+	return res, nil
+}
+
+// makeRoom offloads previously accepted results until there's enough space.
+// Offloads largest results first (greedy) to minimize number of offloads.
+//
+// When no store is available, makeRoom cannot retroactively free space
+// from already-accepted results — it becomes a no-op and the caller
+// truncates the new result instead.
+func (be *ResultBudgetEnforcer) makeRoom(needed int) {
+	if be.store == nil {
+		return
+	}
+	for be.used+needed > be.budget && len(be.accepted) > 0 {
+		maxIdx := 0
+		for i := 1; i < len(be.accepted); i++ {
+			if be.accepted[i].size > be.accepted[maxIdx].size {
+				maxIdx = i
+			}
+		}
+		largest := be.accepted[maxIdx]
+		_ = largest
+		be.used -= largest.size
+		be.accepted[maxIdx] = be.accepted[len(be.accepted)-1]
+		be.accepted = be.accepted[:len(be.accepted)-1]
+	}
+}
+
+// offload stores the result in ResultStore and replaces content with a
+// compact reference. The original content is removed from budget tracking.
+func (be *ResultBudgetEnforcer) offload(toolName, toolUseID string, res agentsdk.ToolResult) (agentsdk.ToolResult, error) {
+	if be.store == nil {
+		return res, nil
+	}
+	ref, err := be.store.OffloadResult(toolName, toolUseID, res.Content)
+	if err != nil {
+		// Graceful degradation: return original if offload fails.
+		// Log the error so operators can detect store problems.
+		return res, fmt.Errorf("offload failed: %w", err)
+	}
+	res.Content = ref
+	be.used += len(ref)
+	return res, nil
+}
+
+// truncate trims content to maxLen bytes, preserving head and tail with
+// a marker. Falls back to head-only if maxLen is too small.
+//
+// The marker itself is included in the maxLen budget. If maxLen is smaller
+// than the marker, the content is truncated to fit the marker.
+func (be *ResultBudgetEnforcer) truncate(content string, maxLen int) string {
+	if len(content) <= maxLen {
+		return content
+	}
+	marker := fmt.Sprintf("\n\n[... truncated: %d chars exceeded budget ...]\n\n", len(content))
+	markerLen := len(marker)
+	if maxLen <= markerLen {
+		// Budget too small for marker+content; return truncated marker.
+		return marker[:maxLen]
+	}
+	if maxLen <= markerLen+100 {
+		return content[:max(0, maxLen-markerLen)] + marker
+	}
+	half := (maxLen - markerLen) / 2
+	return content[:half] + marker + content[len(content)-half:]
+}

--- a/internal/agent/budget_enforcer.go
+++ b/internal/agent/budget_enforcer.go
@@ -140,22 +140,7 @@ func (be *ResultBudgetEnforcer) offload(toolName, toolUseID string, res agentsdk
 
 // truncate trims content to maxLen bytes, preserving head and tail with
 // a marker. Falls back to head-only if maxLen is too small.
-//
-// The marker itself is included in the maxLen budget. If maxLen is smaller
-// than the marker, the content is truncated to fit the marker.
 func (be *ResultBudgetEnforcer) truncate(content string, maxLen int) string {
-	if len(content) <= maxLen {
-		return content
-	}
 	marker := fmt.Sprintf("\n\n[... truncated: %d chars exceeded budget ...]\n\n", len(content))
-	markerLen := len(marker)
-	if maxLen <= markerLen {
-		// Budget too small for marker+content; return truncated marker.
-		return marker[:maxLen]
-	}
-	if maxLen <= markerLen+100 {
-		return content[:max(0, maxLen-markerLen)] + marker
-	}
-	half := (maxLen - markerLen) / 2
-	return content[:half] + marker + content[len(content)-half:]
+	return truncateHeadTail(content, maxLen, marker)
 }

--- a/internal/agent/budget_enforcer.go
+++ b/internal/agent/budget_enforcer.go
@@ -6,42 +6,22 @@ import (
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
-// DefaultMaxResultCharsPerTool is the default per-tool result size limit.
-// Matches Claude Code's DEFAULT_MAX_RESULT_SIZE_CHARS=50_000.
-const DefaultMaxResultCharsPerTool = 50000
-
 // DefaultMaxResultsPerMessageChars is the aggregate budget for all tool
-// results within a single assistant message. When exceeded, the largest
-// fresh results are offloaded until the total fits.
-// Matches Claude Code's MAX_TOOL_RESULTS_PER_MESSAGE_CHARS=200_000.
+// results within a single assistant message. When exceeded, results are
+// offloaded or truncated to fit.
 const DefaultMaxResultsPerMessageChars = 200000
 
 // ResultBudgetEnforcer tracks aggregate tool result size per message and
-// offloads results when the total would exceed the budget.
-//
-// The enforcer maintains a running total (used) and a list of accepted
-// results by size. When a new result would exceed the budget, the largest
-// previously accepted results are offloaded first (greedy eviction) to
-// minimize the number of offloads.
+// offloads or truncates results when the total would exceed the budget.
 type ResultBudgetEnforcer struct {
 	budget int
 	used   int
 	store  *ResultStore
-	// accepted tracks results that have been counted against the budget.
-	// Greedy eviction (makeRoom) needs per-result sizes to find the largest.
-	accepted []acceptedResult
-}
-
-// acceptedResult tracks a result that has been accepted into the budget.
-type acceptedResult struct {
-	toolName  string
-	toolUseID string
-	size      int
 }
 
 // NewResultBudgetEnforcer creates a budget enforcer with the given aggregate
-// budget in characters. If store is non-nil, oversized results are offloaded
-// to the store; otherwise they are truncated in-place.
+// budget. A non-positive budget is treated as unlimited (caller should skip
+// enforcement instead, but this prevents nil-pointer panics).
 func NewResultBudgetEnforcer(budget int, store *ResultStore) *ResultBudgetEnforcer {
 	if budget <= 0 {
 		budget = DefaultMaxResultsPerMessageChars
@@ -77,26 +57,17 @@ func (be *ResultBudgetEnforcer) Enforce(toolName, toolUseID string, res agentsdk
 		// No store: truncate to fit remaining budget.
 		res.Content = be.truncate(res.Content, remaining)
 		be.used += len(res.Content)
-		be.accepted = append(be.accepted, acceptedResult{toolName: toolName, toolUseID: toolUseID, size: len(res.Content)})
 		return res, nil
 	}
 
 	// Result fits within remaining budget.
 	be.used += size
-	be.accepted = append(be.accepted, acceptedResult{toolName: toolName, toolUseID: toolUseID, size: size})
 	return res, nil
 }
 
-// makeRoom is no longer used — the simplified Enforce handles budget
-// exhaustion by checking remaining budget per result.
-// Kept for backward compatibility; will be removed in a follow-up.
-//
-//nolint:unused
-func (be *ResultBudgetEnforcer) makeRoom(needed int) {
-}
-
 // offload stores the result in ResultStore and replaces content with a
-// compact reference. The original content is removed from budget tracking.
+// compact reference. The reference size replaces the original in budget
+// tracking so the total stays within budget.
 func (be *ResultBudgetEnforcer) offload(toolName, toolUseID string, res agentsdk.ToolResult) (agentsdk.ToolResult, error) {
 	if be.store == nil {
 		return res, nil

--- a/internal/agent/budget_enforcer.go
+++ b/internal/agent/budget_enforcer.go
@@ -28,7 +28,7 @@ type ResultBudgetEnforcer struct {
 	used   int
 	store  *ResultStore
 	// accepted tracks results that have been counted against the budget.
-	// Used for eviction when makeRoom needs to free space.
+	// Greedy eviction (makeRoom) needs per-result sizes to find the largest.
 	accepted []acceptedResult
 }
 
@@ -57,9 +57,6 @@ func NewResultBudgetEnforcer(budget int, store *ResultStore) *ResultBudgetEnforc
 // Returns the (possibly modified) result that should be added to the message.
 func (be *ResultBudgetEnforcer) Enforce(toolName, toolUseID string, res agentsdk.ToolResult) (agentsdk.ToolResult, error) {
 	size := len(res.Content)
-
-	// First, apply per-tool cap if the tool implements ResultBudgeted.
-	// (This would require the tool instance; for now we apply aggregate only.)
 
 	// Check if this result alone exceeds the aggregate budget.
 	if size > be.budget {
@@ -114,7 +111,6 @@ func (be *ResultBudgetEnforcer) makeRoom(needed int) {
 			}
 		}
 		largest := be.accepted[maxIdx]
-		_ = largest
 		be.used -= largest.size
 		be.accepted[maxIdx] = be.accepted[len(be.accepted)-1]
 		be.accepted = be.accepted[:len(be.accepted)-1]
@@ -130,7 +126,7 @@ func (be *ResultBudgetEnforcer) offload(toolName, toolUseID string, res agentsdk
 	ref, err := be.store.OffloadResult(toolName, toolUseID, res.Content)
 	if err != nil {
 		// Graceful degradation: return original if offload fails.
-		// Log the error so operators can detect store problems.
+		// The error is returned to the caller (agent.go logs it).
 		return res, fmt.Errorf("offload failed: %w", err)
 	}
 	res.Content = ref

--- a/internal/agent/budget_enforcer_test.go
+++ b/internal/agent/budget_enforcer_test.go
@@ -1,0 +1,83 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+func TestBudgetEnforcer_Basic(t *testing.T) {
+	be := NewResultBudgetEnforcer(100, nil) // 100 char aggregate budget, no store
+
+	// First result: 1 char — fits
+	r1 := agentsdk.ToolResult{Content: "a"}
+	out, err := be.Enforce("tool1", "id1", r1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Content != "a" {
+		t.Errorf("expected 'a', got %q", out.Content)
+	}
+
+	// Add 99 more single-char results to reach budget limit
+	for i := 0; i < 99; i++ {
+		_, err := be.Enforce("tool", "id", agentsdk.ToolResult{Content: "x"})
+		if err != nil {
+			t.Fatalf("unexpected error at %d: %v", i, err)
+		}
+	}
+	// Budget now at 100, next result should be truncated/offloaded
+	r2 := agentsdk.ToolResult{Content: "b"}
+	out2, err := be.Enforce("tool2", "id2", r2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out2.Content == "b" {
+		t.Error("expected content to be truncated since budget exceeded")
+	}
+}
+
+func TestBudgetEnforcer_SingleResultExceedsBudget(t *testing.T) {
+	be := NewResultBudgetEnforcer(10, nil)
+
+	// Single result of 50 chars exceeds entire budget of 10
+	r := agentsdk.ToolResult{Content: "this is a very long result that exceeds the budget"}
+	out, err := be.Enforce("tool", "id", r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The result is truncated to fit within budget (10 chars). The marker
+	// itself is ~50 chars, so when budget < marker, we get a truncated marker.
+	if len(out.Content) != 10 {
+		t.Errorf("expected truncated content == 10 chars, got %d: %q", len(out.Content), out.Content)
+	}
+}
+
+func TestBudgetEnforcer_TruncatePreservesHeadAndTail(t *testing.T) {
+	be := NewResultBudgetEnforcer(500, nil)
+
+	// Fill budget to 400
+	for i := 0; i < 400; i++ {
+		_, err := be.Enforce("tool", "id", agentsdk.ToolResult{Content: "x"})
+		if err != nil {
+			t.Fatalf("unexpected error at %d: %v", i, err)
+		}
+	}
+
+	// Add a 200-char result — should be truncated to fit remaining 100 chars
+	r := agentsdk.ToolResult{Content: "this is some content that is definitely longer than one hundred characters and should be truncated because it exceeds the remaining budget in the enforcer"}
+	out, _ := be.Enforce("tool", "id", r)
+	if out.Content == r.Content {
+		t.Error("expected truncation")
+	}
+	if len(out.Content) > 100 {
+		t.Errorf("expected truncated content <= 100 chars, got %d", len(out.Content))
+	}
+}
+
+func TestBudgetEnforcer_DefaultBudget(t *testing.T) {
+	be := NewResultBudgetEnforcer(0, nil)
+	if be.budget != DefaultMaxResultsPerMessageChars {
+		t.Errorf("expected default budget %d, got %d", DefaultMaxResultsPerMessageChars, be.budget)
+	}
+}

--- a/internal/agent/budget_enforcer_test.go
+++ b/internal/agent/budget_enforcer_test.go
@@ -81,3 +81,36 @@ func TestBudgetEnforcer_DefaultBudget(t *testing.T) {
 		t.Errorf("expected default budget %d, got %d", DefaultMaxResultsPerMessageChars, be.budget)
 	}
 }
+
+func TestBudgetEnforcer_WithStore_Offload(t *testing.T) {
+	be := NewResultBudgetEnforcer(50, nil)
+
+	// Test that a result exceeding budget gets truncated when no store
+	r := agentsdk.ToolResult{Content: "this is a very long result that definitely exceeds the budget of fifty characters"}
+	out, err := be.Enforce("tool", "id", r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Content) >= len(r.Content) {
+		t.Errorf("expected truncation, got %d chars", len(out.Content))
+	}
+	if len(out.Content) > 50 {
+		t.Errorf("expected content <= 50 chars, got %d", len(out.Content))
+	}
+}
+
+func TestBudgetEnforcer_MakeRoom(t *testing.T) {
+	// Budget of 20, store available. Add a 15-char result, then a 10-char result
+	// that should trigger eviction of the 15-char result.
+	be := NewResultBudgetEnforcer(20, nil)
+
+	// First result: 15 chars
+	_, _ = be.Enforce("tool1", "id1", agentsdk.ToolResult{Content: "123456789012345"})
+
+	// Second result: 10 chars — would exceed budget (15+10=25 > 20)
+	// Since no store, makeRoom is a no-op and result gets truncated.
+	out, _ := be.Enforce("tool2", "id2", agentsdk.ToolResult{Content: "1234567890"})
+	if len(out.Content) > 5 {
+		t.Logf("truncated to %d chars (budget remaining after first result)", len(out.Content))
+	}
+}

--- a/internal/agent/budget_enforcer_test.go
+++ b/internal/agent/budget_enforcer_test.go
@@ -99,18 +99,15 @@ func TestBudgetEnforcer_WithStore_Offload(t *testing.T) {
 	}
 }
 
-func TestBudgetEnforcer_MakeRoom(t *testing.T) {
-	// Budget of 20, store available. Add a 15-char result, then a 10-char result
-	// that should trigger eviction of the 15-char result.
+func TestBudgetEnforcer_BudgetExhausted(t *testing.T) {
 	be := NewResultBudgetEnforcer(20, nil)
 
 	// First result: 15 chars
 	_, _ = be.Enforce("tool1", "id1", agentsdk.ToolResult{Content: "123456789012345"})
 
-	// Second result: 10 chars — would exceed budget (15+10=25 > 20)
-	// Since no store, makeRoom is a no-op and result gets truncated.
+	// Second result: 10 chars — only 5 remaining, so truncated to fit.
 	out, _ := be.Enforce("tool2", "id2", agentsdk.ToolResult{Content: "1234567890"})
 	if len(out.Content) > 5 {
-		t.Logf("truncated to %d chars (budget remaining after first result)", len(out.Content))
+		t.Errorf("expected truncation to <= 5 chars, got %d", len(out.Content))
 	}
 }

--- a/internal/agent/result_cap.go
+++ b/internal/agent/result_cap.go
@@ -1,22 +1,12 @@
 package agent
 
 import (
-	"fmt"
-
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
 // applyResultCap truncates a tool result if the tool implements
 // agentsdk.ResultCapped and the content exceeds its declared cap.
 // Exempt tools (nil, no interface, or cap <= 0) pass through unchanged.
-//
-// The truncation strategy preserves both the head and tail of the
-// content, with a marker inserted between them. This beats head-only
-// truncation because tool output often has essential information at
-// both ends — shell commands put errors at the tail, file reads put
-// context at the head. When the cap is too small to hold the marker
-// plus meaningful head+tail slices, the helper falls back to a
-// head-only trim.
 func applyResultCap(tool agentsdk.Tool, res agentsdk.ToolResult) agentsdk.ToolResult {
 	capped, ok := tool.(agentsdk.ResultCapped)
 	if !ok {
@@ -30,23 +20,6 @@ func applyResultCap(tool agentsdk.Tool, res agentsdk.ToolResult) agentsdk.ToolRe
 		return res
 	}
 
-	marker := fmt.Sprintf("\n\n[... truncated: %d bytes exceeded %d byte cap ...]\n\n",
-		len(res.Content), maxBytes)
-
-	// If the cap is too small to hold the marker plus meaningful
-	// head+tail slices, fall back to head-only.
-	sliceBudget := maxBytes - len(marker)
-	const minSidePerEnd = 100 // bytes
-	if sliceBudget < 2*minSidePerEnd {
-		if sliceBudget < 0 {
-			sliceBudget = 0
-		}
-		res.Content = res.Content[:sliceBudget] + marker
-		return res
-	}
-
-	head := sliceBudget / 2
-	tail := sliceBudget - head
-	res.Content = res.Content[:head] + marker + res.Content[len(res.Content)-tail:]
+	res.Content = truncateResultCap(res.Content, maxBytes)
 	return res
 }

--- a/internal/agent/truncate.go
+++ b/internal/agent/truncate.go
@@ -1,0 +1,34 @@
+package agent
+
+import "fmt"
+
+// truncateHeadTail trims content to maxLen bytes, preserving both head and
+// tail with a marker between them. Falls back to head-only when maxLen is
+// too small for meaningful head+tail slices.
+//
+// This strategy preserves context at both ends of tool output — shell
+// commands put errors at the tail, file reads put context at the head.
+func truncateHeadTail(content string, maxLen int, marker string) string {
+	if len(content) <= maxLen {
+		return content
+	}
+
+	markerLen := len(marker)
+	if maxLen <= markerLen {
+		return marker[:maxLen]
+	}
+	if maxLen <= markerLen+100 {
+		return content[:max(0, maxLen-markerLen)] + marker
+	}
+
+	half := (maxLen - markerLen) / 2
+	return content[:half] + marker + content[len(content)-half:]
+}
+
+// truncateResultCap is a convenience wrapper for per-tool result caps.
+// Builds a marker that includes the original and cap sizes.
+func truncateResultCap(content string, maxBytes int) string {
+	marker := fmt.Sprintf("\n\n[... truncated: %d bytes exceeded %d byte cap ...]\n\n",
+		len(content), maxBytes)
+	return truncateHeadTail(content, maxBytes, marker)
+}

--- a/internal/agent/truncate.go
+++ b/internal/agent/truncate.go
@@ -25,8 +25,8 @@ func truncateHeadTail(content string, maxLen int, marker string) string {
 	return content[:half] + marker + content[len(content)-half:]
 }
 
-// truncateResultCap is a convenience wrapper for per-tool result caps.
-// Builds a marker that includes the original and cap sizes.
+// truncateResultCap builds a marker that includes the original and cap
+// sizes. The explicit size audit trail helps debug why a result was cut.
 func truncateResultCap(content string, maxBytes int) string {
 	marker := fmt.Sprintf("\n\n[... truncated: %d bytes exceeded %d byte cap ...]\n\n",
 		len(content), maxBytes)

--- a/internal/hooks/events_test.go
+++ b/internal/hooks/events_test.go
@@ -1,0 +1,17 @@
+package hooks
+
+import "testing"
+
+func TestAllEvents(t *testing.T) {
+	events := AllEvents()
+	if len(events) != 23 {
+		t.Errorf("expected 23 events, got %d", len(events))
+	}
+	seen := make(map[string]bool)
+	for _, e := range events {
+		if seen[e] {
+			t.Errorf("duplicate event: %s", e)
+		}
+		seen[e] = true
+	}
+}

--- a/internal/hooks/http.go
+++ b/internal/hooks/http.go
@@ -19,12 +19,17 @@ var sharedHTTPClient = &http.Client{
 	Timeout: 30 * time.Second,
 }
 
+// failOpen returns a continue result and a wrapped error. Used for all
+// error paths in executeHTTPHook so a broken hook cannot block execution.
+func failOpen(err error) (HookResult, error) {
+	return HookResult{Continue: true}, err
+}
+
 // executeHTTPHook sends a POST request to the configured URL with the
 // event data as JSON. Returns the hook result parsed from the response.
 //
-// Fail-open design: all errors (network, marshal, bad response) log the
-// failure and return Continue=true so a broken hook cannot block execution.
-// Operators should monitor logs for hook failures.
+// Fail-open design: all errors return Continue=true so a broken hook
+// cannot block execution. Operators should monitor logs for hook failures.
 func executeHTTPHook(cfg UserHookConfig, data map[string]interface{}) (HookResult, error) {
 	payload := map[string]interface{}{
 		"event": cfg.Event,
@@ -32,7 +37,7 @@ func executeHTTPHook(cfg UserHookConfig, data map[string]interface{}) (HookResul
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return HookResult{Continue: true}, fmt.Errorf("marshal failed: %w", err)
+		return failOpen(fmt.Errorf("marshal failed: %w", err))
 	}
 
 	// Use context timeout only; http.Client.Timeout is redundant and can
@@ -42,19 +47,19 @@ func executeHTTPHook(cfg UserHookConfig, data map[string]interface{}) (HookResul
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.URL, bytes.NewReader(body))
 	if err != nil {
-		return HookResult{Continue: true}, fmt.Errorf("request build failed: %w", err)
+		return failOpen(fmt.Errorf("request build failed: %w", err))
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := sharedHTTPClient.Do(req)
 	if err != nil {
-		return HookResult{Continue: true}, fmt.Errorf("HTTP request failed: %w", err)
+		return failOpen(fmt.Errorf("HTTP request failed: %w", err))
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxHookResponseSize))
 	if err != nil {
-		return HookResult{Continue: true}, fmt.Errorf("read body failed: %w", err)
+		return failOpen(fmt.Errorf("read body failed: %w", err))
 	}
 
 	var result HookResult

--- a/internal/hooks/http.go
+++ b/internal/hooks/http.go
@@ -78,6 +78,9 @@ func executeHTTPHook(cfg UserHookConfig, data map[string]interface{}) (HookResul
 }
 
 // HookResult captures the response from a hook execution.
+//
+// Hooks can control execution via Cancel, return messages for logging,
+// mutate tool input via UpdatedInput, or modify output via ModifiedOutput.
 type HookResult struct {
 	Continue       bool                   `json:"continue"`
 	Cancel         bool                   `json:"cancel"`

--- a/internal/hooks/http.go
+++ b/internal/hooks/http.go
@@ -64,15 +64,19 @@ func executeHTTPHook(cfg UserHookConfig, data map[string]interface{}) (HookResul
 
 	var result HookResult
 	if err := json.Unmarshal(respBody, &result); err != nil {
-		// Non-JSON response: treat as no-op (continue).
-		return HookResult{Continue: true}, nil
+		// Non-JSON response: log the parse error and continue.
+		return failOpen(fmt.Errorf("unmarshal hook response: %w", err))
 	}
 
-	// Explicit cancel takes precedence; everything else defaults to continue.
 	if result.Cancel {
 		return result, nil
 	}
-	return HookResult{Continue: true, Message: result.Message, UpdatedInput: result.UpdatedInput}, nil
+	return HookResult{
+		Continue:       true,
+		Message:        result.Message,
+		UpdatedInput:   result.UpdatedInput,
+		ModifiedOutput: result.ModifiedOutput,
+	}, nil
 }
 
 // HookResult captures the response from a hook execution.

--- a/internal/hooks/http.go
+++ b/internal/hooks/http.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 )
 
 // maxHookResponseSize limits how much data we read from a hook response.
@@ -15,9 +14,8 @@ import (
 const maxHookResponseSize = 1 << 20 // 1 MiB
 
 // sharedHTTPClient is reused across hook calls for connection pooling.
-var sharedHTTPClient = &http.Client{
-	Timeout: 30 * time.Second,
-}
+// No timeout here — per-request timeouts are set via context in executeHTTPHook.
+var sharedHTTPClient = &http.Client{}
 
 // failOpen returns a continue result and a wrapped error. Used for all
 // error paths in executeHTTPHook so a broken hook cannot block execution.

--- a/internal/hooks/http.go
+++ b/internal/hooks/http.go
@@ -1,0 +1,80 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// maxHookResponseSize limits how much data we read from a hook response.
+// Prevents OOM from misconfigured or malicious hook servers.
+const maxHookResponseSize = 1 << 20 // 1 MiB
+
+// sharedHTTPClient is reused across hook calls for connection pooling.
+var sharedHTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
+
+// executeHTTPHook sends a POST request to the configured URL with the
+// event data as JSON. Returns the hook result parsed from the response.
+//
+// Fail-open design: all errors (network, marshal, bad response) log the
+// failure and return Continue=true so a broken hook cannot block execution.
+// Operators should monitor logs for hook failures.
+func executeHTTPHook(cfg UserHookConfig, data map[string]interface{}) (HookResult, error) {
+	payload := map[string]interface{}{
+		"event": cfg.Event,
+		"data":  data,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return HookResult{Continue: true}, fmt.Errorf("marshal failed: %w", err)
+	}
+
+	// Use context timeout only; http.Client.Timeout is redundant and can
+	// cause confusing error types when both fire.
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.URL, bytes.NewReader(body))
+	if err != nil {
+		return HookResult{Continue: true}, fmt.Errorf("request build failed: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := sharedHTTPClient.Do(req)
+	if err != nil {
+		return HookResult{Continue: true}, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxHookResponseSize))
+	if err != nil {
+		return HookResult{Continue: true}, fmt.Errorf("read body failed: %w", err)
+	}
+
+	var result HookResult
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		// Non-JSON response: treat as no-op (continue).
+		return HookResult{Continue: true}, nil
+	}
+
+	// Explicit cancel takes precedence; everything else defaults to continue.
+	if result.Cancel {
+		return result, nil
+	}
+	return HookResult{Continue: true, Message: result.Message, UpdatedInput: result.UpdatedInput}, nil
+}
+
+// HookResult captures the response from a hook execution.
+type HookResult struct {
+	Continue       bool                   `json:"continue"`
+	Cancel         bool                   `json:"cancel"`
+	Message        string                 `json:"message"`
+	UpdatedInput   map[string]interface{} `json:"updated_input,omitempty"`
+	ModifiedOutput string                 `json:"modified_output,omitempty"`
+}

--- a/internal/hooks/http_test.go
+++ b/internal/hooks/http_test.go
@@ -1,0 +1,105 @@
+package hooks
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestExecuteHTTPHook(t *testing.T) {
+	var receivedPayload map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &receivedPayload)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"continue": true}`))
+	}))
+	defer server.Close()
+
+	cfg := UserHookConfig{
+		Event:   EventPreTool,
+		URL:     server.URL,
+		Timeout: 5 * time.Second,
+	}
+
+	result, err := executeHTTPHook(cfg, map[string]interface{}{"tool": "test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Continue {
+		t.Error("expected continue=true")
+	}
+	data, ok := receivedPayload["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data map in payload, got %T", receivedPayload["data"])
+	}
+	if data["tool"] != "test" {
+		t.Errorf("expected tool=test in payload.data, got %v", data["tool"])
+	}
+}
+
+func TestExecuteHTTPHook_NonJSONResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	defer server.Close()
+
+	cfg := UserHookConfig{
+		Event:   EventPreTool,
+		URL:     server.URL,
+		Timeout: 5 * time.Second,
+	}
+
+	result, err := executeHTTPHook(cfg, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Continue {
+		t.Error("expected continue=true for non-JSON response")
+	}
+}
+
+func TestExecuteHTTPHook_CancelResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cancel": true, "message": "blocked"}`))
+	}))
+	defer server.Close()
+
+	cfg := UserHookConfig{
+		Event:   EventPreTool,
+		URL:     server.URL,
+		Timeout: 5 * time.Second,
+	}
+
+	result, err := executeHTTPHook(cfg, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Cancel {
+		t.Error("expected cancel=true")
+	}
+	if result.Message != "blocked" {
+		t.Errorf("expected message=blocked, got %q", result.Message)
+	}
+}
+
+func TestExecuteHTTPHook_NetworkError(t *testing.T) {
+	cfg := UserHookConfig{
+		Event:   EventPreTool,
+		URL:     "http://localhost:1", // unlikely to be listening
+		Timeout: 1 * time.Second,
+	}
+
+	result, err := executeHTTPHook(cfg, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+	if !result.Continue {
+		t.Error("expected continue=true on network error (fail-open)")
+	}
+}

--- a/internal/hooks/http_test.go
+++ b/internal/hooks/http_test.go
@@ -55,11 +55,11 @@ func TestExecuteHTTPHook_NonJSONResponse(t *testing.T) {
 	}
 
 	result, err := executeHTTPHook(cfg, map[string]interface{}{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected error for non-JSON response")
 	}
 	if !result.Continue {
-		t.Error("expected continue=true for non-JSON response")
+		t.Error("expected continue=true for non-JSON response (fail-open)")
 	}
 }
 

--- a/internal/hooks/prompt.go
+++ b/internal/hooks/prompt.go
@@ -9,6 +9,7 @@ type PromptHook struct {
 	Replace string
 }
 
+// Transform applies the find/replace to the input text.
 func (h PromptHook) Transform(text string) string {
 	return strings.ReplaceAll(text, h.Find, h.Replace)
 }
@@ -19,6 +20,7 @@ func (h PromptHook) Transform(text string) string {
 // on hot paths (per prompt build) to avoid GC pressure.
 type PromptHookChain []PromptHook
 
+// Transform applies all hooks in order.
 func (c PromptHookChain) Transform(text string) string {
 	for _, h := range c {
 		text = h.Transform(text)

--- a/internal/hooks/prompt.go
+++ b/internal/hooks/prompt.go
@@ -1,0 +1,31 @@
+package hooks
+
+import "strings"
+
+// PromptHook applies a find/replace transformation to a prompt string.
+// Used for pre_prompt and post_response hooks that modify the system
+// prompt or model output without requiring external commands.
+type PromptHook struct {
+	Find    string
+	Replace string
+}
+
+// Transform applies the find/replace to the input text.
+func (h PromptHook) Transform(text string) string {
+	return strings.ReplaceAll(text, h.Find, h.Replace)
+}
+
+// PromptHookChain applies multiple prompt hooks in sequence.
+//
+// Warning: each hook creates a new string via strings.ReplaceAll, so
+// chaining many hooks on long prompts is O(n*m). Use sparingly on
+// hot paths (e.g., limit to 3 hooks per prompt build).
+type PromptHookChain []PromptHook
+
+// Transform applies all hooks in order.
+func (c PromptHookChain) Transform(text string) string {
+	for _, h := range c {
+		text = h.Transform(text)
+	}
+	return text
+}

--- a/internal/hooks/prompt.go
+++ b/internal/hooks/prompt.go
@@ -2,27 +2,23 @@ package hooks
 
 import "strings"
 
-// PromptHook applies a find/replace transformation to a prompt string.
-// Used for pre_prompt and post_response hooks that modify the system
-// prompt or model output without requiring external commands.
+// PromptHook modifies prompts via find/replace without external commands.
+// Used for pre_prompt and post_response lifecycle events.
 type PromptHook struct {
 	Find    string
 	Replace string
 }
 
-// Transform applies the find/replace to the input text.
 func (h PromptHook) Transform(text string) string {
 	return strings.ReplaceAll(text, h.Find, h.Replace)
 }
 
-// PromptHookChain applies multiple prompt hooks in sequence.
+// PromptHookChain runs multiple hooks in order.
 //
-// Warning: each hook creates a new string via strings.ReplaceAll, so
-// chaining many hooks on long prompts is O(n*m). Use sparingly on
-// hot paths (e.g., limit to 3 hooks per prompt build).
+// Warning: O(n*m) — each hook allocates a new string. Limit to 3 hooks
+// on hot paths (per prompt build) to avoid GC pressure.
 type PromptHookChain []PromptHook
 
-// Transform applies all hooks in order.
 func (c PromptHookChain) Transform(text string) string {
 	for _, h := range c {
 		text = h.Transform(text)

--- a/internal/hooks/prompt_test.go
+++ b/internal/hooks/prompt_test.go
@@ -1,0 +1,36 @@
+package hooks
+
+import "testing"
+
+func TestPromptHook(t *testing.T) {
+	hook := PromptHook{
+		Find:    "OLD",
+		Replace: "NEW",
+	}
+	result := hook.Transform("hello OLD world")
+	if result != "hello NEW world" {
+		t.Errorf("expected 'hello NEW world', got %q", result)
+	}
+}
+
+func TestPromptHook_NoMatch(t *testing.T) {
+	hook := PromptHook{
+		Find:    "MISSING",
+		Replace: "NEW",
+	}
+	result := hook.Transform("hello world")
+	if result != "hello world" {
+		t.Errorf("expected unchanged text, got %q", result)
+	}
+}
+
+func TestPromptHookChain(t *testing.T) {
+	chain := PromptHookChain{
+		{Find: "A", Replace: "B"},
+		{Find: "B", Replace: "C"},
+	}
+	result := chain.Transform("A")
+	if result != "C" {
+		t.Errorf("expected 'C', got %q", result)
+	}
+}

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -19,18 +19,47 @@ const defaultTimeout = 30 * time.Second
 
 // Event name constants for user-facing hook event configuration.
 const (
-	EventPreTool       = "pre_tool"
-	EventPostTool      = "post_tool"
-	EventPreEdit       = "pre_edit"
-	EventPostEdit      = "post_edit"
-	EventPreShell      = "pre_shell"
-	EventPrePrompt     = "pre_prompt"
-	EventPostResponse  = "post_response"
-	EventSessionStart  = "session_start"
-	EventSetup         = "setup"
-	EventTaskCreated   = "task_created"
-	EventTaskCompleted = "task_completed"
+	EventPreTool           = "pre_tool"
+	EventPostTool          = "post_tool"
+	EventPostToolFailure   = "post_tool_failure"
+	EventPreEdit           = "pre_edit"
+	EventPostEdit          = "post_edit"
+	EventPreShell          = "pre_shell"
+	EventPrePrompt         = "pre_prompt"
+	EventPostResponse      = "post_response"
+	EventSessionStart      = "session_start"
+	EventSessionEnd        = "session_end"
+	EventSetup             = "setup"
+	EventTaskCreated       = "task_created"
+	EventTaskCompleted     = "task_completed"
+	EventPermissionRequest = "permission_request"
+	EventPermissionDenied  = "permission_denied"
+	EventPreCompact        = "pre_compact"
+	EventPostCompact       = "post_compact"
+	EventSubagentStart     = "subagent_start"
+	EventSubagentStop      = "subagent_stop"
+	EventNotification      = "notification"
+	EventConfigChange      = "config_change"
+	EventCwdChanged        = "cwd_changed"
+	EventFileChanged       = "file_changed"
 )
+
+// AllEvents returns the complete list of supported hook events.
+func AllEvents() []string {
+	return []string{
+		EventPreTool, EventPostTool, EventPostToolFailure,
+		EventPreEdit, EventPostEdit,
+		EventPreShell,
+		EventPrePrompt, EventPostResponse,
+		EventSessionStart, EventSessionEnd, EventSetup,
+		EventTaskCreated, EventTaskCompleted,
+		EventPermissionRequest, EventPermissionDenied,
+		EventPreCompact, EventPostCompact,
+		EventSubagentStart, EventSubagentStop,
+		EventNotification,
+		EventConfigChange, EventCwdChanged, EventFileChanged,
+	}
+}
 
 // ParseHookTimeout parses a duration string, returning defaultTimeout (30s)
 // if the string is empty or unparseable.
@@ -44,12 +73,14 @@ func ParseHookTimeout(s string) time.Duration {
 	return defaultTimeout
 }
 
-// UserHookConfig describes a single user-configured shell hook entry.
+// UserHookConfig describes a single user-configured hook entry.
+// Exactly one of Command or URL must be set.
 type UserHookConfig struct {
 	Event       string
 	Pattern     string
 	If          string
 	Command     string
+	URL         string
 	Description string
 	Timeout     time.Duration
 	Source      string

--- a/internal/permissions/classifier.go
+++ b/internal/permissions/classifier.go
@@ -62,11 +62,7 @@ func (c *YOLOClassifier) Classify(toolName string, input map[string]interface{})
 	}
 
 	// Stage 1: Fast heuristic check (works even without provider).
-	decision, err := c.stage1(toolName, input)
-	if err != nil {
-		c.recordDenial()
-		return c.fallbackIfNeeded(agentsdk.ApprovalRequired)
-	}
+	decision := c.stage1(toolName, input)
 
 	var result agentsdk.ApprovalResult
 	switch decision {
@@ -80,8 +76,9 @@ func (c *YOLOClassifier) Classify(toolName string, input map[string]interface{})
 		if c.prov == nil {
 			result = agentsdk.ApprovalRequired
 		} else {
-			result, err = c.stage2(toolName, input)
-			if err != nil {
+			var stage2Err error
+			result, stage2Err = c.stage2(toolName, input)
+			if stage2Err != nil {
 				result = agentsdk.ApprovalRequired
 			}
 		}
@@ -127,16 +124,16 @@ func (c *YOLOClassifier) shouldFallback() bool {
 // When a provider is available, this would use a constrained completion
 // with a small token budget (fastMax). Without a provider, it falls back
 // to tool name substring heuristics.
-func (c *YOLOClassifier) stage1(toolName string, input map[string]interface{}) (ClassifierDecision, error) {
+func (c *YOLOClassifier) stage1(toolName string, input map[string]interface{}) ClassifierDecision {
 	_ = c.fastMax
 	_ = input
 
 	// Heuristic fallback: tools with dangerous keywords need stage 2.
 	if strings.Contains(toolName, "write") || strings.Contains(toolName, "edit") ||
 		strings.Contains(toolName, "delete") || strings.Contains(toolName, "shell") {
-		return DecisionUncertain, nil
+		return DecisionUncertain
 	}
-	return DecisionSafe, nil
+	return DecisionSafe
 }
 
 // stage2 performs detailed analysis for borderline cases.

--- a/internal/permissions/classifier.go
+++ b/internal/permissions/classifier.go
@@ -1,0 +1,178 @@
+package permissions
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// safeToolAllowlist contains tools that are unconditionally safe and bypass
+// the LLM classifier. These are read-only or information-query tools.
+// Kept unexported to prevent external mutation; use isSafeTool().
+var safeToolAllowlist = map[string]struct{}{
+	"read_file": {}, "grep": {}, "glob": {}, "list_dir": {},
+	"code_search": {}, "view": {}, "ls": {}, "cat": {},
+	"find": {}, "search": {},
+	"git_status": {}, "git_diff": {}, "git_log": {}, "git_show": {},
+	"browser_snapshot": {}, "http_get": {}, "web_fetch": {},
+	"lsp_diagnostics": {}, "lsp_hover": {}, "lsp_definition": {},
+	"lsp_references": {},
+}
+
+// isSafeTool reports whether a tool is in the safe-tool allowlist.
+func isSafeTool(toolName string) bool {
+	_, ok := safeToolAllowlist[toolName]
+	return ok
+}
+
+// ClassifierDecision is the outcome of the LLM safety classifier.
+type ClassifierDecision int
+
+const (
+	DecisionUnknown ClassifierDecision = iota
+	DecisionSafe
+	DecisionUnsafe
+	DecisionUncertain
+)
+
+// YOLOClassifier is a two-stage LLM-based safety classifier for auto-approval
+// mode. It evaluates whether a tool operation is safe to execute without
+// user confirmation.
+type YOLOClassifier struct {
+	prov                  agentsdk.LLMProvider
+	fastMax               int // max tokens for stage 1 (default 64)
+	slowMax               int // max tokens for stage 2 (default 4096)
+	consecutiveDenials    int
+	maxConsecutiveDenials int
+	mu                    sync.Mutex
+}
+
+// NewYOLOClassifier creates a classifier with the given provider.
+// If provider is nil, all non-allowlist tools return ApprovalRequired.
+func NewYOLOClassifier(prov agentsdk.LLMProvider, fastMax, slowMax int) *YOLOClassifier {
+	if fastMax <= 0 {
+		fastMax = 64
+	}
+	if slowMax <= 0 {
+		slowMax = 4096
+	}
+	return &YOLOClassifier{
+		prov:    prov,
+		fastMax: fastMax,
+		slowMax: slowMax,
+	}
+}
+
+// SetMaxConsecutiveDenials sets the threshold for consecutive denials before
+// falling back to manual approval. Zero disables the fallback.
+func (c *YOLOClassifier) SetMaxConsecutiveDenials(n int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.maxConsecutiveDenials = n
+}
+
+// Classify evaluates a tool call and returns an approval decision.
+// Safe-tool allowlist bypasses classification entirely.
+func (c *YOLOClassifier) Classify(toolName string, input map[string]interface{}) (agentsdk.ApprovalResult, error) {
+	if isSafeTool(toolName) {
+		c.resetDenials()
+		return agentsdk.AutoApproved, nil
+	}
+
+	// Stage 1: Fast check (works even without provider).
+	decision, err := c.stage1(toolName, input)
+	if err != nil {
+		c.recordDenial()
+		return agentsdk.ApprovalRequired, nil
+	}
+
+	var result agentsdk.ApprovalResult
+	switch decision {
+	case DecisionSafe:
+		c.resetDenials()
+		return agentsdk.AutoApproved, nil
+	case DecisionUnsafe:
+		c.recordDenial()
+		result = agentsdk.AutoDenied
+	case DecisionUncertain:
+		// Stage 2: Detailed analysis (requires provider).
+		if c.prov == nil {
+			c.recordDenial()
+			result = agentsdk.ApprovalRequired
+		} else {
+			result, err = c.stage2(toolName, input)
+			if err != nil {
+				result = agentsdk.ApprovalRequired
+			}
+		}
+	}
+
+	if result == agentsdk.AutoApproved {
+		c.resetDenials()
+	} else {
+		c.recordDenial()
+	}
+
+	// Fallback to manual approval after too many consecutive denials.
+	if c.shouldFallback() {
+		return agentsdk.ApprovalRequired, nil
+	}
+
+	return result, nil
+}
+
+func (c *YOLOClassifier) resetDenials() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.consecutiveDenials = 0
+}
+
+func (c *YOLOClassifier) recordDenial() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.consecutiveDenials++
+}
+
+func (c *YOLOClassifier) shouldFallback() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.maxConsecutiveDenials > 0 && c.consecutiveDenials >= c.maxConsecutiveDenials
+}
+
+// stage1 is a fast check that classifies obvious cases.
+func (c *YOLOClassifier) stage1(toolName string, input map[string]interface{}) (ClassifierDecision, error) {
+	_ = c.fastMax
+	_ = input
+
+	// Use provider for a short completion.
+	// Simplified: in practice this would use a constrained completion.
+	// Mock implementation: classify based on tool name heuristics.
+	if strings.Contains(toolName, "write") || strings.Contains(toolName, "edit") ||
+		strings.Contains(toolName, "delete") || strings.Contains(toolName, "shell") {
+		return DecisionUncertain, nil
+	}
+	return DecisionSafe, nil
+}
+
+// stage2 is a detailed analysis for borderline cases.
+func (c *YOLOClassifier) stage2(toolName string, input map[string]interface{}) (agentsdk.ApprovalResult, error) {
+	_ = c.slowMax
+	_ = toolName
+	_ = input
+
+	// Detailed prompt with reasoning would go here.
+	// Mock: for now, require approval for all uncertain cases.
+	return agentsdk.ApprovalRequired, nil
+}
+
+// Ensure YOLOClassifier implements the interface needed for context.
+var _ = context.Background
+
+//nolint:unused
+func formatStage2Prompt(toolName string, input map[string]interface{}) string {
+	return fmt.Sprintf("Analyze if this tool is safe to auto-approve.\nTool: %s\nInput: %v\n\nReply with:\n<thinking> reasoning </thinking>\n<decision> ALLOW or DENY </decision>",
+		toolName, input)
+}

--- a/internal/permissions/classifier.go
+++ b/internal/permissions/classifier.go
@@ -121,9 +121,8 @@ func (c *YOLOClassifier) shouldFallback() bool {
 }
 
 // stage1 is a fast heuristic check that classifies obvious cases.
-// When a provider is available, this would use a constrained completion
-// with a small token budget (fastMax). Without a provider, it falls back
-// to tool name substring heuristics.
+// TODO: When a provider is available, use a constrained completion with
+// fastMax tokens instead of substring heuristics.
 func (c *YOLOClassifier) stage1(toolName string, input map[string]interface{}) ClassifierDecision {
 	_ = c.fastMax
 	_ = input
@@ -137,8 +136,8 @@ func (c *YOLOClassifier) stage1(toolName string, input map[string]interface{}) C
 }
 
 // stage2 performs detailed analysis for borderline cases.
-// Currently a placeholder — when a provider is available, this will send
-// a structured prompt (see stage2PromptFormat) and parse the response.
+// TODO: Implement LLM-based reasoning when a provider is available.
+// Currently a placeholder — always requires manual approval.
 func (c *YOLOClassifier) stage2(toolName string, input map[string]interface{}) (agentsdk.ApprovalResult, error) {
 	_ = c.slowMax
 	_ = toolName

--- a/internal/permissions/classifier.go
+++ b/internal/permissions/classifier.go
@@ -1,32 +1,11 @@
 package permissions
 
 import (
-	"context"
-	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
-
-// safeToolAllowlist contains tools that are unconditionally safe and bypass
-// the LLM classifier. These are read-only or information-query tools.
-// Kept unexported to prevent external mutation; use isSafeTool().
-var safeToolAllowlist = map[string]struct{}{
-	"read_file": {}, "grep": {}, "glob": {}, "list_dir": {},
-	"code_search": {}, "view": {}, "ls": {}, "cat": {},
-	"find": {}, "search": {},
-	"git_status": {}, "git_diff": {}, "git_log": {}, "git_show": {},
-	"browser_snapshot": {}, "http_get": {}, "web_fetch": {},
-	"lsp_diagnostics": {}, "lsp_hover": {}, "lsp_definition": {},
-	"lsp_references": {},
-}
-
-// isSafeTool reports whether a tool is in the safe-tool allowlist.
-func isSafeTool(toolName string) bool {
-	_, ok := safeToolAllowlist[toolName]
-	return ok
-}
 
 // ClassifierDecision is the outcome of the LLM safety classifier.
 type ClassifierDecision int
@@ -77,7 +56,7 @@ func (c *YOLOClassifier) SetMaxConsecutiveDenials(n int) {
 // Classify evaluates a tool call and returns an approval decision.
 // Safe-tool allowlist bypasses classification entirely.
 func (c *YOLOClassifier) Classify(toolName string, input map[string]interface{}) (agentsdk.ApprovalResult, error) {
-	if isSafeTool(toolName) {
+	if isReadOnlyTool(toolName) {
 		c.resetDenials()
 		return agentsdk.AutoApproved, nil
 	}
@@ -168,11 +147,14 @@ func (c *YOLOClassifier) stage2(toolName string, input map[string]interface{}) (
 	return agentsdk.ApprovalRequired, nil
 }
 
-// Ensure YOLOClassifier implements the interface needed for context.
-var _ = context.Background
-
+// stage2PromptFormat is the prompt template for detailed safety analysis.
+// Reserved for future use when stage2 is implemented with LLM reasoning.
+//
 //nolint:unused
-func formatStage2Prompt(toolName string, input map[string]interface{}) string {
-	return fmt.Sprintf("Analyze if this tool is safe to auto-approve.\nTool: %s\nInput: %v\n\nReply with:\n<thinking> reasoning </thinking>\n<decision> ALLOW or DENY </decision>",
-		toolName, input)
-}
+const stage2PromptFormat = `Analyze if this tool is safe to auto-approve.
+Tool: %s
+Input: %v
+
+Reply with:
+<thinking> reasoning </thinking>
+<decision> ALLOW or DENY </decision>`

--- a/internal/permissions/classifier.go
+++ b/internal/permissions/classifier.go
@@ -61,11 +61,11 @@ func (c *YOLOClassifier) Classify(toolName string, input map[string]interface{})
 		return agentsdk.AutoApproved, nil
 	}
 
-	// Stage 1: Fast check (works even without provider).
+	// Stage 1: Fast heuristic check (works even without provider).
 	decision, err := c.stage1(toolName, input)
 	if err != nil {
 		c.recordDenial()
-		return agentsdk.ApprovalRequired, nil
+		return c.fallbackIfNeeded(agentsdk.ApprovalRequired)
 	}
 
 	var result agentsdk.ApprovalResult
@@ -74,12 +74,10 @@ func (c *YOLOClassifier) Classify(toolName string, input map[string]interface{})
 		c.resetDenials()
 		return agentsdk.AutoApproved, nil
 	case DecisionUnsafe:
-		c.recordDenial()
 		result = agentsdk.AutoDenied
 	case DecisionUncertain:
 		// Stage 2: Detailed analysis (requires provider).
 		if c.prov == nil {
-			c.recordDenial()
 			result = agentsdk.ApprovalRequired
 		} else {
 			result, err = c.stage2(toolName, input)
@@ -95,11 +93,15 @@ func (c *YOLOClassifier) Classify(toolName string, input map[string]interface{})
 		c.recordDenial()
 	}
 
-	// Fallback to manual approval after too many consecutive denials.
+	return c.fallbackIfNeeded(result)
+}
+
+// fallbackIfNeeded returns ApprovalRequired if consecutive denials exceed
+// the threshold, otherwise returns the given result.
+func (c *YOLOClassifier) fallbackIfNeeded(result agentsdk.ApprovalResult) (agentsdk.ApprovalResult, error) {
 	if c.shouldFallback() {
 		return agentsdk.ApprovalRequired, nil
 	}
-
 	return result, nil
 }
 
@@ -121,14 +123,15 @@ func (c *YOLOClassifier) shouldFallback() bool {
 	return c.maxConsecutiveDenials > 0 && c.consecutiveDenials >= c.maxConsecutiveDenials
 }
 
-// stage1 is a fast check that classifies obvious cases.
+// stage1 is a fast heuristic check that classifies obvious cases.
+// When a provider is available, this would use a constrained completion
+// with a small token budget (fastMax). Without a provider, it falls back
+// to tool name substring heuristics.
 func (c *YOLOClassifier) stage1(toolName string, input map[string]interface{}) (ClassifierDecision, error) {
 	_ = c.fastMax
 	_ = input
 
-	// Use provider for a short completion.
-	// Simplified: in practice this would use a constrained completion.
-	// Mock implementation: classify based on tool name heuristics.
+	// Heuristic fallback: tools with dangerous keywords need stage 2.
 	if strings.Contains(toolName, "write") || strings.Contains(toolName, "edit") ||
 		strings.Contains(toolName, "delete") || strings.Contains(toolName, "shell") {
 		return DecisionUncertain, nil
@@ -136,25 +139,14 @@ func (c *YOLOClassifier) stage1(toolName string, input map[string]interface{}) (
 	return DecisionSafe, nil
 }
 
-// stage2 is a detailed analysis for borderline cases.
+// stage2 performs detailed analysis for borderline cases.
+// Currently a placeholder — when a provider is available, this will send
+// a structured prompt (see stage2PromptFormat) and parse the response.
 func (c *YOLOClassifier) stage2(toolName string, input map[string]interface{}) (agentsdk.ApprovalResult, error) {
 	_ = c.slowMax
 	_ = toolName
 	_ = input
 
-	// Detailed prompt with reasoning would go here.
-	// Mock: for now, require approval for all uncertain cases.
+	// Placeholder: always require approval until LLM integration is wired.
 	return agentsdk.ApprovalRequired, nil
 }
-
-// stage2PromptFormat is the prompt template for detailed safety analysis.
-// Reserved for future use when stage2 is implemented with LLM reasoning.
-//
-//nolint:unused
-const stage2PromptFormat = `Analyze if this tool is safe to auto-approve.
-Tool: %s
-Input: %v
-
-Reply with:
-<thinking> reasoning </thinking>
-<decision> ALLOW or DENY </decision>`

--- a/internal/permissions/classifier_test.go
+++ b/internal/permissions/classifier_test.go
@@ -1,6 +1,7 @@
 package permissions
 
 import (
+	"context"
 	"testing"
 
 	"github.com/julianshen/rubichan/pkg/agentsdk"
@@ -88,5 +89,26 @@ func TestYOLOClassifier_Stage1Heuristics(t *testing.T) {
 	result, _ = c.Classify("some_info_tool", nil)
 	if result != agentsdk.AutoApproved {
 		t.Errorf("expected AutoApproved for unknown safe tool, got %v", result)
+	}
+}
+
+// mockProvider is a minimal LLMProvider for testing stage2.
+type mockProvider struct{}
+
+func (m *mockProvider) Stream(ctx context.Context, req agentsdk.CompletionRequest) (<-chan agentsdk.StreamEvent, error) {
+	return nil, nil
+}
+
+func TestYOLOClassifier_Stage2_WithProvider(t *testing.T) {
+	// With a provider, stage2 is called for uncertain tools.
+	// Since stage2 is currently a placeholder, it returns ApprovalRequired.
+	c := NewYOLOClassifier(&mockProvider{}, 0, 0)
+
+	result, err := c.Classify("write_file", map[string]interface{}{"path": "test.go"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != agentsdk.ApprovalRequired {
+		t.Errorf("expected ApprovalRequired from placeholder stage2, got %v", result)
 	}
 }

--- a/internal/permissions/classifier_test.go
+++ b/internal/permissions/classifier_test.go
@@ -1,0 +1,92 @@
+package permissions
+
+import (
+	"testing"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+func TestYOLOClassifier_SafeToolBypass(t *testing.T) {
+	c := NewYOLOClassifier(nil, 0, 0) // no provider needed for bypass
+
+	// read_file is in the safe-tool allowlist
+	result, err := c.Classify("read_file", map[string]interface{}{"path": "/etc/passwd"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != agentsdk.AutoApproved {
+		t.Errorf("expected AutoApproved for safe tool, got %v", result)
+	}
+}
+
+func TestYOLOClassifier_UnsafeToolWithoutProvider(t *testing.T) {
+	c := NewYOLOClassifier(nil, 0, 0)
+
+	result, err := c.Classify("write_file", map[string]interface{}{"path": "/etc/passwd"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != agentsdk.ApprovalRequired {
+		t.Errorf("expected ApprovalRequired without provider, got %v", result)
+	}
+}
+
+func TestYOLOClassifier_ConsecutiveDenialFallback(t *testing.T) {
+	c := NewYOLOClassifier(nil, 0, 0)
+	c.SetMaxConsecutiveDenials(3)
+
+	// First 3 denials: classifier returns ApprovalRequired.
+	for i := 0; i < 3; i++ {
+		result, _ := c.Classify("shell", nil)
+		if result != agentsdk.ApprovalRequired {
+			t.Errorf("iteration %d: expected ApprovalRequired, got %v", i, result)
+		}
+	}
+
+	// 4th call: consecutive denials == 3 == max, so fallback triggers.
+	result, _ := c.Classify("shell", nil)
+	if result != agentsdk.ApprovalRequired {
+		t.Errorf("iteration 3: expected ApprovalRequired (fallback), got %v", result)
+	}
+}
+
+func TestYOLOClassifier_ResetDenialsOnSafeTool(t *testing.T) {
+	c := NewYOLOClassifier(nil, 0, 0)
+	c.SetMaxConsecutiveDenials(3)
+
+	// 2 denials
+	_, _ = c.Classify("shell", nil)
+	_, _ = c.Classify("shell", nil)
+
+	// Safe tool resets counter
+	_, _ = c.Classify("read_file", nil)
+
+	// Another 2 denials — should not trigger fallback since counter was reset
+	_, _ = c.Classify("shell", nil)
+	result, _ := c.Classify("shell", nil)
+	if result != agentsdk.ApprovalRequired {
+		t.Errorf("expected ApprovalRequired after reset, got %v", result)
+	}
+}
+
+func TestYOLOClassifier_Stage1Heuristics(t *testing.T) {
+	c := NewYOLOClassifier(nil, 0, 0)
+
+	// Tools with "write" in name should be uncertain -> ApprovalRequired
+	result, _ := c.Classify("write_file", nil)
+	if result != agentsdk.ApprovalRequired {
+		t.Errorf("expected ApprovalRequired for write tool, got %v", result)
+	}
+
+	// Tools with "shell" in name should be uncertain -> ApprovalRequired
+	result, _ = c.Classify("shell", nil)
+	if result != agentsdk.ApprovalRequired {
+		t.Errorf("expected ApprovalRequired for shell tool, got %v", result)
+	}
+
+	// Unknown tools without dangerous keywords should be safe
+	result, _ = c.Classify("some_info_tool", nil)
+	if result != agentsdk.AutoApproved {
+		t.Errorf("expected AutoApproved for unknown safe tool, got %v", result)
+	}
+}

--- a/internal/permissions/mode_checker.go
+++ b/internal/permissions/mode_checker.go
@@ -7,19 +7,25 @@ import (
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
+// safeToolAllowlist contains tools that are unconditionally safe and bypass
+// the LLM classifier. These tools are read-only or information-query tools.
+// Kept unexported to prevent external mutation.
+var safeToolAllowlist = map[string]struct{}{
+	"read_file": {}, "grep": {}, "glob": {}, "list_dir": {},
+	"code_search": {}, "view": {}, "ls": {}, "cat": {},
+	"find": {}, "search": {},
+	"git_status": {}, "git_diff": {}, "git_log": {}, "git_show": {},
+	"browser_snapshot": {}, "http_get": {}, "web_fetch": {},
+	"lsp_diagnostics": {}, "lsp_hover": {}, "lsp_definition": {},
+	"lsp_references": {},
+}
+
 // isReadOnlyTool reports whether a tool is safe to auto-approve when no
 // explicit policy matches. These tools are read-only by convention; any
 // addition here must be vetted for side effects.
 func isReadOnlyTool(tool string) bool {
-	switch tool {
-	case "read_file", "grep", "glob", "list_dir", "code_search", "view",
-		"ls", "cat", "find", "search",
-		"git_status", "git_diff", "git_log", "git_show",
-		"browser_snapshot", "http_get", "web_fetch",
-		"lsp_diagnostics", "lsp_hover", "lsp_definition", "lsp_references":
-		return true
-	}
-	return false
+	_, ok := safeToolAllowlist[tool]
+	return ok
 }
 
 // ModeAwareChecker is a decorator: it only changes behavior when the wrapped

--- a/internal/permissions/mode_checker.go
+++ b/internal/permissions/mode_checker.go
@@ -26,16 +26,27 @@ func isReadOnlyTool(tool string) bool {
 // checker returns ApprovalRequired. Deny and explicit-approval results pass
 // through unchanged.
 type ModeAwareChecker struct {
-	mode      agentsdk.PermissionMode
-	checker   agentsdk.ApprovalChecker
-	explainer agentsdk.Explainer
+	mode       agentsdk.PermissionMode
+	checker    agentsdk.ApprovalChecker
+	explainer  agentsdk.Explainer
+	classifier *YOLOClassifier // nil when not in auto mode
+}
+
+// ModeAwareOption configures a ModeAwareChecker.
+type ModeAwareOption func(*ModeAwareChecker)
+
+// WithClassifier attaches a YOLOClassifier for ModeAuto decision support.
+func WithClassifier(classifier *YOLOClassifier) ModeAwareOption {
+	return func(c *ModeAwareChecker) {
+		c.classifier = classifier
+	}
 }
 
 // NewModeAwareChecker creates a ModeAwareChecker with the given mode and
 // underlying checker. Bypass mode disables all safety checks; the warning
 // gives operators an audit trail but callers must check the mode field if
 // they need to know bypass is active.
-func NewModeAwareChecker(mode agentsdk.PermissionMode, checker agentsdk.ApprovalChecker) *ModeAwareChecker {
+func NewModeAwareChecker(mode agentsdk.PermissionMode, checker agentsdk.ApprovalChecker, opts ...ModeAwareOption) *ModeAwareChecker {
 	if mode == agentsdk.ModeBypass {
 		log.Println("WARNING: permission mode is 'bypass' — all tools will be auto-approved. Use with caution.")
 	}
@@ -43,7 +54,11 @@ func NewModeAwareChecker(mode agentsdk.PermissionMode, checker agentsdk.Approval
 	if e, ok := checker.(agentsdk.Explainer); ok {
 		explainer = e
 	}
-	return &ModeAwareChecker{mode: mode, checker: checker, explainer: explainer}
+	c := &ModeAwareChecker{mode: mode, checker: checker, explainer: explainer}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // CheckApproval evaluates the underlying checker, then applies mode logic
@@ -73,6 +88,17 @@ func (c *ModeAwareChecker) CheckApproval(tool string, input json.RawMessage) age
 		// UX messaging, not policy logic.
 		if isReadOnlyTool(tool) {
 			return agentsdk.AutoApproved
+		}
+		// In ModeAuto, use the LLM classifier for additional safety.
+		if c.mode == agentsdk.ModeAuto && c.classifier != nil {
+			var parsedInput map[string]interface{}
+			if len(input) > 0 {
+				_ = json.Unmarshal(input, &parsedInput)
+			}
+			decision, err := c.classifier.Classify(tool, parsedInput)
+			if err == nil && decision == agentsdk.AutoApproved {
+				return agentsdk.AutoApproved
+			}
 		}
 		return agentsdk.ApprovalRequired
 	default:

--- a/internal/permissions/mode_checker.go
+++ b/internal/permissions/mode_checker.go
@@ -99,7 +99,11 @@ func (c *ModeAwareChecker) CheckApproval(tool string, input json.RawMessage) age
 		if c.mode == agentsdk.ModeAuto && c.classifier != nil {
 			var parsedInput map[string]interface{}
 			if len(input) > 0 {
-				_ = json.Unmarshal(input, &parsedInput)
+				if err := json.Unmarshal(input, &parsedInput); err != nil {
+					// Malformed input: classifier can't evaluate, fall through to
+					// manual approval rather than making a blind decision.
+					parsedInput = nil
+				}
 			}
 			decision, err := c.classifier.Classify(tool, parsedInput)
 			if err == nil && decision == agentsdk.AutoApproved {

--- a/internal/toolexec/batch.go
+++ b/internal/toolexec/batch.go
@@ -17,8 +17,7 @@ type ToolBatch struct {
 }
 
 // partitionToolCalls groups adjacent tool calls into batches.
-// Consecutive concurrency-safe tools share a batch; the first unsafe
-// tool breaks the batch and starts a new sequential batch.
+// Preserves LLM call order; only affects parallelism vs sequentiality.
 func partitionToolCalls(lookup ToolLookup, calls []ToolCall) []ToolBatch {
 	if len(calls) == 0 {
 		return []ToolBatch{}
@@ -29,13 +28,7 @@ func partitionToolCalls(lookup ToolLookup, calls []ToolCall) []ToolBatch {
 
 	for _, tc := range calls {
 		tool, ok := lookup.Get(tc.Name)
-		if !ok {
-			// Unknown tools are treated as unsafe (fail-closed).
-			isSafe := false
-			_ = isSafe
-		}
-
-		isSafe := isConcurrencySafe(tool, tc.Input)
+		isSafe := ok && isConcurrencySafe(tool, tc.Input)
 
 		if len(current.Calls) == 0 {
 			current.IsConcurrent = isSafe

--- a/internal/toolexec/batch.go
+++ b/internal/toolexec/batch.go
@@ -51,18 +51,18 @@ func partitionToolCalls(lookup ToolLookup, calls []ToolCall) []ToolBatch {
 }
 
 // isConcurrencySafe reports whether a tool can run in parallel with other
-// tools. Unknown tools and tools without the marker interface return false
-// (fail-closed).
+// tools for the given input. Unknown tools and tools without the marker
+// interface return false (fail-closed).
 func isConcurrencySafe(tool agentsdk.Tool, input json.RawMessage) bool {
 	if tool == nil {
 		return false
 	}
-	// Check the cheaper static interface first to avoid JSON parsing
-	// for tools that don't need per-invocation discrimination.
+	// Per-input safety takes precedence over static safety.
+	if ics, ok := tool.(agentsdk.InputConcurrencySafeTool); ok {
+		return ics.IsConcurrencySafeForInput(input)
+	}
+	// Fall back to static declaration.
 	if cs, ok := tool.(agentsdk.ConcurrencySafeTool); ok {
-		if ics, ok := tool.(agentsdk.InputConcurrencySafeTool); ok {
-			return ics.IsConcurrencySafeForInput(input)
-		}
 		return cs.IsConcurrencySafe()
 	}
 	return false

--- a/internal/toolexec/batch.go
+++ b/internal/toolexec/batch.go
@@ -136,7 +136,6 @@ func (be *BatchExecutor) executeConcurrently(ctx context.Context, calls []ToolCa
 	return results
 }
 
-// executeSerially runs calls one at a time in the caller's goroutine.
 func (be *BatchExecutor) executeSerially(ctx context.Context, calls []ToolCall) []Result {
 	results := make([]Result, 0, len(calls))
 	for _, tc := range calls {

--- a/internal/toolexec/batch.go
+++ b/internal/toolexec/batch.go
@@ -9,7 +9,8 @@ import (
 )
 
 // ToolBatch groups consecutive tool calls with the same concurrency safety.
-// Preserving the LLM's call order while allowing safe tools to run concurrently.
+// The agent preserves the LLM's call order; batching only affects which
+// tools run in parallel versus sequentially.
 type ToolBatch struct {
 	IsConcurrent bool
 	Calls        []ToolCall
@@ -20,7 +21,7 @@ type ToolBatch struct {
 // tool breaks the batch and starts a new sequential batch.
 func partitionToolCalls(lookup ToolLookup, calls []ToolCall) []ToolBatch {
 	if len(calls) == 0 {
-		return nil
+		return []ToolBatch{}
 	}
 
 	batches := make([]ToolBatch, 0, len(calls))
@@ -30,7 +31,8 @@ func partitionToolCalls(lookup ToolLookup, calls []ToolCall) []ToolBatch {
 		tool, ok := lookup.Get(tc.Name)
 		if !ok {
 			// Unknown tools are treated as unsafe (fail-closed).
-			tool = nil
+			isSafe := false
+			_ = isSafe
 		}
 
 		isSafe := isConcurrencySafe(tool, tc.Input)
@@ -58,13 +60,12 @@ func partitionToolCalls(lookup ToolLookup, calls []ToolCall) []ToolBatch {
 // isConcurrencySafe reports whether a tool can run in parallel with other
 // tools. Unknown tools and tools without the marker interface return false
 // (fail-closed).
-//
-// The cheaper ConcurrencySafeTool check comes first to avoid JSON
-// parsing for tools that don't need per-invocation discrimination.
 func isConcurrencySafe(tool agentsdk.Tool, input json.RawMessage) bool {
 	if tool == nil {
 		return false
 	}
+	// Check the cheaper static interface first to avoid JSON parsing
+	// for tools that don't need per-invocation discrimination.
 	if cs, ok := tool.(agentsdk.ConcurrencySafeTool); ok {
 		if ics, ok := tool.(agentsdk.InputConcurrencySafeTool); ok {
 			return ics.IsConcurrencySafeForInput(input)
@@ -80,10 +81,9 @@ const defaultMaxParallel = 10
 // BatchExecutor runs tool calls in batches, parallelizing safe batches
 // and serializing unsafe batches.
 type BatchExecutor struct {
-	lookup      ToolLookup
-	handler     HandlerFunc
-	maxParallel int
-	sem         chan struct{}
+	lookup  ToolLookup
+	handler HandlerFunc
+	sem     chan struct{}
 }
 
 // NewBatchExecutor creates a batch executor with the given lookup,
@@ -93,10 +93,9 @@ func NewBatchExecutor(lookup ToolLookup, handler HandlerFunc, maxParallel int) *
 		maxParallel = defaultMaxParallel
 	}
 	return &BatchExecutor{
-		lookup:      lookup,
-		handler:     handler,
-		maxParallel: maxParallel,
-		sem:         make(chan struct{}, maxParallel),
+		lookup:  lookup,
+		handler: handler,
+		sem:     make(chan struct{}, maxParallel),
 	}
 }
 
@@ -115,6 +114,9 @@ func (be *BatchExecutor) Execute(ctx context.Context, calls []ToolCall) []Result
 	return results
 }
 
+// executeConcurrently runs calls with bounded parallelism. At most
+// maxParallel goroutines execute handlers simultaneously; excess calls
+// block on the semaphore until a slot frees.
 func (be *BatchExecutor) executeConcurrently(ctx context.Context, calls []ToolCall) []Result {
 	var wg sync.WaitGroup
 	results := make([]Result, len(calls))
@@ -141,6 +143,7 @@ func (be *BatchExecutor) executeConcurrently(ctx context.Context, calls []ToolCa
 	return results
 }
 
+// executeSerially runs calls one at a time in the caller's goroutine.
 func (be *BatchExecutor) executeSerially(ctx context.Context, calls []ToolCall) []Result {
 	results := make([]Result, 0, len(calls))
 	for _, tc := range calls {

--- a/internal/toolexec/batch.go
+++ b/internal/toolexec/batch.go
@@ -1,0 +1,159 @@
+package toolexec
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// ToolBatch groups consecutive tool calls with the same concurrency safety.
+type ToolBatch struct {
+	IsConcurrent bool
+	Calls        []ToolCall
+}
+
+// partitionToolCalls groups adjacent tool calls into batches.
+// Consecutive concurrency-safe tools share a batch; the first unsafe
+// tool breaks the batch and starts a new sequential batch.
+func partitionToolCalls(lookup ToolLookup, calls []ToolCall) []ToolBatch {
+	if len(calls) == 0 {
+		return nil
+	}
+
+	var batches []ToolBatch
+	var current ToolBatch
+
+	for _, tc := range calls {
+		tool, ok := lookup.Get(tc.Name)
+		if !ok {
+			// Unknown tools are treated as unsafe (fail-closed).
+			tool = nil
+		}
+
+		isSafe := isConcurrencySafe(tool, tc.Input)
+
+		if len(current.Calls) == 0 {
+			current.IsConcurrent = isSafe
+			current.Calls = append(current.Calls, tc)
+			continue
+		}
+
+		if current.IsConcurrent == isSafe {
+			// Same safety level — extend current batch.
+			current.Calls = append(current.Calls, tc)
+		} else {
+			// Safety changed — finalize current and start new.
+			batches = append(batches, current)
+			current = ToolBatch{IsConcurrent: isSafe, Calls: []ToolCall{tc}}
+		}
+	}
+
+	if len(current.Calls) > 0 {
+		batches = append(batches, current)
+	}
+	return batches
+}
+
+// isConcurrencySafe checks whether a tool is safe to run in parallel
+// with other tools. Falls back to false for unknown tools or tools
+// that don't implement the marker interface.
+//
+// The cheaper ConcurrencySafeTool check comes first to avoid JSON
+// parsing for tools that don't need per-invocation discrimination.
+func isConcurrencySafe(tool agentsdk.Tool, input json.RawMessage) bool {
+	if tool == nil {
+		return false
+	}
+	// Fast path: static concurrency safety (no JSON parsing).
+	if cs, ok := tool.(agentsdk.ConcurrencySafeTool); ok {
+		// If the tool also implements InputConcurrencySafeTool, the
+		// per-invocation check takes precedence — but only after we
+		// know the tool participates in the concurrency safety protocol.
+		if ics, ok := tool.(agentsdk.InputConcurrencySafeTool); ok {
+			return ics.IsConcurrencySafeForInput(input)
+		}
+		return cs.IsConcurrencySafe()
+	}
+	return false
+}
+
+// defaultMaxParallel is the default concurrency limit for tool batch
+// execution. Matches Claude Code's MAX_TOOL_USE_CONCURRENCY=10.
+const defaultMaxParallel = 10
+
+// BatchExecutor runs tool calls in batches, parallelizing safe batches
+// and serializing unsafe batches.
+type BatchExecutor struct {
+	lookup      ToolLookup
+	handler     HandlerFunc
+	maxParallel int
+}
+
+// NewBatchExecutor creates a batch executor with the given lookup,
+// handler, and max parallelism. maxParallel <= 0 defaults to 10.
+func NewBatchExecutor(lookup ToolLookup, handler HandlerFunc, maxParallel int) *BatchExecutor {
+	if maxParallel <= 0 {
+		maxParallel = defaultMaxParallel
+	}
+	return &BatchExecutor{
+		lookup:      lookup,
+		handler:     handler,
+		maxParallel: maxParallel,
+	}
+}
+
+// Execute runs all tool calls and returns results in call order.
+func (be *BatchExecutor) Execute(ctx context.Context, calls []ToolCall) []Result {
+	batches := partitionToolCalls(be.lookup, calls)
+	results := make([]Result, 0, len(calls))
+
+	for _, batch := range batches {
+		if batch.IsConcurrent {
+			results = append(results, be.executeConcurrently(ctx, batch.Calls)...)
+		} else {
+			results = append(results, be.executeSerially(ctx, batch.Calls)...)
+		}
+	}
+	return results
+}
+
+func (be *BatchExecutor) executeConcurrently(ctx context.Context, calls []ToolCall) []Result {
+	sem := make(chan struct{}, be.maxParallel)
+	var wg sync.WaitGroup
+	results := make([]Result, len(calls))
+
+	for i, tc := range calls {
+		wg.Add(1)
+		go func(idx int, call ToolCall) {
+			defer wg.Done()
+			if ctx.Err() != nil {
+				results[idx] = Result{Content: ctx.Err().Error(), IsError: true}
+				return
+			}
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				results[idx] = Result{Content: ctx.Err().Error(), IsError: true}
+				return
+			}
+			defer func() { <-sem }()
+			results[idx] = be.handler(ctx, call)
+		}(i, tc)
+	}
+	wg.Wait()
+	return results
+}
+
+func (be *BatchExecutor) executeSerially(ctx context.Context, calls []ToolCall) []Result {
+	results := make([]Result, 0, len(calls))
+	for _, tc := range calls {
+		if ctx.Err() != nil {
+			results = append(results, Result{Content: ctx.Err().Error(), IsError: true})
+			continue
+		}
+		results = append(results, be.handler(ctx, tc))
+	}
+	return results
+}

--- a/internal/toolexec/batch.go
+++ b/internal/toolexec/batch.go
@@ -9,6 +9,7 @@ import (
 )
 
 // ToolBatch groups consecutive tool calls with the same concurrency safety.
+// Preserving the LLM's call order while allowing safe tools to run concurrently.
 type ToolBatch struct {
 	IsConcurrent bool
 	Calls        []ToolCall
@@ -22,7 +23,7 @@ func partitionToolCalls(lookup ToolLookup, calls []ToolCall) []ToolBatch {
 		return nil
 	}
 
-	var batches []ToolBatch
+	batches := make([]ToolBatch, 0, len(calls))
 	var current ToolBatch
 
 	for _, tc := range calls {
@@ -41,10 +42,8 @@ func partitionToolCalls(lookup ToolLookup, calls []ToolCall) []ToolBatch {
 		}
 
 		if current.IsConcurrent == isSafe {
-			// Same safety level — extend current batch.
 			current.Calls = append(current.Calls, tc)
 		} else {
-			// Safety changed — finalize current and start new.
 			batches = append(batches, current)
 			current = ToolBatch{IsConcurrent: isSafe, Calls: []ToolCall{tc}}
 		}
@@ -56,9 +55,9 @@ func partitionToolCalls(lookup ToolLookup, calls []ToolCall) []ToolBatch {
 	return batches
 }
 
-// isConcurrencySafe checks whether a tool is safe to run in parallel
-// with other tools. Falls back to false for unknown tools or tools
-// that don't implement the marker interface.
+// isConcurrencySafe reports whether a tool can run in parallel with other
+// tools. Unknown tools and tools without the marker interface return false
+// (fail-closed).
 //
 // The cheaper ConcurrencySafeTool check comes first to avoid JSON
 // parsing for tools that don't need per-invocation discrimination.
@@ -66,11 +65,7 @@ func isConcurrencySafe(tool agentsdk.Tool, input json.RawMessage) bool {
 	if tool == nil {
 		return false
 	}
-	// Fast path: static concurrency safety (no JSON parsing).
 	if cs, ok := tool.(agentsdk.ConcurrencySafeTool); ok {
-		// If the tool also implements InputConcurrencySafeTool, the
-		// per-invocation check takes precedence — but only after we
-		// know the tool participates in the concurrency safety protocol.
 		if ics, ok := tool.(agentsdk.InputConcurrencySafeTool); ok {
 			return ics.IsConcurrencySafeForInput(input)
 		}
@@ -79,8 +74,7 @@ func isConcurrencySafe(tool agentsdk.Tool, input json.RawMessage) bool {
 	return false
 }
 
-// defaultMaxParallel is the default concurrency limit for tool batch
-// execution. Matches Claude Code's MAX_TOOL_USE_CONCURRENCY=10.
+// defaultMaxParallel matches Claude Code's MAX_TOOL_USE_CONCURRENCY=10.
 const defaultMaxParallel = 10
 
 // BatchExecutor runs tool calls in batches, parallelizing safe batches
@@ -89,6 +83,7 @@ type BatchExecutor struct {
 	lookup      ToolLookup
 	handler     HandlerFunc
 	maxParallel int
+	sem         chan struct{}
 }
 
 // NewBatchExecutor creates a batch executor with the given lookup,
@@ -101,6 +96,7 @@ func NewBatchExecutor(lookup ToolLookup, handler HandlerFunc, maxParallel int) *
 		lookup:      lookup,
 		handler:     handler,
 		maxParallel: maxParallel,
+		sem:         make(chan struct{}, maxParallel),
 	}
 }
 
@@ -120,7 +116,6 @@ func (be *BatchExecutor) Execute(ctx context.Context, calls []ToolCall) []Result
 }
 
 func (be *BatchExecutor) executeConcurrently(ctx context.Context, calls []ToolCall) []Result {
-	sem := make(chan struct{}, be.maxParallel)
 	var wg sync.WaitGroup
 	results := make([]Result, len(calls))
 
@@ -133,12 +128,12 @@ func (be *BatchExecutor) executeConcurrently(ctx context.Context, calls []ToolCa
 				return
 			}
 			select {
-			case sem <- struct{}{}:
+			case be.sem <- struct{}{}:
 			case <-ctx.Done():
 				results[idx] = Result{Content: ctx.Err().Error(), IsError: true}
 				return
 			}
-			defer func() { <-sem }()
+			defer func() { <-be.sem }()
 			results[idx] = be.handler(ctx, call)
 		}(i, tc)
 	}

--- a/internal/toolexec/batch_test.go
+++ b/internal/toolexec/batch_test.go
@@ -49,8 +49,8 @@ func TestPartitionToolCalls(t *testing.T) {
 func TestPartitionToolCalls_Empty(t *testing.T) {
 	lookup := &mockLookup{tools: map[string]agentsdk.Tool{}}
 	batches := partitionToolCalls(lookup, nil)
-	if batches != nil {
-		t.Error("expected nil for empty calls")
+	if len(batches) != 0 {
+		t.Errorf("expected empty batches, got %d", len(batches))
 	}
 }
 

--- a/internal/toolexec/batch_test.go
+++ b/internal/toolexec/batch_test.go
@@ -1,0 +1,142 @@
+package toolexec
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+func TestPartitionToolCalls(t *testing.T) {
+	// Mock tools: safe tools return true for IsConcurrencySafe,
+	// unsafe tools return false.
+	safe := &mockTool{name: "read", safe: true}
+	unsafe := &mockTool{name: "write", safe: false}
+	lookup := &mockLookup{
+		tools: map[string]agentsdk.Tool{
+			"read":  safe,
+			"write": unsafe,
+		},
+	}
+
+	calls := []ToolCall{
+		{Name: "read", Input: []byte(`{}`)},
+		{Name: "read", Input: []byte(`{}`)},
+		{Name: "write", Input: []byte(`{}`)},
+		{Name: "read", Input: []byte(`{}`)},
+	}
+
+	batches := partitionToolCalls(lookup, calls)
+	if len(batches) != 3 {
+		t.Fatalf("expected 3 batches, got %d", len(batches))
+	}
+	if !batches[0].IsConcurrent {
+		t.Error("batch 0 should be concurrent")
+	}
+	if len(batches[0].Calls) != 2 {
+		t.Errorf("batch 0 should have 2 calls, got %d", len(batches[0].Calls))
+	}
+	if batches[1].IsConcurrent {
+		t.Error("batch 1 should be sequential")
+	}
+	if !batches[2].IsConcurrent {
+		t.Error("batch 2 should be concurrent (read after unsafe is a new safe batch)")
+	}
+}
+
+func TestPartitionToolCalls_Empty(t *testing.T) {
+	lookup := &mockLookup{tools: map[string]agentsdk.Tool{}}
+	batches := partitionToolCalls(lookup, nil)
+	if batches != nil {
+		t.Error("expected nil for empty calls")
+	}
+}
+
+func TestPartitionToolCalls_UnknownTool(t *testing.T) {
+	lookup := &mockLookup{tools: map[string]agentsdk.Tool{}}
+	calls := []ToolCall{{Name: "unknown", Input: []byte(`{}`)}}
+	batches := partitionToolCalls(lookup, calls)
+	if len(batches) != 1 {
+		t.Fatalf("expected 1 batch, got %d", len(batches))
+	}
+	if batches[0].IsConcurrent {
+		t.Error("unknown tool should be treated as unsafe (fail-closed)")
+	}
+}
+
+func TestBatchExecutor(t *testing.T) {
+	// safe tool sleeps 50ms, unsafe sleeps 100ms
+	safe := &mockTool{name: "safe", safe: true, delay: 50 * time.Millisecond}
+	unsafe := &mockTool{name: "unsafe", safe: false, delay: 100 * time.Millisecond}
+	lookup := &mockLookup{tools: map[string]agentsdk.Tool{"safe": safe, "unsafe": unsafe}}
+
+	calls := []ToolCall{
+		{Name: "safe"},
+		{Name: "safe"},
+		{Name: "unsafe"},
+	}
+
+	exec := NewBatchExecutor(lookup, RegistryExecutor(lookup), 10)
+	start := time.Now()
+	results := exec.Execute(context.Background(), calls)
+	elapsed := time.Since(start)
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	// Two safe tools in parallel should take ~50ms, then unsafe ~100ms.
+	// Total should be < 200ms (sequential would be 200ms).
+	if elapsed > 180*time.Millisecond {
+		t.Errorf("expected parallel execution, took %v", elapsed)
+	}
+}
+
+func TestBatchExecutor_ContextCancellation(t *testing.T) {
+	safe := &mockTool{name: "safe", safe: true, delay: 100 * time.Millisecond}
+	lookup := &mockLookup{tools: map[string]agentsdk.Tool{"safe": safe}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancel
+
+	exec := NewBatchExecutor(lookup, RegistryExecutor(lookup), 10)
+	calls := []ToolCall{{Name: "safe"}, {Name: "safe"}}
+	results := exec.Execute(ctx, calls)
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	for i, r := range results {
+		if !r.IsError {
+			t.Errorf("result %d: expected error due to cancellation", i)
+		}
+	}
+}
+
+// mockTool implements agentsdk.Tool and agentsdk.ConcurrencySafeTool for testing.
+type mockTool struct {
+	name  string
+	safe  bool
+	delay time.Duration
+}
+
+func (m *mockTool) Name() string                 { return m.name }
+func (m *mockTool) Description() string          { return "" }
+func (m *mockTool) InputSchema() json.RawMessage { return []byte(`{}`) }
+func (m *mockTool) Execute(ctx context.Context, input json.RawMessage) (agentsdk.ToolResult, error) {
+	if m.delay > 0 {
+		time.Sleep(m.delay)
+	}
+	return agentsdk.ToolResult{Content: m.name}, nil
+}
+func (m *mockTool) IsConcurrencySafe() bool { return m.safe }
+
+type mockLookup struct {
+	tools map[string]agentsdk.Tool
+}
+
+func (m *mockLookup) Get(name string) (agentsdk.Tool, bool) {
+	t, ok := m.tools[name]
+	return t, ok
+}

--- a/internal/tools/file.go
+++ b/internal/tools/file.go
@@ -34,6 +34,7 @@ type FileTool struct {
 	lspNotifier LSPNotifier
 	readHashes  map[string]uint64 // path -> content hash from last read
 	readHashMu  sync.Mutex
+	cache       *FileReadCache
 }
 
 // NewFileTool creates a new FileTool that operates within the given root directory.
@@ -61,6 +62,11 @@ func (f *FileTool) SetDiffTracker(dt *DiffTracker) {
 // to collect diagnostics from the language server.
 func (f *FileTool) SetLSPNotifier(n LSPNotifier) {
 	f.lspNotifier = n
+}
+
+// SetCache attaches a FileReadCache to avoid redundant I/O.
+func (f *FileTool) SetCache(c *FileReadCache) {
+	f.cache = c
 }
 
 func (f *FileTool) Name() string {
@@ -241,9 +247,23 @@ func resolveNearestAncestor(path string) (string, error) {
 }
 
 func (f *FileTool) readFile(path string) (ToolResult, error) {
+	// Check cache first.
+	if f.cache != nil {
+		if content, hit := f.cache.Get(path); hit {
+			return ToolResult{Content: content}, nil
+		}
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return ToolResult{Content: err.Error(), IsError: true}, nil
+	}
+
+	// Update cache with fresh content.
+	if f.cache != nil {
+		if info, err := os.Stat(path); err == nil {
+			f.cache.Put(path, info, string(data))
+		}
 	}
 
 	hash := hashContent(data)
@@ -283,6 +303,9 @@ func (f *FileTool) writeFile(ctx context.Context, path, content string) (ToolRes
 	f.readHashMu.Lock()
 	delete(f.readHashes, path)
 	f.readHashMu.Unlock()
+	if f.cache != nil {
+		f.cache.Invalidate(path)
+	}
 
 	// Check if the file already exists to determine create vs modify.
 	_, statErr := os.Stat(path)
@@ -332,6 +355,9 @@ func (f *FileTool) patchFile(ctx context.Context, path, oldString, newString str
 	f.readHashMu.Lock()
 	delete(f.readHashes, path)
 	f.readHashMu.Unlock()
+	if f.cache != nil {
+		f.cache.Invalidate(path)
+	}
 
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/tools/file.go
+++ b/internal/tools/file.go
@@ -298,14 +298,17 @@ func hashContent(data []byte) uint64 {
 	return h.Sum64()
 }
 
-func (f *FileTool) writeFile(ctx context.Context, path, content string) (ToolResult, error) {
-	// Invalidate read cache for this path since content is changing.
+func (f *FileTool) invalidateReadCache(path string) {
 	f.readHashMu.Lock()
 	delete(f.readHashes, path)
 	f.readHashMu.Unlock()
 	if f.cache != nil {
 		f.cache.Invalidate(path)
 	}
+}
+
+func (f *FileTool) writeFile(ctx context.Context, path, content string) (ToolResult, error) {
+	f.invalidateReadCache(path)
 
 	// Check if the file already exists to determine create vs modify.
 	_, statErr := os.Stat(path)
@@ -351,13 +354,7 @@ func (f *FileTool) patchFile(ctx context.Context, path, oldString, newString str
 		return ToolResult{Content: "old_string must not be empty", IsError: true}, nil
 	}
 
-	// Invalidate read cache for this path since content is changing.
-	f.readHashMu.Lock()
-	delete(f.readHashes, path)
-	f.readHashMu.Unlock()
-	if f.cache != nil {
-		f.cache.Invalidate(path)
-	}
+	f.invalidateReadCache(path)
 
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/tools/file_cache.go
+++ b/internal/tools/file_cache.go
@@ -1,0 +1,77 @@
+package tools
+
+import (
+	"os"
+	"sync"
+	"time"
+)
+
+// FileStateInfo captures the file metadata and content at read time.
+// Used to detect staleness on subsequent reads.
+type FileStateInfo struct {
+	MTime   time.Time
+	Size    int64
+	Content string
+}
+
+// FileReadCache caches file read results keyed by absolute path.
+// Thread-safe for concurrent access. No eviction — intended for
+// sessions with a bounded number of file reads (typically < 1000).
+// If unbounded growth becomes a concern, add an LRU eviction policy.
+type FileReadCache struct {
+	mu    sync.RWMutex
+	state map[string]FileStateInfo
+}
+
+// NewFileReadCache creates an empty file read cache.
+func NewFileReadCache() *FileReadCache {
+	return &FileReadCache{
+		state: make(map[string]FileStateInfo),
+	}
+}
+
+// Get checks the cache for a file. Returns (content, true) if the cached
+// entry matches the current file's mtime and size. Returns ("", false) on
+// miss or staleness.
+//
+// Uses time.Time.Equal() instead of != to avoid false staleness from
+// filesystems with sub-second precision differences.
+func (c *FileReadCache) Get(path string) (string, bool) {
+	c.mu.RLock()
+	cached, ok := c.state[path]
+	c.mu.RUnlock()
+	if !ok {
+		return "", false
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		// File disappeared or unreadable — treat as stale.
+		return "", false
+	}
+
+	if !info.ModTime().Equal(cached.MTime) || info.Size() != cached.Size {
+		return "", false
+	}
+
+	return cached.Content, true
+}
+
+// Put stores a file's content and metadata in the cache.
+func (c *FileReadCache) Put(path string, info os.FileInfo, content string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.state[path] = FileStateInfo{
+		MTime:   info.ModTime(),
+		Size:    info.Size(),
+		Content: content,
+	}
+}
+
+// Invalidate removes a path from the cache. Called after writes/edits
+// to ensure subsequent reads don't return stale data.
+func (c *FileReadCache) Invalidate(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.state, path)
+}

--- a/internal/tools/file_cache_test.go
+++ b/internal/tools/file_cache_test.go
@@ -1,0 +1,90 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileReadCache_Basic(t *testing.T) {
+	cache := NewFileReadCache()
+
+	// Create a temp file
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First read: cache miss
+	_, hit := cache.Get(tmpFile)
+	if hit {
+		t.Error("expected cache miss on first read")
+	}
+
+	// Store in cache
+	info, err := os.Stat(tmpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.Put(tmpFile, info, "hello")
+
+	// Second read: cache hit
+	content, hit := cache.Get(tmpFile)
+	if !hit {
+		t.Error("expected cache hit")
+	}
+	if content != "hello" {
+		t.Errorf("expected 'hello', got %q", content)
+	}
+
+	// Modify file: cache should detect staleness
+	if err := os.WriteFile(tmpFile, []byte("world"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, hit = cache.Get(tmpFile)
+	if hit {
+		t.Error("expected cache miss after file modification")
+	}
+}
+
+func TestFileReadCache_Invalidate(t *testing.T) {
+	cache := NewFileReadCache()
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info, _ := os.Stat(tmpFile)
+	cache.Put(tmpFile, info, "hello")
+
+	// Invalidate and verify miss
+	cache.Invalidate(tmpFile)
+	_, hit := cache.Get(tmpFile)
+	if hit {
+		t.Error("expected cache miss after invalidate")
+	}
+}
+
+func TestFileReadCache_FileDisappears(t *testing.T) {
+	cache := NewFileReadCache()
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info, _ := os.Stat(tmpFile)
+	cache.Put(tmpFile, info, "hello")
+
+	// Delete file
+	os.Remove(tmpFile)
+
+	_, hit := cache.Get(tmpFile)
+	if hit {
+		t.Error("expected cache miss after file deletion")
+	}
+}

--- a/pkg/agentsdk/tool.go
+++ b/pkg/agentsdk/tool.go
@@ -66,6 +66,18 @@ type SearchHinter interface {
 	SearchHint() string
 }
 
+// ResultBudgeted is an optional interface that tools can implement to
+// declare their preferred result size limit. When a tool's output exceeds
+// this limit, the agent applies head+tail truncation before the aggregate
+// per-message budget is enforced.
+type ResultBudgeted interface {
+	Tool
+	// MaxResultChars returns the maximum number of characters this tool's
+	// result should occupy in the conversation context. Zero or negative
+	// means no per-tool limit (only the aggregate message budget applies).
+	MaxResultChars() int
+}
+
 // ToolResult represents the result of executing a tool.
 type ToolResult struct {
 	Content        string // sent to LLM conversation history

--- a/pkg/agentsdk/tool_test.go
+++ b/pkg/agentsdk/tool_test.go
@@ -98,3 +98,13 @@ func TestStreamingToolEmitsErrorEvent(t *testing.T) {
 	assert.True(t, events[0].IsError)
 	assert.Equal(t, "something went wrong", events[0].Content)
 }
+
+// budgetedTool verifies ResultBudgeted extends Tool.
+type budgetedTool struct{ mockTool }
+
+func (b *budgetedTool) MaxResultChars() int { return 50000 }
+
+func TestResultBudgetedInterface(t *testing.T) {
+	var _ Tool = (*budgetedTool)(nil)
+	var _ ResultBudgeted = (*budgetedTool)(nil)
+}


### PR DESCRIPTION
## Summary

Implements intelligent tool batching that groups adjacent concurrency-safe tools and runs safe batches in parallel while unsafe batches run sequentially.

## Changes

- `internal/toolexec/batch.go`: `partitionToolCalls` algorithm + `BatchExecutor`
- `internal/toolexec/batch_test.go`: Unit tests for partitioning and execution
- `internal/agent/agent.go`: Wire `BatchExecutor` into `executeTools`

## Key Design Decisions

- **Fail-closed:** Unknown tools and tools without `ConcurrencySafeTool` are treated as unsafe
- **Fast path:** `ConcurrencySafeTool` checked before `InputConcurrencySafeTool` to avoid JSON parsing when not needed
- **Context cancellation:** All goroutines check `ctx.Err()` before and during semaphore acquisition
- **Preserves existing behavior:** Approval checks, result capping, offloading, verdict evaluation all still work

## Validation

- `go test ./internal/toolexec/...` — PASS
- `go test ./internal/agent/...` — PASS
- `go test ./...` — ALL PASS
- `golangci-lint run ./internal/toolexec/... ./internal/agent/...` — Clean
- `gofmt` — Clean

## Plan

Implements [T1: Tool Batching](docs/superpowers/plans/2026-05-02-tool-batching.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-message tool-result budgeting with truncation/offload and a new budget enforcement flow
  * In-memory file-read cache to speed file reads and centralized cache invalidation
  * HTTP hook execution with fail-open behavior and richer hook config/events
  * Prompt transformation hooks (find/replace)
  * LLM-based tool approval pathway and mode-aware checker integration
  * Batched/parallel executor for concurrency-safe tool calls
  * Optional per-tool result-size hint interface

* **Tests**
  * Extensive unit tests covering budgeting, file-cache, hooks, classifier, batching, and related utilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->