### PR TITLE
[BEHAVIORAL] Prompt cache break detection for Anthropic prompt caching

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -139,6 +139,13 @@ func WithCollapseStore(store *CollapseStore) AgentOption {
 	}
 }
 
+// WithCacheBreakDetector attaches a cache break detector for diagnosing prompt cache misses.
+func WithCacheBreakDetector(d *CacheBreakDetector) AgentOption {
+	return func(a *Agent) {
+		a.cacheBreakDetector = d
+	}
+}
+
 // WithMemoryStore attaches a memory store for cross-session learning.
 func WithMemoryStore(ms MemoryStore) AgentOption {
 	return func(a *Agent) {
@@ -411,6 +418,7 @@ type Agent struct {
 	summaryHandle       atomic.Pointer[SummaryHandle]
 	autoDreamSvc        *AutoDreamService
 	collapseStore       *CollapseStore
+	cacheBreakDetector  *CacheBreakDetector
 }
 
 const maxUIRequestInputBytes = 2048
@@ -1528,6 +1536,11 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			systemPrompt = systemPrompt + "\n\n" + toolPrompt
 		}
 
+		// Snapshot cache-key state before model call for break detection.
+		if a.cacheBreakDetector != nil {
+			a.cacheBreakDetector.Snapshot(ls.turnCount, systemPrompt, activeTools, a.model, cacheBreakpoints)
+		}
+
 		// Measure component-level token usage before the LLM call.
 		// Skill prompt fragments are included in systemPrompt via PromptBuilder
 		// but tracked separately for budget visibility.
@@ -1771,6 +1784,13 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			// Accumulate token usage from every stream event.
 			totalInputTokens += event.InputTokens
 			totalOutputTokens += event.OutputTokens
+
+			// Detect prompt cache breaks on message_start.
+			if event.Type == agentsdk.EventMessageStart && a.cacheBreakDetector != nil {
+				if report := a.cacheBreakDetector.RecordUsage(ls.turnCount, event.CacheReadTokens); report != nil {
+					a.logger.Warn("cache break detected: %s", report.Diagnosis)
+				}
+			}
 
 			switch event.Type {
 			case "thinking_delta":

--- a/internal/agent/cache_break_detector.go
+++ b/internal/agent/cache_break_detector.go
@@ -1,0 +1,146 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+const (
+	cacheBreakThresholdPct    = 5.0  // % drop triggers diagnosis
+	cacheBreakThresholdTokens = 2000 // minimum token drop to trigger
+)
+
+// CacheStateSnapshot captures cache-key parameters before a model call.
+type CacheStateSnapshot struct {
+	SystemPromptHash    string
+	ToolsHash           string
+	CacheControlHash    string
+	Model               string
+	TurnNumber          int
+	PrevCacheReadTokens int
+}
+
+// CacheBreakDetector tracks prompt cache stability across turns.
+type CacheBreakDetector struct {
+	mu                  sync.Mutex
+	lastSnapshot        *CacheStateSnapshot
+	lastCacheReadTokens int
+	reports             []agentsdk.CacheBreakReport
+}
+
+// NewCacheBreakDetector creates a new detector.
+func NewCacheBreakDetector() *CacheBreakDetector {
+	return &CacheBreakDetector{}
+}
+
+// Snapshot captures the current cache-key state before a model call.
+func (d *CacheBreakDetector) Snapshot(turnNumber int, systemPrompt string, tools []agentsdk.ToolDef, model string, cacheBreakpoints []int) *CacheStateSnapshot {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	snap := &CacheStateSnapshot{
+		SystemPromptHash:    hashString(systemPrompt),
+		ToolsHash:           hashToolDefs(tools),
+		CacheControlHash:    hashInts(cacheBreakpoints),
+		Model:               model,
+		TurnNumber:          turnNumber,
+		PrevCacheReadTokens: d.lastCacheReadTokens,
+	}
+	d.lastSnapshot = snap
+	return snap
+}
+
+// RecordUsage compares actual cache read tokens against baseline and diagnoses breaks.
+func (d *CacheBreakDetector) RecordUsage(turnNumber, cacheReadTokens int) *agentsdk.CacheBreakReport {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.lastSnapshot == nil {
+		d.lastCacheReadTokens = cacheReadTokens
+		return nil
+	}
+
+	prev := d.lastSnapshot.PrevCacheReadTokens
+	if prev <= 0 {
+		d.lastCacheReadTokens = cacheReadTokens
+		return nil
+	}
+
+	delta := cacheReadTokens - prev
+	dropPct := float64(-delta) / float64(prev) * 100
+
+	if dropPct < cacheBreakThresholdPct || -delta < cacheBreakThresholdTokens {
+		d.lastCacheReadTokens = cacheReadTokens
+		return nil
+	}
+
+	report := agentsdk.CacheBreakReport{
+		TurnNumber:        turnNumber,
+		ExpectedCacheRead: prev,
+		ActualCacheRead:   cacheReadTokens,
+		CacheReadDelta:    delta,
+		Diagnosis:         d.diagnose(delta),
+		Timestamp:         timeNow(),
+	}
+	d.reports = append(d.reports, report)
+	d.lastCacheReadTokens = cacheReadTokens
+	return &report
+}
+
+// diagnose returns a human-readable explanation for the cache break.
+func (d *CacheBreakDetector) diagnose(delta int) string {
+	if d.lastSnapshot == nil {
+		return "unknown: no prior snapshot"
+	}
+	return fmt.Sprintf("cache read dropped by %d tokens (%.1f%%); check system prompt, tools, or cache_control changes",
+		-delta, float64(-delta)/float64(d.lastSnapshot.PrevCacheReadTokens)*100)
+}
+
+// Reports returns all detected cache break reports.
+func (d *CacheBreakDetector) Reports() []agentsdk.CacheBreakReport {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]agentsdk.CacheBreakReport(nil), d.reports...)
+}
+
+// Reset clears all state.
+func (d *CacheBreakDetector) Reset() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.lastSnapshot = nil
+	d.lastCacheReadTokens = 0
+	d.reports = d.reports[:0]
+}
+
+func hashString(s string) string {
+	h := sha256.New()
+	h.Write([]byte(s))
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func hashToolDefs(tools []agentsdk.ToolDef) string {
+	h := sha256.New()
+	for _, t := range tools {
+		h.Write([]byte(t.Name))
+		h.Write([]byte(t.Description))
+		h.Write(t.InputSchema)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func hashInts(ints []int) string {
+	h := sha256.New()
+	for _, v := range ints {
+		h.Write([]byte(fmt.Sprintf("%d,", v)))
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// timeNow is a variable for testability.
+var timeNow = func() time.Time {
+	return time.Now()
+}

--- a/internal/agent/cache_break_detector_test.go
+++ b/internal/agent/cache_break_detector_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheBreakDetectorSnapshot(t *testing.T) {
+	d := NewCacheBreakDetector()
+	snap := d.Snapshot(1, "system prompt", nil, "claude-3", []int{10})
+	require.NotNil(t, snap)
+	require.Equal(t, 1, snap.TurnNumber)
+	require.Equal(t, "claude-3", snap.Model)
+}
+
+func TestCacheBreakDetectorNoBreak(t *testing.T) {
+	d := NewCacheBreakDetector()
+	d.Snapshot(1, "system", nil, "model", nil)
+	d.RecordUsage(1, 10000) // establish baseline
+
+	d.Snapshot(2, "system", nil, "model", nil)
+	r := d.RecordUsage(2, 9800) // 2% drop, below 5% threshold
+	require.Nil(t, r)
+}
+
+func TestCacheBreakDetectorDetectsBreak(t *testing.T) {
+	d := NewCacheBreakDetector()
+	d.Snapshot(1, "system", nil, "model", nil)
+	d.RecordUsage(1, 10000) // establish baseline
+
+	d.Snapshot(2, "changed system", nil, "model", nil)
+	r := d.RecordUsage(2, 1000) // 90% drop
+	require.NotNil(t, r)
+	require.Equal(t, -9000, r.CacheReadDelta)
+	require.Contains(t, r.Diagnosis, "9000 tokens")
+}
+
+func TestCacheBreakDetectorSmallDropIgnored(t *testing.T) {
+	d := NewCacheBreakDetector()
+	d.Snapshot(1, "system", nil, "model", nil)
+	d.RecordUsage(1, 10000)
+
+	d.Snapshot(2, "system", nil, "model", nil)
+	r := d.RecordUsage(2, 7900) // 21% drop, 2100 tokens > 2000 threshold
+	require.NotNil(t, r)
+	require.Equal(t, -2100, r.CacheReadDelta)
+}
+
+func TestCacheBreakDetectorReports(t *testing.T) {
+	d := NewCacheBreakDetector()
+	d.Snapshot(1, "s", nil, "m", nil)
+	d.RecordUsage(1, 10000)
+	d.Snapshot(2, "s2", nil, "m", nil)
+	d.RecordUsage(2, 1000)
+
+	require.Len(t, d.Reports(), 1)
+	d.Reset()
+	require.Len(t, d.Reports(), 0)
+}
+
+func TestCacheBreakDetectorFirstTurnNoBreak(t *testing.T) {
+	d := NewCacheBreakDetector()
+	d.Snapshot(1, "system", nil, "model", nil)
+	r := d.RecordUsage(1, 5000) // first turn, no prior baseline
+	require.Nil(t, r)
+}

--- a/pkg/agentsdk/cache.go
+++ b/pkg/agentsdk/cache.go
@@ -1,0 +1,17 @@
+package agentsdk
+
+import "time"
+
+// CacheBreakReport describes why a prompt cache miss occurred.
+type CacheBreakReport struct {
+	TurnNumber          int
+	ExpectedCacheRead   int    // baseline from previous turn
+	ActualCacheRead     int    // actual cache read tokens
+	CacheReadDelta      int    // negative = cache miss
+	Diagnosis           string // human-readable cause
+	SystemPromptChanged bool
+	ToolsChanged        bool
+	CacheControlChanged bool
+	ModelChanged        bool
+	Timestamp           time.Time
+}

--- a/pkg/agentsdk/cache_test.go
+++ b/pkg/agentsdk/cache_test.go
@@ -1,0 +1,23 @@
+package agentsdk
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheBreakReport(t *testing.T) {
+	r := CacheBreakReport{
+		TurnNumber:          5,
+		ExpectedCacheRead:   10000,
+		ActualCacheRead:     2000,
+		CacheReadDelta:      -8000,
+		Diagnosis:           "system prompt changed",
+		SystemPromptChanged: true,
+		Timestamp:           time.Now(),
+	}
+	require.Equal(t, 5, r.TurnNumber)
+	require.Equal(t, -8000, r.CacheReadDelta)
+	require.True(t, r.SystemPromptChanged)
+}


### PR DESCRIPTION
## Summary
- CacheBreakDetector tracks cache read tokens across turns
- Snapshot() captures cache-key state before model call (system prompt hash, tools hash, cache_control hash, model)
- RecordUsage() compares actual vs expected cache read tokens
- Triggers diagnosis when drop >5% AND >2,000 tokens
- CacheBreakReport with human-readable diagnosis and timestamp
- Integration: snapshot before model call in runLoop, record on message_start event
- WithCacheBreakDetector AgentOption for configuration
- Ports Claude Code's promptCacheBreakDetection.ts pattern to Go