### PR TITLE
[BEHAVIORAL] Session memory file with periodic updates

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -197,6 +197,11 @@ func WithPrefetchManager(pm *PrefetchManager) AgentOption {
 	return func(a *Agent) { a.prefetchMgr = pm }
 }
 
+// WithSessionMemory attaches a session memory service to the agent.
+func WithSessionMemory(sm *SessionMemoryService) AgentOption {
+	return func(a *Agent) { a.sessionMemory = sm }
+}
+
 // WorkingDir returns the agent's effective working directory.
 // The value is frozen at construction time and never changes.
 func (a *Agent) WorkingDir() string {
@@ -377,6 +382,7 @@ type Agent struct {
 	agentRegistry       *AgentRegistry
 	stopHookRegistry    *hooks.StopHookRegistry
 	prefetchMgr         *PrefetchManager
+	sessionMemory       *SessionMemoryService
 }
 
 const maxUIRequestInputBytes = 2048
@@ -413,6 +419,10 @@ func New(p provider.LLMProvider, t *tools.Registry, approve ApprovalFunc, cfg *c
 	// Freeze working directory at construction time.
 	if a.workingDir == "" {
 		a.workingDir, _ = os.Getwd()
+	}
+	// Initialize session memory if not provided.
+	if a.sessionMemory == nil {
+		a.sessionMemory = NewSessionMemoryService(a.workingDir)
 	}
 	// Load cross-session memories into system prompt.
 	var memories []MemoryEntry
@@ -1977,6 +1987,17 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 
 		// Drain any pending wake events from background subagents.
 		a.drainWakeEvents(ctx, ch)
+
+		// Trigger session memory extraction after tool execution if enough
+		// tool calls have accumulated since the last update.
+		if a.sessionMemory != nil && a.sessionMemory.ShouldExtract(len(a.conversation.Messages())) {
+			go func() {
+				_, err := a.sessionMemory.Extract(ctx, a.conversation.Messages(), a.provider.Stream, a.conversation.SystemPrompt())
+				if err != nil {
+					a.logger.Warn("session memory extraction failed: %v", err)
+				}
+			}()
+		}
 
 		if nudge := a.context.BudgetNudge(a.conversation); nudge != "" && !ls.nudgeEmitted {
 			a.conversation.AddUser(nudge)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1990,13 +1990,16 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 
 		// Trigger session memory extraction after tool execution if enough
 		// tool calls have accumulated since the last update.
-		if a.sessionMemory != nil && a.sessionMemory.ShouldExtract(len(a.conversation.Messages())) {
-			go func() {
-				_, err := a.sessionMemory.Extract(ctx, a.conversation.Messages(), a.provider.Stream, a.conversation.SystemPrompt())
-				if err != nil {
-					a.logger.Warn("session memory extraction failed: %v", err)
-				}
-			}()
+		if a.sessionMemory != nil {
+			a.sessionMemory.RecordTurn()
+			if a.sessionMemory.ShouldExtract(len(a.conversation.Messages())) {
+				go func() {
+					_, err := a.sessionMemory.Extract(ctx, a.conversation.Messages(), a.provider.Stream, a.conversation.SystemPrompt())
+					if err != nil {
+						a.logger.Warn("session memory extraction failed: %v", err)
+					}
+				}()
+			}
 		}
 
 		if nudge := a.context.BudgetNudge(a.conversation); nudge != "" && !ls.nudgeEmitted {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1993,12 +1993,13 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		if a.sessionMemory != nil {
 			a.sessionMemory.RecordTurn()
 			if a.sessionMemory.ShouldExtract(len(a.conversation.Messages())) {
-				go func() {
-					_, err := a.sessionMemory.Extract(ctx, a.conversation.Messages(), a.provider.Stream, a.conversation.SystemPrompt())
+				msgs := a.conversation.Messages()
+				go func(msgsCopy []Message) {
+					_, err := a.sessionMemory.Extract(ctx, msgsCopy, a.provider.Stream, a.conversation.SystemPrompt())
 					if err != nil {
 						a.logger.Warn("session memory extraction failed: %v", err)
 					}
-				}()
+				}(msgs)
 			}
 		}
 

--- a/internal/agent/session_memory_service.go
+++ b/internal/agent/session_memory_service.go
@@ -178,8 +178,6 @@ func (s *SessionMemoryService) Extract(
 		s.mu.Unlock()
 	}()
 
-	s.markInitialized()
-
 	notesPath := s.GetMemoryPath()
 	notes, err := s.ReadCurrentMemory()
 	if err != nil {
@@ -219,6 +217,10 @@ func (s *SessionMemoryService) Extract(
 					Input: evt.ToolUse.Input,
 				})
 			}
+		case agentsdk.EventError:
+			if evt.Error != nil {
+				return nil, fmt.Errorf("session memory stream error: %w", evt.Error)
+			}
 		}
 	}
 
@@ -227,6 +229,7 @@ func (s *SessionMemoryService) Extract(
 	s.mu.Lock()
 	s.turnsSinceLast = 0
 	s.mu.Unlock()
+	s.markInitialized()
 
 	return writtenPaths, nil
 }

--- a/internal/agent/session_memory_service.go
+++ b/internal/agent/session_memory_service.go
@@ -1,0 +1,278 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// SessionMemoryConfig controls when and how session memory is extracted.
+type SessionMemoryConfig struct {
+	MinMessageTokensToInit  int
+	MinTokensBetweenUpdate  int
+	ToolCallsBetweenUpdates int
+}
+
+// DefaultSessionMemoryConfig returns the default configuration.
+func DefaultSessionMemoryConfig() SessionMemoryConfig {
+	return SessionMemoryConfig{
+		MinMessageTokensToInit:  10000,
+		MinTokensBetweenUpdate:  5000,
+		ToolCallsBetweenUpdates: 3,
+	}
+}
+
+// DefaultSessionMemoryTemplate is the initial content of session-notes.md.
+const DefaultSessionMemoryTemplate = `# Session Title
+_A short and distinctive 5-10 word descriptive title for the session._
+
+# Current State
+_What is actively being worked on right now?_
+
+# Task specification
+_What did the user ask to build?_
+
+# Files and Functions
+_What are the important files?_
+
+# Workflow
+_What bash commands are usually run?_
+
+# Errors & Corrections
+_Errors encountered and how they were fixed._
+
+# Codebase and System Documentation
+_What are the important system components?_
+
+# Learnings
+_What has worked well? What has not?_
+
+# Key results
+_If the user asked a specific output, repeat the exact result here._
+
+# Worklog
+_Step by step, what was attempted, done?_
+`
+
+// SessionMemoryService maintains a session-notes.md file with structured state.
+type SessionMemoryService struct {
+	mu              sync.Mutex
+	config          SessionMemoryConfig
+	initialized     bool
+	inProgress      bool
+	lastMessageUUID string
+	turnsSinceLast  int
+	tokensAtLast    int
+	homeDir         string
+}
+
+// NewSessionMemoryService creates a service attached to homeDir.
+func NewSessionMemoryService(homeDir string) *SessionMemoryService {
+	return &SessionMemoryService{
+		config:  DefaultSessionMemoryConfig(),
+		homeDir: homeDir,
+	}
+}
+
+// Config returns a copy of the current config.
+func (s *SessionMemoryService) Config() SessionMemoryConfig {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.config
+}
+
+// SetConfig replaces the config.
+func (s *SessionMemoryService) SetConfig(cfg SessionMemoryConfig) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.config = cfg
+}
+
+// GetMemoryPath returns the path to session-notes.md.
+func (s *SessionMemoryService) GetMemoryPath() string {
+	return filepath.Join(s.homeDir, "session-notes.md")
+}
+
+// ReadCurrentMemory reads the current notes file.
+func (s *SessionMemoryService) ReadCurrentMemory() (string, error) {
+	data, err := os.ReadFile(s.GetMemoryPath())
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (s *SessionMemoryService) writeInitialTemplate() error {
+	if err := os.MkdirAll(s.homeDir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(s.GetMemoryPath(), []byte(DefaultSessionMemoryTemplate), 0o600)
+}
+
+// MarkInitialized marks the service as initialized.
+func (s *SessionMemoryService) MarkInitialized() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.initialized = true
+}
+
+// IsInitialized reports whether the service has been initialized.
+func (s *SessionMemoryService) IsInitialized() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.initialized
+}
+
+// Reset clears all state.
+func (s *SessionMemoryService) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.initialized = false
+	s.inProgress = false
+	s.lastMessageUUID = ""
+	s.turnsSinceLast = 0
+	s.tokensAtLast = 0
+}
+
+// ShouldExtract returns true if enough tool calls have passed since last update.
+func (s *SessionMemoryService) ShouldExtract(messageCount int) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if messageCount < 3 {
+		return false
+	}
+	if s.inProgress {
+		return false
+	}
+	s.turnsSinceLast++
+	return s.turnsSinceLast >= s.config.ToolCallsBetweenUpdates
+}
+
+// BuildSessionMemoryUpdatePrompt constructs the prompt for the model.
+func BuildSessionMemoryUpdatePrompt(currentNotes string, notesPath string) string {
+	return fmt.Sprintf(`IMPORTANT: This message and these instructions are NOT part of the actual user conversation.
+
+The file %s has already been read for you. Here are its current contents:
+<current_notes_content>
+%s
+</current_notes_content>
+
+Your ONLY task is to use the Edit tool to update the notes file, then stop. Make all Edit tool calls in parallel in a single message.
+
+CRITICAL RULES FOR EDITING:
+- Do not modify, delete, or add section headers (lines starting with #)
+- Do not modify or delete the italic _section description_ lines
+- ONLY update the actual content below the italic descriptions within each section
+- Write DETAILED, INFO-DENSE content for each section
+- Keep each section under ~2000 tokens
+- Always update "Current State" to reflect the most recent work
+
+Use the Edit tool with file_path: %s
+
+REMEMBER: Only include insights from the actual user conversation. Do not delete or change section headers or italic descriptions.`, notesPath, currentNotes, notesPath)
+}
+
+// TruncateSessionMemoryForCompact truncates each section to maxCharsPerSection.
+func TruncateSessionMemoryForCompact(content string, maxCharsPerSection int) (string, bool) {
+	if maxCharsPerSection <= 0 {
+		maxCharsPerSection = 8000
+	}
+	lines := strings.Split(content, "\n")
+	var outputLines []string
+	var currentSectionLines []string
+	currentSectionHeader := ""
+	wasTruncated := false
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "# ") {
+			result := flushSection(currentSectionHeader, currentSectionLines, maxCharsPerSection)
+			outputLines = append(outputLines, result.lines...)
+			wasTruncated = wasTruncated || result.wasTruncated
+			currentSectionHeader = line
+			currentSectionLines = nil
+		} else {
+			currentSectionLines = append(currentSectionLines, line)
+		}
+	}
+
+	result := flushSection(currentSectionHeader, currentSectionLines, maxCharsPerSection)
+	outputLines = append(outputLines, result.lines...)
+	wasTruncated = wasTruncated || result.wasTruncated
+
+	return strings.Join(outputLines, "\n"), wasTruncated
+}
+
+type flushResult struct {
+	lines        []string
+	wasTruncated bool
+}
+
+func flushSection(header string, sectionLines []string, maxChars int) flushResult {
+	if header == "" {
+		return flushResult{lines: sectionLines, wasTruncated: false}
+	}
+
+	sectionContent := strings.Join(sectionLines, "\n")
+	if len(sectionContent) <= maxChars {
+		return flushResult{lines: append([]string{header}, sectionLines...), wasTruncated: false}
+	}
+
+	charCount := 0
+	keptLines := []string{header}
+	for _, line := range sectionLines {
+		if charCount+len(line)+1 > maxChars {
+			break
+		}
+		keptLines = append(keptLines, line)
+		charCount += len(line) + 1
+	}
+	keptLines = append(keptLines, "\n[... section truncated for length ...]")
+	return flushResult{lines: keptLines, wasTruncated: true}
+}
+
+// CountToolCallsSince counts tool_use blocks in messages after sinceUUID.
+func CountToolCallsSince(messages []Message, sinceUUID string) int {
+	n := 0
+	foundStart := sinceUUID == ""
+	for _, msg := range messages {
+		if !foundStart {
+			if id, ok := msg.Metadata["uuid"].(string); ok && id == sinceUUID {
+				foundStart = true
+			}
+			continue
+		}
+		if msg.Role == "assistant" {
+			for _, block := range msg.Content {
+				if block.Type == "tool_use" {
+					n++
+				}
+			}
+		}
+	}
+	return n
+}
+
+func extractWrittenPaths(blocks []agentsdk.ContentBlock) []string {
+	seen := make(map[string]bool)
+	var paths []string
+	for _, block := range blocks {
+		if block.Type != "tool_use" || (block.Name != "Edit" && block.Name != "Write") {
+			continue
+		}
+		var input map[string]interface{}
+		if err := json.Unmarshal(block.Input, &input); err != nil {
+			continue
+		}
+		if fp, ok := input["file_path"].(string); ok && fp != "" && !seen[fp] {
+			seen[fp] = true
+			paths = append(paths, fp)
+		}
+	}
+	return paths
+}

--- a/internal/agent/session_memory_service.go
+++ b/internal/agent/session_memory_service.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
@@ -152,6 +154,86 @@ func (s *SessionMemoryService) ShouldExtract(messageCount int) bool {
 	}
 	s.turnsSinceLast++
 	return s.turnsSinceLast >= s.config.ToolCallsBetweenUpdates
+}
+
+// Extract triggers a model call to update the session notes file.
+func (s *SessionMemoryService) Extract(
+	ctx context.Context,
+	messages []Message,
+	callModel func(ctx context.Context, req provider.CompletionRequest) (<-chan provider.StreamEvent, error),
+	systemPrompt string,
+) ([]string, error) {
+	s.mu.Lock()
+	if s.inProgress {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("session memory extraction already in progress")
+	}
+	s.inProgress = true
+	s.mu.Unlock()
+
+	defer func() {
+		s.mu.Lock()
+		s.inProgress = false
+		s.mu.Unlock()
+	}()
+
+	s.MarkInitialized()
+
+	notesPath := s.GetMemoryPath()
+	if _, err := os.Stat(notesPath); os.IsNotExist(err) {
+		if writeErr := s.writeInitialTemplate(); writeErr != nil {
+			return nil, fmt.Errorf("write initial template: %w", writeErr)
+		}
+	}
+
+	notes, err := s.ReadCurrentMemory()
+	if err != nil {
+		return nil, fmt.Errorf("read current memory: %w", err)
+	}
+
+	prompt := BuildSessionMemoryUpdatePrompt(notes, notesPath)
+
+	stream, err := callModel(ctx, provider.CompletionRequest{
+		Messages:  append(messages, Message{Role: "user", Content: []agentsdk.ContentBlock{{Type: "text", Text: prompt}}}),
+		System:    systemPrompt,
+		MaxTokens: 16384,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("session memory model call: %w", err)
+	}
+
+	var assistantBlocks []agentsdk.ContentBlock
+	for evt := range stream {
+		switch evt.Type {
+		case "content_block_delta":
+			if evt.Text != "" {
+				assistantBlocks = append(assistantBlocks, agentsdk.ContentBlock{Type: "text", Text: evt.Text})
+			}
+		case "tool_use":
+			if evt.ToolUse != nil {
+				assistantBlocks = append(assistantBlocks, agentsdk.ContentBlock{
+					Type:  "tool_use",
+					ID:    evt.ToolUse.ID,
+					Name:  evt.ToolUse.Name,
+					Input: evt.ToolUse.Input,
+				})
+			}
+		}
+	}
+
+	writtenPaths := extractWrittenPaths(assistantBlocks)
+
+	if len(messages) > 0 {
+		lastMsg := messages[len(messages)-1]
+		s.mu.Lock()
+		if id, ok := lastMsg.Metadata["uuid"].(string); ok {
+			s.lastMessageUUID = id
+		}
+		s.turnsSinceLast = 0
+		s.mu.Unlock()
+	}
+
+	return writtenPaths, nil
 }
 
 // BuildSessionMemoryUpdatePrompt constructs the prompt for the model.

--- a/internal/agent/session_memory_service.go
+++ b/internal/agent/session_memory_service.go
@@ -63,14 +63,12 @@ _Step by step, what was attempted, done?_
 
 // SessionMemoryService maintains a session-notes.md file with structured state.
 type SessionMemoryService struct {
-	mu              sync.Mutex
-	config          SessionMemoryConfig
-	initialized     bool
-	inProgress      bool
-	lastMessageUUID string
-	turnsSinceLast  int
-	tokensAtLast    int
-	homeDir         string
+	mu             sync.Mutex
+	config         SessionMemoryConfig
+	initialized    bool
+	inProgress     bool
+	turnsSinceLast int
+	homeDir        string
 }
 
 // NewSessionMemoryService creates a service attached to homeDir.
@@ -81,14 +79,12 @@ func NewSessionMemoryService(homeDir string) *SessionMemoryService {
 	}
 }
 
-// Config returns a copy of the current config.
 func (s *SessionMemoryService) Config() SessionMemoryConfig {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.config
 }
 
-// SetConfig replaces the config.
 func (s *SessionMemoryService) SetConfig(cfg SessionMemoryConfig) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -109,22 +105,23 @@ func (s *SessionMemoryService) ReadCurrentMemory() (string, error) {
 	return string(data), nil
 }
 
-func (s *SessionMemoryService) writeInitialTemplate() error {
+func (s *SessionMemoryService) writeInitialTemplate() (string, error) {
 	if err := os.MkdirAll(s.homeDir, 0o755); err != nil {
-		return err
+		return "", err
 	}
-	return os.WriteFile(s.GetMemoryPath(), []byte(DefaultSessionMemoryTemplate), 0o600)
+	if err := os.WriteFile(s.GetMemoryPath(), []byte(DefaultSessionMemoryTemplate), 0o600); err != nil {
+		return "", err
+	}
+	return DefaultSessionMemoryTemplate, nil
 }
 
-// MarkInitialized marks the service as initialized.
-func (s *SessionMemoryService) MarkInitialized() {
+func (s *SessionMemoryService) markInitialized() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.initialized = true
 }
 
-// IsInitialized reports whether the service has been initialized.
-func (s *SessionMemoryService) IsInitialized() bool {
+func (s *SessionMemoryService) isInitialized() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.initialized
@@ -136,12 +133,10 @@ func (s *SessionMemoryService) Reset() {
 	defer s.mu.Unlock()
 	s.initialized = false
 	s.inProgress = false
-	s.lastMessageUUID = ""
 	s.turnsSinceLast = 0
-	s.tokensAtLast = 0
 }
 
-// ShouldExtract returns true if enough tool calls have passed since last update.
+// ShouldExtract returns true if enough turns have passed since last update.
 func (s *SessionMemoryService) ShouldExtract(messageCount int) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -152,8 +147,14 @@ func (s *SessionMemoryService) ShouldExtract(messageCount int) bool {
 	if s.inProgress {
 		return false
 	}
-	s.turnsSinceLast++
 	return s.turnsSinceLast >= s.config.ToolCallsBetweenUpdates
+}
+
+// RecordTurn increments the turn counter. Call after each tool execution.
+func (s *SessionMemoryService) RecordTurn() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.turnsSinceLast++
 }
 
 // Extract triggers a model call to update the session notes file.
@@ -177,24 +178,24 @@ func (s *SessionMemoryService) Extract(
 		s.mu.Unlock()
 	}()
 
-	s.MarkInitialized()
+	s.markInitialized()
 
 	notesPath := s.GetMemoryPath()
-	if _, err := os.Stat(notesPath); os.IsNotExist(err) {
-		if writeErr := s.writeInitialTemplate(); writeErr != nil {
-			return nil, fmt.Errorf("write initial template: %w", writeErr)
-		}
-	}
-
 	notes, err := s.ReadCurrentMemory()
 	if err != nil {
-		return nil, fmt.Errorf("read current memory: %w", err)
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("read current memory: %w", err)
+		}
+		notes, err = s.writeInitialTemplate()
+		if err != nil {
+			return nil, fmt.Errorf("write initial template: %w", err)
+		}
 	}
 
 	prompt := BuildSessionMemoryUpdatePrompt(notes, notesPath)
 
 	stream, err := callModel(ctx, provider.CompletionRequest{
-		Messages:  append(messages, Message{Role: "user", Content: []agentsdk.ContentBlock{{Type: "text", Text: prompt}}}),
+		Messages:  append(messages, Message{Role: "user", Content: []agentsdk.ContentBlock{{Type: agentsdk.BlockTypeText, Text: prompt}}}),
 		System:    systemPrompt,
 		MaxTokens: 16384,
 	})
@@ -205,14 +206,14 @@ func (s *SessionMemoryService) Extract(
 	var assistantBlocks []agentsdk.ContentBlock
 	for evt := range stream {
 		switch evt.Type {
-		case "content_block_delta":
+		case agentsdk.EventTextDelta:
 			if evt.Text != "" {
-				assistantBlocks = append(assistantBlocks, agentsdk.ContentBlock{Type: "text", Text: evt.Text})
+				assistantBlocks = append(assistantBlocks, agentsdk.ContentBlock{Type: agentsdk.BlockTypeText, Text: evt.Text})
 			}
-		case "tool_use":
+		case agentsdk.EventToolUse:
 			if evt.ToolUse != nil {
 				assistantBlocks = append(assistantBlocks, agentsdk.ContentBlock{
-					Type:  "tool_use",
+					Type:  agentsdk.BlockTypeToolUse,
 					ID:    evt.ToolUse.ID,
 					Name:  evt.ToolUse.Name,
 					Input: evt.ToolUse.Input,
@@ -223,15 +224,9 @@ func (s *SessionMemoryService) Extract(
 
 	writtenPaths := extractWrittenPaths(assistantBlocks)
 
-	if len(messages) > 0 {
-		lastMsg := messages[len(messages)-1]
-		s.mu.Lock()
-		if id, ok := lastMsg.Metadata["uuid"].(string); ok {
-			s.lastMessageUUID = id
-		}
-		s.turnsSinceLast = 0
-		s.mu.Unlock()
-	}
+	s.mu.Lock()
+	s.turnsSinceLast = 0
+	s.mu.Unlock()
 
 	return writtenPaths, nil
 }
@@ -331,7 +326,7 @@ func CountToolCallsSince(messages []Message, sinceUUID string) int {
 		}
 		if msg.Role == "assistant" {
 			for _, block := range msg.Content {
-				if block.Type == "tool_use" {
+				if block.Type == agentsdk.BlockTypeToolUse {
 					n++
 				}
 			}
@@ -344,7 +339,7 @@ func extractWrittenPaths(blocks []agentsdk.ContentBlock) []string {
 	seen := make(map[string]bool)
 	var paths []string
 	for _, block := range blocks {
-		if block.Type != "tool_use" || (block.Name != "Edit" && block.Name != "Write") {
+		if block.Type != agentsdk.BlockTypeToolUse || (block.Name != "Edit" && block.Name != "Write") {
 			continue
 		}
 		var input map[string]interface{}

--- a/internal/agent/session_memory_service_test.go
+++ b/internal/agent/session_memory_service_test.go
@@ -24,7 +24,7 @@ func TestSessionMemoryService_GetMemoryPath(t *testing.T) {
 func TestSessionMemoryService_WriteAndRead(t *testing.T) {
 	dir := t.TempDir()
 	s := NewSessionMemoryService(dir)
-	err := s.writeInitialTemplate()
+	_, err := s.writeInitialTemplate()
 	require.NoError(t, err)
 	content, err := s.ReadCurrentMemory()
 	require.NoError(t, err)
@@ -35,14 +35,14 @@ func TestSessionMemoryService_WriteAndRead(t *testing.T) {
 func TestShouldExtract(t *testing.T) {
 	dir := t.TempDir()
 	s := NewSessionMemoryService(dir)
-	_ = s.writeInitialTemplate()
+	_, _ = s.writeInitialTemplate()
 
-	// First call: turnsSinceLast becomes 1, not enough
+	// turnsSinceLast starts at 0, not enough
 	assert.False(t, s.ShouldExtract(5))
-	// Simulate 2 more calls
-	s.mu.Lock()
-	s.turnsSinceLast = 2
-	s.mu.Unlock()
+	// Simulate 3 turns
+	s.RecordTurn()
+	s.RecordTurn()
+	s.RecordTurn()
 	assert.True(t, s.ShouldExtract(5))
 }
 

--- a/internal/agent/session_memory_service_test.go
+++ b/internal/agent/session_memory_service_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionMemoryService_DefaultConfig(t *testing.T) {
+	s := NewSessionMemoryService("/tmp/test-session")
+	cfg := s.Config()
+	assert.Equal(t, 3, cfg.ToolCallsBetweenUpdates)
+	assert.Equal(t, 10000, cfg.MinMessageTokensToInit)
+}
+
+func TestSessionMemoryService_GetMemoryPath(t *testing.T) {
+	s := NewSessionMemoryService("/tmp/test-session")
+	assert.Equal(t, "/tmp/test-session/session-notes.md", s.GetMemoryPath())
+}
+
+func TestSessionMemoryService_WriteAndRead(t *testing.T) {
+	dir := t.TempDir()
+	s := NewSessionMemoryService(dir)
+	err := s.writeInitialTemplate()
+	require.NoError(t, err)
+	content, err := s.ReadCurrentMemory()
+	require.NoError(t, err)
+	assert.Contains(t, content, "# Session Title")
+	assert.Contains(t, content, "# Worklog")
+}
+
+func TestShouldExtract(t *testing.T) {
+	dir := t.TempDir()
+	s := NewSessionMemoryService(dir)
+	_ = s.writeInitialTemplate()
+
+	// First call: turnsSinceLast becomes 1, not enough
+	assert.False(t, s.ShouldExtract(5))
+	// Simulate 2 more calls
+	s.mu.Lock()
+	s.turnsSinceLast = 2
+	s.mu.Unlock()
+	assert.True(t, s.ShouldExtract(5))
+}
+
+func TestTruncateSessionMemoryForCompact(t *testing.T) {
+	content := "# Section A\nline1\nline2\n# Section B\n" + strings.Repeat("x", 100)
+	truncated, wasTruncated := TruncateSessionMemoryForCompact(content, 50)
+	assert.True(t, wasTruncated)
+	assert.Contains(t, truncated, "[... section truncated for length ...]")
+	assert.Contains(t, truncated, "# Section A")
+	assert.Contains(t, truncated, "# Section B")
+}
+
+func TestCountToolCallsSince(t *testing.T) {
+	msgs := []agentsdk.Message{
+		{Role: "assistant", Metadata: map[string]any{"uuid": "m1"}, Content: []agentsdk.ContentBlock{{Type: "tool_use", ID: "t1"}}},
+		{Role: "assistant", Metadata: map[string]any{"uuid": "m2"}, Content: []agentsdk.ContentBlock{{Type: "tool_use", ID: "t2"}}},
+		{Role: "assistant", Metadata: map[string]any{"uuid": "m3"}, Content: []agentsdk.ContentBlock{{Type: "tool_use", ID: "t3"}}},
+	}
+	assert.Equal(t, 2, CountToolCallsSince(msgs, "m1"))
+	assert.Equal(t, 1, CountToolCallsSince(msgs, "m2"))
+	assert.Equal(t, 3, CountToolCallsSince(msgs, ""))
+}


### PR DESCRIPTION
## Summary

Port ccgo's `sessionmemory/sessionmemory.go` to rubichan. A `SessionMemoryService` maintains a `session-notes.md` file that the agent updates periodically with structured session state.

## Changes

- `internal/agent/session_memory_service.go` — `SessionMemoryService` with:
  - Default template with 10 sections (Session Title, Current State, Task spec, etc.)
  - `ShouldExtract` triggered every N tool calls (default 3)
  - `Extract` uses forked model call to update notes via Edit tool
  - `TruncateSessionMemoryForCompact` truncates sections for compact injection
  - `CountToolCallsSince` counts tool calls since last update
- `internal/agent/session_memory_service_test.go` — 6 tests
- `internal/agent/agent.go` — Added `WithSessionMemory` option, integrated into `runLoop`

## Validation

```bash
go test ./internal/agent/...
gofmt -l .
```

All tests pass, formatting clean.