### PR TITLE
feat: Streaming tombstone + prefetch handles (Plans N \u0026 O)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -27,6 +27,7 @@ import (
 	"github.com/julianshen/rubichan/internal/knowledgegraph"
 	"github.com/julianshen/rubichan/internal/persona"
 	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/provider/normalize"
 	"github.com/julianshen/rubichan/internal/skills"
 	"github.com/julianshen/rubichan/internal/store"
 	"github.com/julianshen/rubichan/internal/text"
@@ -188,6 +189,11 @@ func WithCapabilities(caps provider.ModelCapabilities) AgentOption {
 
 func WithFallbackModel(model string) AgentOption {
 	return func(a *Agent) { a.fallbackModel = model }
+}
+
+// WithPrefetchManager attaches a prefetch manager for async memory/skill loading.
+func WithPrefetchManager(pm *PrefetchManager) AgentOption {
+	return func(a *Agent) { a.prefetchMgr = pm }
 }
 
 // WorkingDir returns the agent's effective working directory.
@@ -369,6 +375,7 @@ type Agent struct {
 	agentDef            *agentsdk.AgentDefinition
 	agentRegistry       *AgentRegistry
 	stopHookRegistry    *hooks.StopHookRegistry
+	prefetchMgr         *PrefetchManager
 }
 
 const maxUIRequestInputBytes = 2048
@@ -1470,6 +1477,15 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			a.saveSnapshotIfNeeded()
 		}
 
+		// Start async prefetches before LLM call
+		var memHandle *PrefetchHandle[[]kg.ScoredEntity]
+		var skillHandle *PrefetchHandle[struct{}]
+
+		if a.prefetchMgr != nil {
+			memHandle = a.prefetchMgr.StartMemoryPrefetch(ctx, lastUserMessage, budget.SkillPrompts)
+			skillHandle = a.prefetchMgr.StartSkillPrefetch(ctx, a.buildSkillTriggerContext(lastUserMessage))
+		}
+
 		req := provider.CompletionRequest{
 			Model:            a.model,
 			System:           systemPrompt,
@@ -1554,9 +1570,16 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			if class == errorclass.ClassModelOverloaded && a.fallbackModel != "" {
 				a.logger.Warn("primary model overloaded; retrying with fallback model %s", a.fallbackModel)
 				a.emit(ctx, ch, TurnEvent{Type: "model_fallback", Model: a.fallbackModel})
+
+				// Tombstone orphaned messages from the failed attempt
+				tombstonedCount := a.conversation.TombstoneSinceLastAssistant(agentsdk.TombstoneReasonModelFallback)
+				if tombstonedCount > 0 {
+					a.logger.Warn("tombstoned %d orphaned messages before fallback", tombstonedCount)
+				}
+
 				fallbackReq := req
 				fallbackReq.Model = a.fallbackModel
-				fallbackReq.Messages = stripThinkingBlocks(req.Messages)
+				fallbackReq.Messages = normalize.FilterTombstoned(stripThinkingBlocks(req.Messages))
 				fallbackRetryCfg := TurnRetryConfig{}
 				if ns, ok := a.provider.(NonStreamer); ok {
 					fbReq := fallbackReq
@@ -1937,6 +1960,22 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		if nudge := a.context.BudgetNudge(a.conversation); nudge != "" && !ls.nudgeEmitted {
 			a.conversation.AddUser(nudge)
 			ls.nudgeEmitted = true
+		}
+
+		// Consume prefetch results after tool execution
+		if memHandle != nil {
+			entities, err := memHandle.Consume(ctx)
+			if err != nil {
+				a.logger.Warn("memory prefetch failed: %v", err)
+			} else if len(entities) > 0 && a.knowledgeSelector != nil {
+				_ = a.knowledgeSelector.RecordUsage(ctx, entities)
+			}
+		}
+
+		if skillHandle != nil {
+			if _, err := skillHandle.Consume(ctx); err != nil {
+				a.logger.Warn("skill prefetch failed: %v", err)
+			}
 		}
 
 		// Continue to the next turn after tool results.

--- a/internal/agent/conversation.go
+++ b/internal/agent/conversation.go
@@ -1,6 +1,9 @@
 package agent
 
-import "github.com/julianshen/rubichan/internal/provider"
+import (
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
 
 // Conversation manages the message history for an agent session.
 type Conversation struct {
@@ -96,4 +99,64 @@ func (c *Conversation) DrainMessages(minPairsToKeep int) bool {
 // Clear removes all messages but preserves the system prompt.
 func (c *Conversation) Clear() {
 	c.messages = nil
+}
+
+// Tombstone replaces messages in the range [startIdx:endIdx] with
+// tombstone markers. The messages are preserved in the conversation
+// for history but skipped when building API requests.
+func (c *Conversation) Tombstone(startIdx, endIdx int, reason agentsdk.TombstoneReason) {
+	if startIdx < 0 {
+		startIdx = 0
+	}
+	if endIdx > len(c.messages) {
+		endIdx = len(c.messages)
+	}
+	if startIdx >= endIdx {
+		return
+	}
+
+	for i := startIdx; i < endIdx; i++ {
+		if c.isTombstoned(i) {
+			continue
+		}
+		c.messages[i].Content = []provider.ContentBlock{{
+			Type: "text",
+			Text: agentsdk.TombstoneMarker,
+		}}
+		c.messages[i].Metadata = map[string]any{
+			"tombstoned": true,
+			"reason":     reason,
+		}
+	}
+}
+
+// TombstoneSinceLastAssistant tombstones all messages since the last
+// complete assistant response. Used when model fallback occurs mid-stream.
+func (c *Conversation) TombstoneSinceLastAssistant(reason agentsdk.TombstoneReason) int {
+	lastAssistantIdx := -1
+	for i := len(c.messages) - 1; i >= 0; i-- {
+		if c.messages[i].Role == "assistant" && !c.isTombstoned(i) {
+			lastAssistantIdx = i
+			break
+		}
+	}
+
+	if lastAssistantIdx < 0 {
+		c.Tombstone(0, len(c.messages), reason)
+		return len(c.messages)
+	}
+
+	startIdx := lastAssistantIdx + 1
+	c.Tombstone(startIdx, len(c.messages), reason)
+	return len(c.messages) - startIdx
+}
+
+func (c *Conversation) isTombstoned(idx int) bool {
+	if idx < 0 || idx >= len(c.messages) {
+		return false
+	}
+	if len(c.messages[idx].Content) == 0 {
+		return false
+	}
+	return agentsdk.IsTombstonedMessage(c.messages[idx])
 }

--- a/internal/agent/normalize.go
+++ b/internal/agent/normalize.go
@@ -1,11 +1,15 @@
 package agent
 
-import "github.com/julianshen/rubichan/internal/provider"
+import (
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/provider/normalize"
+)
 
 // normalizeMessages cleans up conversation messages before sending to the LLM.
-// It removes orphaned tool_use blocks (those without a matching tool_result)
-// and merges consecutive assistant messages.
+// It removes tombstoned messages, orphaned tool_use blocks (those without a
+// matching tool_result), and merges consecutive assistant messages.
 func normalizeMessages(messages []provider.Message) []provider.Message {
+	messages = normalize.FilterTombstoned(messages)
 	messages = removeOrphanedToolCalls(messages)
 	messages = mergeConsecutiveAssistant(messages)
 	return messages

--- a/internal/agent/prefetch.go
+++ b/internal/agent/prefetch.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/julianshen/rubichan/internal/skills"
+	kg "github.com/julianshen/rubichan/pkg/knowledgegraph"
+)
+
+// PrefetchHandle tracks an in-flight async operation with a result.
+type PrefetchHandle[T any] struct {
+	Done   chan struct{}
+	Result T
+	Err    error
+}
+
+// Consume waits for and returns the prefetch result.
+func (h *PrefetchHandle[T]) Consume(ctx context.Context) (T, error) {
+	select {
+	case <-ctx.Done():
+		var zero T
+		return zero, ctx.Err()
+	case <-h.Done:
+		return h.Result, h.Err
+	}
+}
+
+// PrefetchManager coordinates async loading of memory and skills.
+type PrefetchManager struct {
+	kgSelector   kg.ContextSelector
+	skillRuntime *skills.Runtime
+}
+
+// NewPrefetchManager creates a manager with the given dependencies.
+func NewPrefetchManager(kg kg.ContextSelector, sr *skills.Runtime) *PrefetchManager {
+	return &PrefetchManager{
+		kgSelector:   kg,
+		skillRuntime: sr,
+	}
+}
+
+// StartMemoryPrefetch begins async loading of knowledge graph entities.
+func (pm *PrefetchManager) StartMemoryPrefetch(ctx context.Context, query string, budget int) *PrefetchHandle[[]kg.ScoredEntity] {
+	handle := &PrefetchHandle[[]kg.ScoredEntity]{Done: make(chan struct{})}
+
+	go func() {
+		defer close(handle.Done)
+		if pm.kgSelector == nil {
+			return
+		}
+
+		entities, err := pm.kgSelector.Select(ctx, query, budget)
+		handle.Result = entities
+		handle.Err = err
+	}()
+
+	return handle
+}
+
+// StartSkillPrefetch begins async evaluation of skill triggers.
+func (pm *PrefetchManager) StartSkillPrefetch(ctx context.Context, triggerCtx skills.TriggerContext) *PrefetchHandle[struct{}] {
+	handle := &PrefetchHandle[struct{}]{Done: make(chan struct{})}
+
+	go func() {
+		defer close(handle.Done)
+		if pm.skillRuntime == nil {
+			return
+		}
+
+		handle.Err = pm.skillRuntime.EvaluateAndActivate(triggerCtx)
+	}()
+
+	return handle
+}

--- a/internal/agent/prefetch_test.go
+++ b/internal/agent/prefetch_test.go
@@ -1,0 +1,25 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/skills"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefetchManagerNilDeps(t *testing.T) {
+	pm := NewPrefetchManager(nil, nil)
+
+	ctx := context.Background()
+	memHandle := pm.StartMemoryPrefetch(ctx, "test", 1000)
+	skillHandle := pm.StartSkillPrefetch(ctx, skills.TriggerContext{})
+
+	// Should complete immediately with nil deps
+	entities, err := memHandle.Consume(ctx)
+	require.NoError(t, err)
+	require.Nil(t, entities)
+
+	_, err = skillHandle.Consume(ctx)
+	require.NoError(t, err)
+}

--- a/internal/agent/tombstone_test.go
+++ b/internal/agent/tombstone_test.go
@@ -1,0 +1,41 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConversationTombstone(t *testing.T) {
+	conv := NewConversation("")
+	conv.AddUser("Hello")
+	conv.AddAssistant([]provider.ContentBlock{{Type: "text", Text: "Hi"}})
+	conv.AddUser("Do something")
+
+	// Tombstone the last user message
+	conv.Tombstone(2, 3, agentsdk.TombstoneReasonModelFallback)
+
+	msgs := conv.Messages()
+	require.Equal(t, 3, len(msgs))
+	require.False(t, agentsdk.IsTombstoned(msgs[0].Content[0].Text))
+	require.False(t, agentsdk.IsTombstoned(msgs[1].Content[0].Text))
+	require.True(t, agentsdk.IsTombstoned(msgs[2].Content[0].Text))
+}
+
+func TestTombstoneSinceLastAssistant(t *testing.T) {
+	conv := NewConversation("")
+	conv.AddUser("Hello")
+	conv.AddAssistant([]provider.ContentBlock{{Type: "text", Text: "Hi"}})
+	conv.AddUser("Do something")
+	conv.AddAssistant([]provider.ContentBlock{{Type: "text", Text: "Working..."}}) // partial
+
+	count := conv.TombstoneSinceLastAssistant(agentsdk.TombstoneReasonModelFallback)
+	require.Equal(t, 0, count) // Last assistant is complete, nothing to tombstone
+
+	// Now add a partial user message
+	conv.AddUser("More")
+	count = conv.TombstoneSinceLastAssistant(agentsdk.TombstoneReasonModelFallback)
+	require.Equal(t, 1, count)
+}

--- a/internal/provider/normalize/normalize.go
+++ b/internal/provider/normalize/normalize.go
@@ -131,3 +131,15 @@ func hasToolResult(m agentsdk.Message) bool {
 	}
 	return false
 }
+
+// FilterTombstoned removes tombstoned messages from a slice.
+// Preserves non-tombstoned messages in order.
+func FilterTombstoned(messages []agentsdk.Message) []agentsdk.Message {
+	out := make([]agentsdk.Message, 0, len(messages))
+	for _, m := range messages {
+		if !agentsdk.IsTombstonedMessage(m) {
+			out = append(out, m)
+		}
+	}
+	return out
+}

--- a/internal/provider/normalize/tombstone_test.go
+++ b/internal/provider/normalize/tombstone_test.go
@@ -1,0 +1,34 @@
+package normalize
+
+import (
+	"testing"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterTombstoned(t *testing.T) {
+	msgs := []agentsdk.Message{
+		{Role: "user", Content: []agentsdk.ContentBlock{{Type: "text", Text: "Hello"}}},
+		{Role: "assistant", Content: []agentsdk.ContentBlock{{Type: "text", Text: agentsdk.TombstoneMarker}}},
+		{Role: "user", Content: []agentsdk.ContentBlock{{Type: "text", Text: "Do something"}}},
+	}
+
+	filtered := FilterTombstoned(msgs)
+	require.Equal(t, 2, len(filtered))
+	require.Equal(t, "Hello", filtered[0].Content[0].Text)
+	require.Equal(t, "Do something", filtered[1].Content[0].Text)
+}
+
+func TestFilterTombstonedEmpty(t *testing.T) {
+	filtered := FilterTombstoned(nil)
+	require.Empty(t, filtered)
+}
+
+func TestFilterTombstonedAllTombstoned(t *testing.T) {
+	msgs := []agentsdk.Message{
+		{Role: "assistant", Content: []agentsdk.ContentBlock{{Type: "text", Text: agentsdk.TombstoneMarker}}},
+	}
+	filtered := FilterTombstoned(msgs)
+	require.Equal(t, 0, len(filtered))
+}

--- a/pkg/agentsdk/tombstone.go
+++ b/pkg/agentsdk/tombstone.go
@@ -1,0 +1,31 @@
+package agentsdk
+
+// TombstoneMarker is the text content of a tombstoned message.
+const TombstoneMarker = "[This message was tombstoned due to model fallback]"
+
+// IsTombstoned checks if a message content is a tombstone marker.
+func IsTombstoned(content string) bool {
+	return content == TombstoneMarker
+}
+
+// IsTombstonedMessage checks if a message is tombstoned.
+func IsTombstonedMessage(m Message) bool {
+	if len(m.Content) == 0 {
+		return false
+	}
+	return IsTombstoned(m.Content[0].Text)
+}
+
+// TombstoneReason explains why a message was tombstoned.
+type TombstoneReason string
+
+const (
+	// TombstoneReasonModelFallback means the message was orphaned
+	// when switching to a fallback model.
+	TombstoneReasonModelFallback TombstoneReason = "model_fallback"
+	// TombstoneReasonStreamError means the message was partial due
+	// to a stream error.
+	TombstoneReasonStreamError TombstoneReason = "stream_error"
+	// TombstoneReasonUserAbort means the user aborted mid-stream.
+	TombstoneReasonUserAbort TombstoneReason = "user_abort"
+)

--- a/pkg/agentsdk/tombstone_test.go
+++ b/pkg/agentsdk/tombstone_test.go
@@ -1,0 +1,12 @@
+package agentsdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTombstoned(t *testing.T) {
+	require.True(t, IsTombstoned(TombstoneMarker))
+	require.False(t, IsTombstoned("normal message"))
+}

--- a/pkg/agentsdk/types.go
+++ b/pkg/agentsdk/types.go
@@ -103,8 +103,9 @@ type CompletionRequest struct {
 
 // Message represents a single message in a conversation.
 type Message struct {
-	Role    string         `json:"role"`
-	Content []ContentBlock `json:"content"`
+	Role     string         `json:"role"`
+	Content  []ContentBlock `json:"content"`
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
 // ContentBlock represents a block of content within a message.


### PR DESCRIPTION
## Summary

Implements Plans N and O from the query loop improvements index:

- **Plan N: Streaming Tombstone Pattern** — Tombstone orphaned messages when switching to a fallback model, preventing context pollution from partial responses
- **Plan O: Prefetch Handles** — Async loading of knowledge graph entities and skill prompt fragments while the LLM runs, reducing latency

## Changes

### Streaming Tombstone (Plan N)
- `pkg/agentsdk/tombstone.go` — `TombstoneMarker`, `IsTombstoned`, `IsTombstonedMessage`, `TombstoneReason` constants
- `internal/agent/conversation.go` — `Tombstone()`, `TombstoneSinceLastAssistant()`, `isTombstoned()` methods
- `internal/provider/normalize/normalize.go` — `FilterTombstoned()` with capacity pre-allocation
- `internal/agent/agent.go` — Integrated into model fallback path and `normalizeMessages()`

### Prefetch Handles (Plan O)
- `internal/agent/prefetch.go` — Generic `PrefetchHandle[T]`, `PrefetchManager`, `StartMemoryPrefetch()`, `StartSkillPrefetch()`
- `internal/agent/agent.go` — Wired into `runLoop`: starts before LLM call, consumes after tool execution

## Test Plan
- [x] `go test ./...` — 78 packages pass
- [x] `golangci-lint run ./...` — clean (only pre-existing issues)
- [x] `gofmt -l .` — clean