### PR TITLE
[BEHAVIORAL] Snippet compaction with boundary markers and token tracking

### DIFF
--- a/internal/agent/compaction_snip.go
+++ b/internal/agent/compaction_snip.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
@@ -15,26 +17,147 @@ func NewHeadTailSnipStrategy() agentsdk.CompactionStrategy {
 func (s *headTailSnipStrategy) Name() string { return "head_tail_snip" }
 
 func (s *headTailSnipStrategy) Compact(_ context.Context, messages []agentsdk.Message, budget int) ([]agentsdk.Message, error) {
-	for estimateMessageTokens(messages) > budget && len(messages) > 4 {
-		prevLen := len(messages)
-		cutStart := len(messages) / 3
-		cutEnd := cutStart + 2
+	result := s.Snip(messages, budget)
+	return result.Messages, nil
+}
 
-		if cutEnd >= len(messages) {
-			break
-		}
-		if hasToolUse(messages[cutStart]) || hasToolResult(messages[cutStart]) {
-			cutEnd++
-		}
-		if cutEnd >= len(messages) {
-			break
-		}
+// Snip performs head-tail compaction and returns detailed result.
+func (s *headTailSnipStrategy) Snip(messages []agentsdk.Message, budget int) agentsdk.SnipResult {
+	if len(messages) <= 4 {
+		return agentsdk.SnipResult{Messages: messages}
+	}
 
-		messages = append(messages[:cutStart:cutStart], messages[cutEnd:]...)
+	beforeTokens := estimateTokens(messages)
+	if beforeTokens <= budget {
+		return agentsdk.SnipResult{Messages: messages}
+	}
 
-		if len(messages) == prevLen {
-			break
+	// Determine how many messages to keep: preserve head (1/3) + tail (2/3)
+	cutStart := len(messages) / 3
+	if cutStart < 1 {
+		cutStart = 1
+	}
+	cutEnd := cutStart + 2
+	if cutEnd >= len(messages) {
+		return agentsdk.SnipResult{Messages: messages}
+	}
+
+	// Don't split tool_use/tool_result pairs
+	if cutEnd < len(messages) && (hasToolUseMsg(messages[cutStart]) || hasToolResultMsg(messages[cutStart])) {
+		cutEnd++
+	}
+	if cutEnd >= len(messages) {
+		return agentsdk.SnipResult{Messages: messages}
+	}
+
+	head := messages[:cutStart]
+	tail := messages[cutEnd:]
+
+	// Collect snipped UUIDs
+	var snippedUUIDs []string
+	for i := cutStart; i < cutEnd && i < len(messages); i++ {
+		if id, ok := messages[i].Metadata["uuid"].(string); ok && id != "" {
+			snippedUUIDs = append(snippedUUIDs, id)
 		}
 	}
-	return messages, nil
+
+	// Calculate tokens freed
+	afterTokens := estimateTokens(append(head, tail...))
+	tokensFreed := beforeTokens - afterTokens
+	if tokensFreed < 0 {
+		tokensFreed = 0
+	}
+
+	// Build boundary marker message
+	boundaryText := fmt.Sprintf("[Context snipped: %d older messages removed to save context space]", len(snippedUUIDs))
+	boundaryMsg := agentsdk.Message{
+		Role: "system",
+		Content: []agentsdk.ContentBlock{{
+			Type: "text",
+			Text: boundaryText,
+		}},
+	}
+
+	result := make([]agentsdk.Message, 0, len(head)+1+len(tail))
+	result = append(result, head...)
+	result = append(result, boundaryMsg)
+	result = append(result, tail...)
+
+	return agentsdk.SnipResult{
+		Messages:     result,
+		TokensFreed:  tokensFreed,
+		BoundaryMsg:  &boundaryMsg,
+		SnippedUUIDs: snippedUUIDs,
+	}
+}
+
+// InjectMessageIDTags adds [id:xxxx] tags to user message text blocks for cross-referencing.
+func InjectMessageIDTags(messages []agentsdk.Message) []agentsdk.Message {
+	result := make([]agentsdk.Message, len(messages))
+	for i, msg := range messages {
+		result[i] = msg
+		if msg.Role != "user" {
+			continue
+		}
+		uuid := ""
+		if msg.Metadata != nil {
+			if id, ok := msg.Metadata["uuid"].(string); ok {
+				uuid = id
+			}
+		}
+		if uuid == "" {
+			continue
+		}
+		tag := fmt.Sprintf("[id:%s] ", deriveShortMessageID(uuid))
+		var newContent []agentsdk.ContentBlock
+		for _, block := range msg.Content {
+			if block.Type == "text" && !strings.HasPrefix(block.Text, "[id:") {
+				newContent = append(newContent, agentsdk.ContentBlock{
+					Type: block.Type,
+					Text: tag + block.Text,
+				})
+			} else {
+				newContent = append(newContent, block)
+			}
+		}
+		result[i].Content = newContent
+	}
+	return result
+}
+
+func deriveShortMessageID(uuid string) string {
+	if len(uuid) < 8 {
+		return uuid
+	}
+	return uuid[:8]
+}
+
+func hasToolUseMsg(msg agentsdk.Message) bool {
+	for _, block := range msg.Content {
+		if block.Type == "tool_use" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasToolResultMsg(msg agentsdk.Message) bool {
+	for _, block := range msg.Content {
+		if block.Type == "tool_result" {
+			return true
+		}
+	}
+	return false
+}
+
+func estimateTokens(msgs []agentsdk.Message) int {
+	total := 0
+	for _, msg := range msgs {
+		for _, block := range msg.Content {
+			chars := len(block.Text) + len(block.ID) + len(block.Name) +
+				len(block.ToolUseID) + len(block.Input)
+			total += chars/4 + 10
+		}
+	}
+	return total
 }

--- a/internal/agent/compaction_snip.go
+++ b/internal/agent/compaction_snip.go
@@ -41,20 +41,16 @@ func (s *headTailSnipStrategy) Snip(messages []agentsdk.Message, budget int) age
 	}
 
 	// Don't split tool_use/tool_result pairs at either boundary.
-	// If a message at the cut boundary contains tool content, expand the cut
-	// to include the full pair.
-	for cutEnd < len(messages) && hasBlockType(messages[cutStart], agentsdk.BlockTypeToolUse, agentsdk.BlockTypeToolResult) {
+	// If a message at the cut boundary contains tool content, shift the boundary
+	// outward to include the full pair.
+	for cutStart > 0 && hasBlockType(messages[cutStart], agentsdk.BlockTypeToolUse, agentsdk.BlockTypeToolResult) {
 		cutStart--
-		if cutStart < 0 {
-			cutStart = 0
-			break
-		}
 		cutEnd--
 	}
 	for cutEnd < len(messages) && hasBlockType(messages[cutEnd], agentsdk.BlockTypeToolUse, agentsdk.BlockTypeToolResult) {
 		cutEnd++
 	}
-	if cutEnd >= len(messages) {
+	if cutEnd >= len(messages) || cutStart < 0 {
 		return agentsdk.SnipResult{Messages: messages}
 	}
 

--- a/internal/agent/compaction_snip.go
+++ b/internal/agent/compaction_snip.go
@@ -21,7 +21,6 @@ func (s *headTailSnipStrategy) Compact(_ context.Context, messages []agentsdk.Me
 	return result.Messages, nil
 }
 
-// Snip performs head-tail compaction and returns detailed result.
 func (s *headTailSnipStrategy) Snip(messages []agentsdk.Message, budget int) agentsdk.SnipResult {
 	if len(messages) <= 4 {
 		return agentsdk.SnipResult{Messages: messages}
@@ -32,7 +31,6 @@ func (s *headTailSnipStrategy) Snip(messages []agentsdk.Message, budget int) age
 		return agentsdk.SnipResult{Messages: messages}
 	}
 
-	// Determine how many messages to keep: preserve head (1/3) + tail (2/3)
 	cutStart := len(messages) / 3
 	if cutStart < 1 {
 		cutStart = 1
@@ -42,8 +40,18 @@ func (s *headTailSnipStrategy) Snip(messages []agentsdk.Message, budget int) age
 		return agentsdk.SnipResult{Messages: messages}
 	}
 
-	// Don't split tool_use/tool_result pairs
-	if cutEnd < len(messages) && (hasToolUseMsg(messages[cutStart]) || hasToolResultMsg(messages[cutStart])) {
+	// Don't split tool_use/tool_result pairs at either boundary.
+	// If a message at the cut boundary contains tool content, expand the cut
+	// to include the full pair.
+	for cutEnd < len(messages) && hasBlockType(messages[cutStart], agentsdk.BlockTypeToolUse, agentsdk.BlockTypeToolResult) {
+		cutStart--
+		if cutStart < 0 {
+			cutStart = 0
+			break
+		}
+		cutEnd--
+	}
+	for cutEnd < len(messages) && hasBlockType(messages[cutEnd], agentsdk.BlockTypeToolUse, agentsdk.BlockTypeToolResult) {
 		cutEnd++
 	}
 	if cutEnd >= len(messages) {
@@ -53,7 +61,6 @@ func (s *headTailSnipStrategy) Snip(messages []agentsdk.Message, budget int) age
 	head := messages[:cutStart]
 	tail := messages[cutEnd:]
 
-	// Collect snipped UUIDs
 	var snippedUUIDs []string
 	for i := cutStart; i < cutEnd && i < len(messages); i++ {
 		if id, ok := messages[i].Metadata["uuid"].(string); ok && id != "" {
@@ -61,19 +68,17 @@ func (s *headTailSnipStrategy) Snip(messages []agentsdk.Message, budget int) age
 		}
 	}
 
-	// Calculate tokens freed
-	afterTokens := estimateTokens(append(head, tail...))
+	afterTokens := estimateTokens(head) + estimateTokens(tail)
 	tokensFreed := beforeTokens - afterTokens
 	if tokensFreed < 0 {
 		tokensFreed = 0
 	}
 
-	// Build boundary marker message
 	boundaryText := fmt.Sprintf("[Context snipped: %d older messages removed to save context space]", len(snippedUUIDs))
 	boundaryMsg := agentsdk.Message{
 		Role: "system",
 		Content: []agentsdk.ContentBlock{{
-			Type: "text",
+			Type: agentsdk.BlockTypeText,
 			Text: boundaryText,
 		}},
 	}
@@ -91,27 +96,24 @@ func (s *headTailSnipStrategy) Snip(messages []agentsdk.Message, budget int) age
 	}
 }
 
-// InjectMessageIDTags adds [id:xxxx] tags to user message text blocks for cross-referencing.
 func InjectMessageIDTags(messages []agentsdk.Message) []agentsdk.Message {
 	result := make([]agentsdk.Message, len(messages))
-	for i, msg := range messages {
-		result[i] = msg
+	copy(result, messages)
+	for i, msg := range result {
 		if msg.Role != "user" {
 			continue
 		}
 		uuid := ""
-		if msg.Metadata != nil {
-			if id, ok := msg.Metadata["uuid"].(string); ok {
-				uuid = id
-			}
+		if id, ok := msg.Metadata["uuid"].(string); ok {
+			uuid = id
 		}
 		if uuid == "" {
 			continue
 		}
 		tag := fmt.Sprintf("[id:%s] ", deriveShortMessageID(uuid))
-		var newContent []agentsdk.ContentBlock
+		newContent := make([]agentsdk.ContentBlock, 0, len(msg.Content))
 		for _, block := range msg.Content {
-			if block.Type == "text" && !strings.HasPrefix(block.Text, "[id:") {
+			if block.Type == agentsdk.BlockTypeText && !strings.HasPrefix(block.Text, "[id:") {
 				newContent = append(newContent, agentsdk.ContentBlock{
 					Type: block.Type,
 					Text: tag + block.Text,
@@ -132,19 +134,12 @@ func deriveShortMessageID(uuid string) string {
 	return uuid[:8]
 }
 
-func hasToolUseMsg(msg agentsdk.Message) bool {
+func hasBlockType(msg agentsdk.Message, types ...string) bool {
 	for _, block := range msg.Content {
-		if block.Type == "tool_use" {
-			return true
-		}
-	}
-	return false
-}
-
-func hasToolResultMsg(msg agentsdk.Message) bool {
-	for _, block := range msg.Content {
-		if block.Type == "tool_result" {
-			return true
+		for _, t := range types {
+			if block.Type == t {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/agent/compaction_snip_test.go
+++ b/internal/agent/compaction_snip_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/julianshen/rubichan/pkg/agentsdk"
@@ -21,7 +22,7 @@ func TestHeadTailSnip_PreservesHeadAndTail(t *testing.T) {
 func TestHeadTailSnip_DoesNotOverShrink(t *testing.T) {
 	s := NewHeadTailSnipStrategy()
 	msgs := makeMessages(9)
-	result, err := s.Compact(context.Background(), msgs, estimateMessageTokens(msgs)+1000)
+	result, err := s.Compact(context.Background(), msgs, estimateTokens(msgs)+1000)
 	assert.NoError(t, err)
 	assert.Equal(t, msgs, result, "should not remove messages when within budget")
 }
@@ -61,6 +62,42 @@ func TestHeadTailSnip_SkipsToolUseBoundary(t *testing.T) {
 	}
 }
 
+func TestHeadTailSnip_BoundaryMarkerInserted(t *testing.T) {
+	s := NewHeadTailSnipStrategy()
+	msgs := makeMessages(9)
+	result, err := s.Compact(context.Background(), msgs, 1)
+	assert.NoError(t, err)
+
+	foundBoundary := false
+	for _, m := range result {
+		for _, b := range m.Content {
+			if b.Type == "text" && strings.Contains(b.Text, "[Context snipped:") {
+				foundBoundary = true
+			}
+		}
+	}
+	assert.True(t, foundBoundary, "should insert boundary marker")
+}
+
+func TestHeadTailSnip_TokensFreedTracked(t *testing.T) {
+	strategy := &headTailSnipStrategy{}
+	msgs := makeMessages(9)
+	result := strategy.Snip(msgs, 1)
+	assert.Greater(t, result.TokensFreed, 0, "should track tokens freed")
+	assert.NotEmpty(t, result.SnippedUUIDs, "should collect snipped UUIDs")
+	assert.NotNil(t, result.BoundaryMsg, "should have boundary message")
+}
+
+func TestInjectMessageIDTags(t *testing.T) {
+	msgs := []agentsdk.Message{
+		{Role: "user", Metadata: map[string]any{"uuid": "abc12345-def"}, Content: []agentsdk.ContentBlock{{Type: "text", Text: "hello"}}},
+		{Role: "assistant", Content: []agentsdk.ContentBlock{{Type: "text", Text: "hi"}}},
+	}
+	result := InjectMessageIDTags(msgs)
+	assert.True(t, strings.HasPrefix(result[0].Content[0].Text, "[id:abc12345]"))
+	assert.Equal(t, "hi", result[1].Content[0].Text)
+}
+
 func makeMessages(n int) []agentsdk.Message {
 	msgs := make([]agentsdk.Message, n)
 	for i := 0; i < n; i++ {
@@ -73,6 +110,7 @@ func makeMessages(n int) []agentsdk.Message {
 			Content: []agentsdk.ContentBlock{
 				{Type: "text", Text: string(rune('a' + i))},
 			},
+			Metadata: map[string]any{"uuid": string(rune('a' + i))},
 		}
 	}
 	return msgs

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -238,6 +238,15 @@ func (cm *ContextManager) ForceCompact(ctx context.Context, conv *Conversation) 
 		if tokensAfter < tokensBefore || countAfter < countBefore {
 			result.StrategiesRun = append(result.StrategiesRun, s.Name())
 		}
+		// If strategy supports Snip, capture the result for telemetry
+		if snipper, ok := s.(interface {
+			Snip([]Message, int) SnipResult
+		}); ok {
+			snip := snipper.Snip(conv.messages, messageBudget)
+			if snip.BoundaryMsg != nil {
+				result.SnipResults = append(result.SnipResults, snip)
+			}
+		}
 		conv.messages = msgs
 	}
 

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -238,11 +238,13 @@ func (cm *ContextManager) ForceCompact(ctx context.Context, conv *Conversation) 
 		if tokensAfter < tokensBefore || countAfter < countBefore {
 			result.StrategiesRun = append(result.StrategiesRun, s.Name())
 		}
-		// If strategy supports Snip, capture the result for telemetry
+		// If strategy supports Snip, capture the result for telemetry.
+		// Use msgs (post-Compact) rather than conv.messages (pre-Compact)
+		// to ensure SnipResult reflects the actual compacted state.
 		if snipper, ok := s.(interface {
 			Snip([]Message, int) SnipResult
 		}); ok {
-			snip := snipper.Snip(conv.messages, messageBudget)
+			snip := snipper.Snip(msgs, messageBudget)
 			if snip.BoundaryMsg != nil {
 				result.SnipResults = append(result.SnipResults, snip)
 			}

--- a/internal/agent/sdk_aliases.go
+++ b/internal/agent/sdk_aliases.go
@@ -100,6 +100,12 @@ type ContextBudget = agentsdk.ContextBudget
 // CompactResult reports what happened during a compaction.
 type CompactResult = agentsdk.CompactResult
 
+// SnipResult is the outcome of a head-tail snip compaction.
+type SnipResult = agentsdk.SnipResult
+
+// Message is a single message in a conversation.
+type Message = agentsdk.Message
+
 // --- Summarizer ---
 
 // Summarizer condenses a sequence of messages into a short text summary.

--- a/pkg/agentsdk/compaction.go
+++ b/pkg/agentsdk/compaction.go
@@ -50,6 +50,14 @@ func (b *ContextBudget) UsedPercentage() float64 {
 	return float64(b.UsedTokens()) / float64(ew)
 }
 
+// SnipResult is the outcome of a head-tail snip compaction.
+type SnipResult struct {
+	Messages     []Message
+	TokensFreed  int
+	BoundaryMsg  *Message
+	SnippedUUIDs []string
+}
+
 // CompactResult reports what happened during a compaction.
 type CompactResult struct {
 	BeforeTokens   int
@@ -57,4 +65,5 @@ type CompactResult struct {
 	BeforeMsgCount int
 	AfterMsgCount  int
 	StrategiesRun  []string
+	SnipResults    []SnipResult
 }

--- a/pkg/agentsdk/compaction_test.go
+++ b/pkg/agentsdk/compaction_test.go
@@ -61,3 +61,16 @@ func TestCompactResultFields(t *testing.T) {
 	assert.Equal(t, 5000, r.AfterTokens)
 	assert.Equal(t, []string{"truncate"}, r.StrategiesRun)
 }
+
+func TestSnipResultFields(t *testing.T) {
+	sr := SnipResult{
+		Messages:     []Message{{Role: "user"}},
+		TokensFreed:  42,
+		BoundaryMsg:  &Message{Role: "system"},
+		SnippedUUIDs: []string{"a", "b"},
+	}
+	assert.Len(t, sr.Messages, 1)
+	assert.Equal(t, 42, sr.TokensFreed)
+	assert.NotNil(t, sr.BoundaryMsg)
+	assert.Equal(t, []string{"a", "b"}, sr.SnippedUUIDs)
+}


### PR DESCRIPTION
## Summary

Port ccgo's `query/snip_compact.go` boundary marker feature to rubichan's `HeadTailSnipStrategy`. Compaction is now transparent with boundary markers, token tracking, and message ID tags.

## Changes

- `pkg/agentsdk/compaction.go` — Added `SnipResult` type, `SnipResults` field on `CompactResult`
- `internal/agent/compaction_snip.go` — Rewrote `HeadTailSnipStrategy`:
  - `Snip()` method returns `SnipResult` with boundary marker, tokens freed, snipped UUIDs
  - Inserts `[Context snipped: N older messages removed to save context space]` marker
  - `InjectMessageIDTags()` adds `[id:xxxx]` tags to user messages for cross-referencing
  - Preserves tool_use/tool_result pair invariants
- `internal/agent/compaction_snip_test.go` — 7 tests for boundary marker, token tracking, ID tags
- `internal/agent/context.go` — `ForceCompact` collects `SnipResults` for telemetry
- `internal/agent/sdk_aliases.go` — Added `SnipResult` and `Message` aliases

## Validation

```bash
go test ./pkg/agentsdk/... ./internal/agent/...
gofmt -l .
```

All tests pass, formatting clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved head-tail message compaction that preserves recent context, inserts boundary markers, and reports tokens freed and IDs of removed messages
  * Automatic short [id:...] tags added to user messages when a UUID is present

* **Tests**
  * Added tests validating boundary marker insertion, tokens-freed tracking, UUID collection, and ID-tag injection

* **Telemetry**
  * Compaction results now include detailed snip telemetry entries for richer reporting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->