### PR TITLE
[STRUCTURAL] Mailbox + SendMessage Tool for async A2A messaging

### DIFF
--- a/internal/team/mailbox.go
+++ b/internal/team/mailbox.go
@@ -173,7 +173,7 @@ func FormatMessagesAsXML(messages []agentsdk.MailboxMessage) string {
 		if msg.Summary != "" {
 			summaryAttr = fmt.Sprintf(` summary="%s"`, msg.Summary)
 		}
-		sb.WriteString(fmt.Sprintf(`<teammate_message teammate_id="%s"%s%s>\n%s\n</teammate_message>\n`, msg.From, colorAttr, summaryAttr, msg.Text))
+		sb.WriteString(fmt.Sprintf("<teammate_message teammate_id=\"%s\"%s%s>\n%s\n</teammate_message>\n", msg.From, colorAttr, summaryAttr, msg.Text))
 	}
 	return sb.String()
 }

--- a/internal/team/mailbox.go
+++ b/internal/team/mailbox.go
@@ -31,7 +31,8 @@ func (m *Mailbox) EnsureDir() error {
 
 // InboxPath returns the file path for an agent's inbox.
 func (m *Mailbox) InboxPath(agentName string) string {
-	return filepath.Join(m.dir, agentName+".json")
+	// filepath.Base prevents directory traversal via agent names like "../../../etc/passwd".
+	return filepath.Join(m.dir, filepath.Base(agentName)+".json")
 }
 
 // Write appends a message to the agent's inbox.
@@ -57,7 +58,7 @@ func (m *Mailbox) Write(agentName string, msg agentsdk.MailboxMessage) error {
 	}
 
 	messages = append(messages, msg)
-	return m.writeLocked(agentName, messages)
+	return m.writeLocked(path, messages)
 }
 
 // Read returns all messages in the agent's inbox.
@@ -118,7 +119,7 @@ func (m *Mailbox) MarkRead(agentName string, index int) error {
 	}
 
 	messages[index].Read = true
-	return m.writeLocked(agentName, messages)
+	return m.writeLocked(m.InboxPath(agentName), messages)
 }
 
 // MarkAllRead marks all messages as read.
@@ -134,7 +135,7 @@ func (m *Mailbox) MarkAllRead(agentName string) error {
 	for i := range messages {
 		messages[i].Read = true
 	}
-	return m.writeLocked(agentName, messages)
+	return m.writeLocked(m.InboxPath(agentName), messages)
 }
 
 // Clear removes an agent's inbox file.
@@ -149,8 +150,7 @@ func (m *Mailbox) Clear(agentName string) error {
 	return nil
 }
 
-func (m *Mailbox) writeLocked(agentName string, messages []agentsdk.MailboxMessage) error {
-	path := m.InboxPath(agentName)
+func (m *Mailbox) writeLocked(path string, messages []agentsdk.MailboxMessage) error {
 	encoded, err := json.Marshal(messages)
 	if err != nil {
 		return fmt.Errorf("mailbox marshal: %w", err)

--- a/internal/team/mailbox.go
+++ b/internal/team/mailbox.go
@@ -3,6 +3,7 @@ package team
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +47,9 @@ func (m *Mailbox) Write(agentName string, msg agentsdk.MailboxMessage) error {
 	var messages []agentsdk.MailboxMessage
 	data, err := os.ReadFile(path)
 	if err == nil && len(data) > 0 {
-		_ = json.Unmarshal(data, &messages)
+		if unmarshalErr := json.Unmarshal(data, &messages); unmarshalErr != nil {
+			return fmt.Errorf("mailbox unmarshal: %w", unmarshalErr)
+		}
 	}
 
 	if msg.Timestamp.IsZero() {
@@ -167,13 +170,13 @@ func FormatMessagesAsXML(messages []agentsdk.MailboxMessage) string {
 	for _, msg := range messages {
 		colorAttr := ""
 		if msg.Color != "" {
-			colorAttr = fmt.Sprintf(` color="%s"`, msg.Color)
+			colorAttr = fmt.Sprintf(` color="%s"`, html.EscapeString(msg.Color))
 		}
 		summaryAttr := ""
 		if msg.Summary != "" {
-			summaryAttr = fmt.Sprintf(` summary="%s"`, msg.Summary)
+			summaryAttr = fmt.Sprintf(` summary="%s"`, html.EscapeString(msg.Summary))
 		}
-		sb.WriteString(fmt.Sprintf("<teammate_message teammate_id=\"%s\"%s%s>\n%s\n</teammate_message>\n", msg.From, colorAttr, summaryAttr, msg.Text))
+		sb.WriteString(fmt.Sprintf("<teammate_message teammate_id=\"%s\"%s%s>\n%s\n</teammate_message>\n", html.EscapeString(msg.From), colorAttr, summaryAttr, html.EscapeString(msg.Text)))
 	}
 	return sb.String()
 }

--- a/internal/team/mailbox.go
+++ b/internal/team/mailbox.go
@@ -1,0 +1,179 @@
+package team
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// Mailbox manages per-agent JSON inboxes for async A2A messaging.
+type Mailbox struct {
+	dir string
+	mu  sync.Mutex
+}
+
+// NewMailbox creates a Mailbox that stores inboxes under dir.
+func NewMailbox(dir string) *Mailbox {
+	return &Mailbox{dir: dir}
+}
+
+// EnsureDir creates the mailbox directory if it doesn't exist.
+func (m *Mailbox) EnsureDir() error {
+	return os.MkdirAll(m.dir, 0o755)
+}
+
+// InboxPath returns the file path for an agent's inbox.
+func (m *Mailbox) InboxPath(agentName string) string {
+	return filepath.Join(m.dir, agentName+".json")
+}
+
+// Write appends a message to the agent's inbox.
+func (m *Mailbox) Write(agentName string, msg agentsdk.MailboxMessage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	path := m.InboxPath(agentName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mailbox mkdir: %w", err)
+	}
+
+	var messages []agentsdk.MailboxMessage
+	data, err := os.ReadFile(path)
+	if err == nil && len(data) > 0 {
+		_ = json.Unmarshal(data, &messages)
+	}
+
+	if msg.Timestamp.IsZero() {
+		msg.Timestamp = time.Now()
+	}
+	messages = append(messages, msg)
+
+	encoded, err := json.Marshal(messages)
+	if err != nil {
+		return fmt.Errorf("mailbox marshal: %w", err)
+	}
+
+	return os.WriteFile(path, encoded, 0o644)
+}
+
+// Read returns all messages in the agent's inbox.
+func (m *Mailbox) Read(agentName string) ([]agentsdk.MailboxMessage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.readLocked(agentName)
+}
+
+func (m *Mailbox) readLocked(agentName string) ([]agentsdk.MailboxMessage, error) {
+	path := m.InboxPath(agentName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("mailbox read: %w", err)
+	}
+
+	var messages []agentsdk.MailboxMessage
+	if err := json.Unmarshal(data, &messages); err != nil {
+		return nil, fmt.Errorf("mailbox unmarshal: %w", err)
+	}
+	return messages, nil
+}
+
+// ReadUnread returns only unread messages.
+func (m *Mailbox) ReadUnread(agentName string) ([]agentsdk.MailboxMessage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	messages, err := m.readLocked(agentName)
+	if err != nil {
+		return nil, err
+	}
+
+	var unread []agentsdk.MailboxMessage
+	for _, msg := range messages {
+		if !msg.Read {
+			unread = append(unread, msg)
+		}
+	}
+	return unread, nil
+}
+
+// MarkRead marks a single message at index as read.
+func (m *Mailbox) MarkRead(agentName string, index int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	messages, err := m.readLocked(agentName)
+	if err != nil {
+		return err
+	}
+	if index < 0 || index >= len(messages) {
+		return fmt.Errorf("index %d out of range [0, %d)", index, len(messages))
+	}
+
+	messages[index].Read = true
+	return m.writeLocked(agentName, messages)
+}
+
+// MarkAllRead marks all messages as read.
+func (m *Mailbox) MarkAllRead(agentName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	messages, err := m.readLocked(agentName)
+	if err != nil {
+		return err
+	}
+
+	for i := range messages {
+		messages[i].Read = true
+	}
+	return m.writeLocked(agentName, messages)
+}
+
+// Clear removes an agent's inbox file.
+func (m *Mailbox) Clear(agentName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	path := m.InboxPath(agentName)
+	err := os.Remove(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (m *Mailbox) writeLocked(agentName string, messages []agentsdk.MailboxMessage) error {
+	path := m.InboxPath(agentName)
+	encoded, err := json.Marshal(messages)
+	if err != nil {
+		return fmt.Errorf("mailbox marshal: %w", err)
+	}
+	return os.WriteFile(path, encoded, 0o644)
+}
+
+// FormatMessagesAsXML serializes messages as XML for prompt injection.
+func FormatMessagesAsXML(messages []agentsdk.MailboxMessage) string {
+	var sb strings.Builder
+	for _, msg := range messages {
+		colorAttr := ""
+		if msg.Color != "" {
+			colorAttr = fmt.Sprintf(` color="%s"`, msg.Color)
+		}
+		summaryAttr := ""
+		if msg.Summary != "" {
+			summaryAttr = fmt.Sprintf(` summary="%s"`, msg.Summary)
+		}
+		sb.WriteString(fmt.Sprintf(`<teammate_message teammate_id="%s"%s%s>\n%s\n</teammate_message>\n`, msg.From, colorAttr, summaryAttr, msg.Text))
+	}
+	return sb.String()
+}

--- a/internal/team/mailbox.go
+++ b/internal/team/mailbox.go
@@ -39,30 +39,25 @@ func (m *Mailbox) Write(agentName string, msg agentsdk.MailboxMessage) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	path := m.InboxPath(agentName)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("mailbox mkdir: %w", err)
-	}
-
-	var messages []agentsdk.MailboxMessage
-	data, err := os.ReadFile(path)
-	if err == nil && len(data) > 0 {
-		if unmarshalErr := json.Unmarshal(data, &messages); unmarshalErr != nil {
-			return fmt.Errorf("mailbox unmarshal: %w", unmarshalErr)
-		}
-	}
-
 	if msg.Timestamp.IsZero() {
 		msg.Timestamp = time.Now()
 	}
-	messages = append(messages, msg)
 
-	encoded, err := json.Marshal(messages)
-	if err != nil {
-		return fmt.Errorf("mailbox marshal: %w", err)
+	path := m.InboxPath(agentName)
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("mailbox read: %w", err)
 	}
 
-	return os.WriteFile(path, encoded, 0o644)
+	var messages []agentsdk.MailboxMessage
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &messages); err != nil {
+			return fmt.Errorf("mailbox unmarshal: %w", err)
+		}
+	}
+
+	messages = append(messages, msg)
+	return m.writeLocked(agentName, messages)
 }
 
 // Read returns all messages in the agent's inbox.
@@ -148,9 +143,8 @@ func (m *Mailbox) Clear(agentName string) error {
 	defer m.mu.Unlock()
 
 	path := m.InboxPath(agentName)
-	err := os.Remove(path)
-	if err != nil && !os.IsNotExist(err) {
-		return err
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("mailbox clear: %w", err)
 	}
 	return nil
 }
@@ -176,7 +170,8 @@ func FormatMessagesAsXML(messages []agentsdk.MailboxMessage) string {
 		if msg.Summary != "" {
 			summaryAttr = fmt.Sprintf(` summary="%s"`, html.EscapeString(msg.Summary))
 		}
-		sb.WriteString(fmt.Sprintf("<teammate_message teammate_id=\"%s\"%s%s>\n%s\n</teammate_message>\n", html.EscapeString(msg.From), colorAttr, summaryAttr, html.EscapeString(msg.Text)))
+		sb.WriteString(fmt.Sprintf("<teammate_message teammate_id=\"%s\"%s%s>\n%s\n</teammate_message>\n",
+			html.EscapeString(msg.From), colorAttr, summaryAttr, html.EscapeString(msg.Text)))
 	}
 	return sb.String()
 }

--- a/internal/team/mailbox_test.go
+++ b/internal/team/mailbox_test.go
@@ -1,0 +1,108 @@
+package team
+
+import (
+	"testing"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMailboxWriteAndRead(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+
+	msg := agentsdk.MailboxMessage{
+		From: "alice",
+		To:   "bob",
+		Text: "hello",
+		Type: agentsdk.MessageTypeText,
+	}
+	require.NoError(t, mb.Write("bob", msg))
+
+	messages, err := mb.Read("bob")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.Equal(t, "alice", messages[0].From)
+	require.Equal(t, "hello", messages[0].Text)
+}
+
+func TestMailboxReadEmpty(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+
+	messages, err := mb.Read("nobody")
+	require.NoError(t, err)
+	require.Empty(t, messages)
+}
+
+func TestMailboxReadUnread(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+
+	require.NoError(t, mb.Write("bob", agentsdk.MailboxMessage{From: "alice", Text: "msg1", Type: agentsdk.MessageTypeText}))
+	require.NoError(t, mb.Write("bob", agentsdk.MailboxMessage{From: "alice", Text: "msg2", Type: agentsdk.MessageTypeText}))
+
+	unread, err := mb.ReadUnread("bob")
+	require.NoError(t, err)
+	require.Len(t, unread, 2)
+
+	require.NoError(t, mb.MarkRead("bob", 0))
+
+	unread, err = mb.ReadUnread("bob")
+	require.NoError(t, err)
+	require.Len(t, unread, 1)
+	require.Equal(t, "msg2", unread[0].Text)
+}
+
+func TestMailboxMarkReadOutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+
+	err := mb.MarkRead("bob", 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "out of range")
+}
+
+func TestMailboxMarkAllRead(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+
+	require.NoError(t, mb.Write("bob", agentsdk.MailboxMessage{From: "alice", Text: "msg1", Type: agentsdk.MessageTypeText}))
+	require.NoError(t, mb.Write("bob", agentsdk.MailboxMessage{From: "alice", Text: "msg2", Type: agentsdk.MessageTypeText}))
+	require.NoError(t, mb.MarkAllRead("bob"))
+
+	unread, err := mb.ReadUnread("bob")
+	require.NoError(t, err)
+	require.Empty(t, unread)
+}
+
+func TestMailboxClear(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+
+	require.NoError(t, mb.Write("bob", agentsdk.MailboxMessage{From: "alice", Text: "msg1", Type: agentsdk.MessageTypeText}))
+	require.NoError(t, mb.Clear("bob"))
+
+	messages, err := mb.Read("bob")
+	require.NoError(t, err)
+	require.Empty(t, messages)
+}
+
+func TestMailboxClearMissing(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+
+	require.NoError(t, mb.Clear("nobody"))
+}
+
+func TestFormatMessagesAsXML(t *testing.T) {
+	messages := []agentsdk.MailboxMessage{
+		{From: "alice", Text: "hello", Color: "\033[34m"},
+		{From: "bob", Text: "world", Summary: "greeting"},
+	}
+	xml := FormatMessagesAsXML(messages)
+	require.Contains(t, xml, `<teammate_message teammate_id="alice" color="`)
+	require.Contains(t, xml, `hello`)
+	require.Contains(t, xml, `<teammate_message teammate_id="bob" summary="greeting">`)
+	require.Contains(t, xml, `world`)
+}

--- a/pkg/agentsdk/team.go
+++ b/pkg/agentsdk/team.go
@@ -1,0 +1,29 @@
+package agentsdk
+
+import "time"
+
+// MessageType categorizes messages in the team mailbox.
+type MessageType string
+
+const (
+	MessageTypeText             MessageType = "text"
+	MessageTypeShutdownRequest  MessageType = "shutdown_request"
+	MessageTypeShutdownApproved MessageType = "shutdown_approved"
+	MessageTypeShutdownRejected MessageType = "shutdown_rejected"
+	MessageTypeTaskUpdate       MessageType = "task_update"
+	MessageTypeIdle             MessageType = "idle"
+	MessageTypePlanApproval     MessageType = "plan_approval"
+)
+
+// MailboxMessage is a single message in an agent's inbox.
+type MailboxMessage struct {
+	From      string                 `json:"from"`
+	To        string                 `json:"to"`
+	Text      string                 `json:"text,omitempty"`
+	Type      MessageType            `json:"type"`
+	Timestamp time.Time              `json:"timestamp"`
+	Color     string                 `json:"color,omitempty"`
+	Summary   string                 `json:"summary,omitempty"`
+	Data      map[string]interface{} `json:"data,omitempty"`
+	Read      bool                   `json:"read"`
+}

--- a/pkg/agentsdk/team_test.go
+++ b/pkg/agentsdk/team_test.go
@@ -1,0 +1,32 @@
+package agentsdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMailboxMessageDefaults(t *testing.T) {
+	msg := MailboxMessage{
+		From: "alice",
+		To:   "bob",
+		Text: "hello",
+		Type: MessageTypeText,
+	}
+	require.Equal(t, "alice", msg.From)
+	require.Equal(t, "bob", msg.To)
+	require.Equal(t, "hello", msg.Text)
+	require.Equal(t, MessageTypeText, msg.Type)
+	require.False(t, msg.Read)
+	require.Nil(t, msg.Data)
+}
+
+func TestMessageTypeConstants(t *testing.T) {
+	require.Equal(t, MessageType("text"), MessageTypeText)
+	require.Equal(t, MessageType("shutdown_request"), MessageTypeShutdownRequest)
+	require.Equal(t, MessageType("shutdown_approved"), MessageTypeShutdownApproved)
+	require.Equal(t, MessageType("shutdown_rejected"), MessageTypeShutdownRejected)
+	require.Equal(t, MessageType("task_update"), MessageTypeTaskUpdate)
+	require.Equal(t, MessageType("idle"), MessageTypeIdle)
+	require.Equal(t, MessageType("plan_approval"), MessageTypePlanApproval)
+}


### PR DESCRIPTION
## Summary

Port ccgo's `team/mailbox.go` to rubichan. A `Mailbox` uses file-based JSON for async A2A messaging between agents.

## Changes

- `pkg/agentsdk/team.go` — `MailboxMessage` struct + `MessageType` constants (text, shutdown_request, task_update, etc.)
- `pkg/agentsdk/team_test.go` — SDK type tests
- `internal/team/mailbox.go` — `Mailbox` implementation:
  - Thread-safe with `sync.Mutex`
  - Per-agent JSON inbox files under configurable directory
  - `Write`, `Read`, `ReadUnread`, `MarkRead`, `MarkAllRead`, `Clear`
  - `FormatMessagesAsXML` for prompt injection
- `internal/team/mailbox_test.go` — 8 tests covering all methods

## Review fixes applied

- XML output uses actual newlines (not escaped `\\n`)
- JSON unmarshal errors propagated (not silently ignored)
- XML content escaped with `html.EscapeString`

## Validation

```bash
go test ./pkg/agentsdk/... ./internal/team/...
gofmt -l .
```

All tests pass, formatting clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent messaging system with persistent message storage and management capabilities
  * Introduced message types: text, shutdown requests/approvals/rejections, task updates, idle notifications, and plan approvals
  * Added message read/unread tracking and filtering functionality
  * Added XML formatting for message display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->