### PR TITLE
[BEHAVIORAL] Wire P6-P10 components into Agent lifecycle

### DIFF
--- a/docs/superpowers/plans/2026-04-27-query-loop-improvements-index.md
+++ b/docs/superpowers/plans/2026-04-27-query-loop-improvements-index.md
@@ -108,11 +108,11 @@ Plans D and E can be executed in any order. Plans B, C, F depend on A.
 | P3 | Token Budget Tracker | `2026-05-04-token-budget-tracker.md` | High | ~~Cross-turn budget tracking with diminishing returns detection~~ ✅ Done |
 | P4 | Snippet Compaction Boundary | `2026-05-04-snippet-compaction-boundary.md` | High | ~~Boundary markers + token tracking for transparent compaction~~ ✅ Done |
 | P5 | Session Memory File | `2026-05-04-session-memory-file.md` | Medium | ~~Structured `session-notes.md` updated periodically by agent~~ ✅ Done |
-| P6 | Classifier Improvements | `2026-05-04-two-stage-classifier-improvements.md` | Medium | Real stage1 heuristics + stage2 LLM reasoning + cache |
-| P7 | Tmux Display Layer | `2026-05-04-tmux-display-layer.md` | Low | Real-time multi-agent observability via tmux windows |
-| P8 | CollapseStore | `2026-05-04-collapse-store.md` | Medium | Staged archival of conversation history with commit/drain |
-| P9 | Auto-Dream Consolidation | `2026-05-04-auto-dream-consolidation.md` | Low | Cross-session memory consolidation via periodic "dream" passes |
-| P10 | Agent Summaries | `2026-05-04-agent-summaries.md` | Low | Periodic 3-5 word activity summaries for observability |
+| P6 | Classifier Improvements | `2026-05-04-two-stage-classifier-improvements.md` | Medium | ~~Real stage1 heuristics + stage2 LLM reasoning + cache~~ ✅ Done |
+| P7 | Tmux Display Layer | `2026-05-04-tmux-display-layer.md` | Low | ~~Real-time multi-agent observability via tmux windows~~ ✅ Done |
+| P8 | CollapseStore | `2026-05-04-collapse-store.md` | Medium | ~~Staged archival of conversation history with commit/drain~~ ✅ Done |
+| P9 | Auto-Dream Consolidation | `2026-05-04-auto-dream-consolidation.md` | Low | ~~Cross-session memory consolidation via periodic "dream" passes~~ ✅ Done |
+| P10 | Agent Summaries | `2026-05-04-agent-summaries.md` | Low | ~~Periodic 3-5 word activity summaries for observability~~ ✅ Done |
 
 ## Dependency Graph (Phase 4)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -115,6 +115,30 @@ func WithSummarizer(s Summarizer) AgentOption {
 	}
 }
 
+// WithSummaryCallback sets a callback that receives periodic activity summaries.
+func WithSummaryCallback(cb agentsdk.SummaryCallback) AgentOption {
+	return func(a *Agent) {
+		a.summaryCallback = cb
+	}
+}
+
+// WithAutoDream attaches an auto-dream service for periodic memory consolidation.
+func WithAutoDream(svc *AutoDreamService) AgentOption {
+	return func(a *Agent) {
+		a.autoDreamSvc = svc
+	}
+}
+
+// WithCollapseStore attaches a collapse store for staged conversation archival.
+func WithCollapseStore(store *CollapseStore) AgentOption {
+	return func(a *Agent) {
+		a.collapseStore = store
+		if a.context != nil {
+			a.context.SetCollapseStore(store)
+		}
+	}
+}
+
 // WithMemoryStore attaches a memory store for cross-session learning.
 func WithMemoryStore(ms MemoryStore) AgentOption {
 	return func(a *Agent) {
@@ -383,6 +407,10 @@ type Agent struct {
 	stopHookRegistry    *hooks.StopHookRegistry
 	prefetchMgr         *PrefetchManager
 	sessionMemory       *SessionMemoryService
+	summaryCallback     agentsdk.SummaryCallback
+	summaryHandle       atomic.Pointer[SummaryHandle]
+	autoDreamSvc        *AutoDreamService
+	collapseStore       *CollapseStore
 }
 
 const maxUIRequestInputBytes = 2048
@@ -1001,10 +1029,33 @@ func (a *Agent) Turn(ctx context.Context, userMessage string) (<-chan TurnEvent,
 		a.diffTracker.Reset()
 	}
 
+	// Start periodic summarization if callback is configured.
+	if a.summaryCallback != nil && a.summaryHandle.Load() == nil {
+		handle := StartAgentSummarization(
+			a.sessionID,
+			a.summarizeForSummary,
+			a.basePrompt,
+			func() []provider.Message {
+				return normalizeMessages(a.conversation.Messages())
+			},
+			a.summaryCallback,
+		)
+		if !a.summaryHandle.CompareAndSwap(nil, handle) {
+			// Lost race — another goroutine started first; stop ours.
+			handle.Stop()
+		}
+	}
+
 	ch := make(chan TurnEvent, 64)
 	go func() {
 		a.generation.Add(1)
-		defer a.turnMu.Unlock()
+		defer func() {
+			// Stop summarizer before releasing turnMu to prevent races.
+			if handle := a.summaryHandle.Swap(nil); handle != nil {
+				handle.Stop()
+			}
+			a.turnMu.Unlock()
+		}()
 		defer close(ch)
 		defer func() {
 			if r := recover(); r != nil {
@@ -2035,6 +2086,66 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 	// Reached max turns.
 	a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("max turns (%d) exceeded", a.maxTurns)})
 	a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitMaxTurns))
+
+	// Trigger auto-dream consolidation at session end if configured.
+	// Run async to avoid blocking turnMu on I/O.
+	go a.triggerAutoDream(context.Background())
+}
+
+// triggerAutoDream runs the auto-dream consolidation if conditions are met.
+func (a *Agent) triggerAutoDream(ctx context.Context) {
+	if a.autoDreamSvc == nil || !a.autoDreamSvc.IsGateOpen() {
+		return
+	}
+
+	lock := NewConsolidationLock(a.autoDreamSvc.memoryDir)
+	lastConsolidated, err := lock.ReadLastConsolidatedAt()
+	if err != nil {
+		a.logger.Warn("auto-dream: read last consolidated: %v", err)
+		return
+	}
+
+	transcriptDir := filepath.Join(a.workingDir, ".claude", "transcripts")
+	sessions, err := ListSessionsTouchedSince(transcriptDir, lastConsolidated)
+	if err != nil {
+		a.logger.Warn("auto-dream: list sessions: %v", err)
+		return
+	}
+
+	if !a.autoDreamSvc.ShouldRun(sessions, lastConsolidated, a.sessionID) {
+		return
+	}
+
+	params := agentsdk.DreamParams{
+		MemoryRoot:    a.autoDreamSvc.memoryDir,
+		TranscriptDir: transcriptDir,
+	}
+
+	err = a.autoDreamSvc.ExecuteDream(ctx, params, func(ctx context.Context, prompt string) (string, error) {
+		req := provider.CompletionRequest{
+			Model:     a.model,
+			System:    "You are a memory consolidation assistant.",
+			Messages:  []provider.Message{provider.NewUserMessage(prompt)},
+			MaxTokens: 4096,
+		}
+		stream, err := a.provider.Stream(ctx, req)
+		if err != nil {
+			return "", err
+		}
+		var result strings.Builder
+		for event := range stream {
+			if event.Error != nil {
+				return "", fmt.Errorf("dream stream error: %w", event.Error)
+			}
+			if event.Type == agentsdk.EventTextDelta {
+				result.WriteString(event.Text)
+			}
+		}
+		return result.String(), nil
+	})
+	if err != nil {
+		a.logger.Warn("auto-dream: execute dream: %v", err)
+	}
 }
 
 const maxRepeatedPendingToolRounds = 3
@@ -2628,6 +2739,30 @@ func LoadBootstrapContext(bootstrapPath string) (*knowledgegraph.BootstrapMetada
 	}
 
 	return &metadata, nil
+}
+
+// summarizeForSummary is the model call adapter for the activity summarizer.
+func (a *Agent) summarizeForSummary(ctx context.Context, messages []provider.Message, systemPrompt string) (string, error) {
+	req := provider.CompletionRequest{
+		Model:     a.model,
+		System:    systemPrompt,
+		Messages:  messages,
+		MaxTokens: 64,
+	}
+	stream, err := a.provider.Stream(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	var result strings.Builder
+	for event := range stream {
+		if event.Error != nil {
+			return "", fmt.Errorf("summary stream error: %w", event.Error)
+		}
+		if event.Type == agentsdk.EventTextDelta {
+			result.WriteString(event.Text)
+		}
+	}
+	return result.String(), nil
 }
 
 // BuildBootstrapSystemPromptPrefix creates a system prompt prefix based on bootstrap context.


### PR DESCRIPTION
## Summary
- Add summaryCallback, summaryHandle, autoDreamSvc, collapseStore to Agent struct
- New AgentOptions: WithSummaryCallback, WithAutoDream, WithCollapseStore
- Agent.Turn() starts ActivitySummarizer when callback configured, stops on turn end
- Agent.runLoop() triggers auto-dream consolidation at session end (max turns)
- WithCollapseStore attaches CollapseStore to ContextManager for compaction projection
- Update plan index: mark P6-P10 as done

## Safety fixes
- summaryHandle uses atomic.Pointer to prevent races between Turn() and goroutine cleanup
- Auto-dream runs async with background context to avoid blocking turnMu on I/O
- Stream error handling in both summarizeForSummary and triggerAutoDream callback
- WithCollapseStore nil-guards a.context before calling SetCollapseStore
- Use agentsdk.EventTextDelta constant instead of string literal
- Use provider.NewUserMessage() instead of raw struct literal