### PR TITLE
[BEHAVIORAL] Cached microcompact via Anthropic cache_edits API

### DIFF
--- a/internal/agent/cached_microcompact.go
+++ b/internal/agent/cached_microcompact.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"sync"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// CachedMicrocompactService uses Anthropic's cache_edits API to remove tool
+// results without invalidating the cached prefix.
+type CachedMicrocompactService struct {
+	mu           sync.Mutex
+	pendingEdits []agentsdk.CacheEdit
+	enabled      bool
+}
+
+// NewCachedMicrocompactService creates a new service.
+func NewCachedMicrocompactService(enabled bool) *CachedMicrocompactService {
+	return &CachedMicrocompactService{
+		enabled: enabled,
+	}
+}
+
+// IsEnabled returns whether the service is enabled.
+func (s *CachedMicrocompactService) IsEnabled() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.enabled
+}
+
+// QueueEdit queues a deletion for a tool result by its tool_use_id.
+func (s *CachedMicrocompactService) QueueEdit(toolUseID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.enabled {
+		return
+	}
+	s.pendingEdits = append(s.pendingEdits, agentsdk.CacheEdit{
+		Type:           agentsdk.CacheEditDelete,
+		CacheReference: toolUseID,
+	})
+}
+
+// TakeEdits returns and clears all pending edits.
+func (s *CachedMicrocompactService) TakeEdits() []agentsdk.CacheEdit {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	edits := s.pendingEdits
+	s.pendingEdits = nil
+	return edits
+}
+
+// HasEdits returns true if there are pending edits.
+func (s *CachedMicrocompactService) HasEdits() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.pendingEdits) > 0
+}
+
+// Reset clears all pending edits.
+func (s *CachedMicrocompactService) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pendingEdits = nil
+}

--- a/internal/agent/cached_microcompact_test.go
+++ b/internal/agent/cached_microcompact_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCachedMicrocompactQueueAndTake(t *testing.T) {
+	s := NewCachedMicrocompactService(true)
+	s.QueueEdit("tu_01")
+	s.QueueEdit("tu_02")
+
+	require.True(t, s.HasEdits())
+	edits := s.TakeEdits()
+	require.Len(t, edits, 2)
+	require.Equal(t, "tu_01", edits[0].CacheReference)
+	require.False(t, s.HasEdits())
+}
+
+func TestCachedMicrocompactDisabled(t *testing.T) {
+	s := NewCachedMicrocompactService(false)
+	s.QueueEdit("tu_01")
+	require.False(t, s.HasEdits())
+}
+
+func TestCachedMicrocompactReset(t *testing.T) {
+	s := NewCachedMicrocompactService(true)
+	s.QueueEdit("tu_01")
+	s.Reset()
+	require.False(t, s.HasEdits())
+}

--- a/internal/provider/anthropic/transformer.go
+++ b/internal/provider/anthropic/transformer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/provider/normalize"
 	"github.com/julianshen/rubichan/internal/tools"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
 // API wire-format types for Anthropic v1 messages endpoint.
@@ -45,14 +46,20 @@ type apiTool struct {
 // apiContentBlock is the Anthropic-specific content block for serialization.
 // The Anthropic API uses "content" (not "text") for tool_result blocks.
 type apiContentBlock struct {
-	Type      string          `json:"type"`
-	Text      string          `json:"text,omitempty"`
-	ID        string          `json:"id,omitempty"`
-	Name      string          `json:"name,omitempty"`
-	Input     json.RawMessage `json:"input,omitempty"`
-	ToolUseID string          `json:"tool_use_id,omitempty"`
-	Content   string          `json:"content,omitempty"`
-	IsError   bool            `json:"is_error,omitempty"`
+	Type       string          `json:"type"`
+	Text       string          `json:"text,omitempty"`
+	ID         string          `json:"id,omitempty"`
+	Name       string          `json:"name,omitempty"`
+	Input      json.RawMessage `json:"input,omitempty"`
+	ToolUseID  string          `json:"tool_use_id,omitempty"`
+	Content    string          `json:"content,omitempty"`
+	IsError    bool            `json:"is_error,omitempty"`
+	CacheEdits []apiCacheEdit  `json:"cache_edits,omitempty"`
+}
+
+type apiCacheEdit struct {
+	Type           string `json:"type"`            // "delete"
+	CacheReference string `json:"cache_reference"` // tool_use_id
 }
 
 // Transformer implements provider.MessageTransformer for the Anthropic API.
@@ -167,12 +174,13 @@ func convertContentBlocks(blocks []provider.ContentBlock) []apiContentBlock {
 	var out []apiContentBlock
 	for _, b := range blocks {
 		cb := apiContentBlock{
-			Type:      b.Type,
-			ID:        b.ID,
-			Name:      b.Name,
-			Input:     b.Input,
-			ToolUseID: b.ToolUseID,
-			IsError:   b.IsError,
+			Type:       b.Type,
+			ID:         b.ID,
+			Name:       b.Name,
+			Input:      b.Input,
+			ToolUseID:  b.ToolUseID,
+			IsError:    b.IsError,
+			CacheEdits: convertCacheEdits(b.CacheEdits),
 		}
 		switch b.Type {
 		case "tool_result":
@@ -181,6 +189,20 @@ func convertContentBlocks(blocks []provider.ContentBlock) []apiContentBlock {
 			cb.Text = b.Text
 		}
 		out = append(out, cb)
+	}
+	return out
+}
+
+func convertCacheEdits(edits []agentsdk.CacheEdit) []apiCacheEdit {
+	if len(edits) == 0 {
+		return nil
+	}
+	var out []apiCacheEdit
+	for _, e := range edits {
+		out = append(out, apiCacheEdit{
+			Type:           string(e.Type),
+			CacheReference: e.CacheReference,
+		})
 	}
 	return out
 }

--- a/pkg/agentsdk/cache_edit.go
+++ b/pkg/agentsdk/cache_edit.go
@@ -1,0 +1,20 @@
+package agentsdk
+
+// CacheEditType represents the type of cache edit operation.
+type CacheEditType string
+
+const (
+	CacheEditDelete CacheEditType = "delete"
+)
+
+// CacheEdit represents an edit to remove content from the cached prefix.
+type CacheEdit struct {
+	Type           CacheEditType `json:"type"`
+	CacheReference string        `json:"cache_reference"`
+}
+
+// CacheReference marks a block as referenceable for cache edits.
+type CacheReference struct {
+	Type string `json:"type"` // "cache_reference"
+	ID   string `json:"id"`   // references tool_use_id
+}

--- a/pkg/agentsdk/cache_edit_test.go
+++ b/pkg/agentsdk/cache_edit_test.go
@@ -1,0 +1,24 @@
+package agentsdk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheEditJSON(t *testing.T) {
+	edit := CacheEdit{Type: CacheEditDelete, CacheReference: "tu_01"}
+	data, err := json.Marshal(edit)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"type":"delete"`)
+	require.Contains(t, string(data), `"cache_reference":"tu_01"`)
+}
+
+func TestCacheReferenceJSON(t *testing.T) {
+	ref := CacheReference{Type: "cache_reference", ID: "tu_01"}
+	data, err := json.Marshal(ref)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"type":"cache_reference"`)
+	require.Contains(t, string(data), `"id":"tu_01"`)
+}

--- a/pkg/agentsdk/types.go
+++ b/pkg/agentsdk/types.go
@@ -110,34 +110,37 @@ type Message struct {
 
 // ContentBlock represents a block of content within a message.
 type ContentBlock struct {
-	Type      string          `json:"type"`
-	Text      string          `json:"text,omitempty"`
-	ID        string          `json:"id,omitempty"`
-	Name      string          `json:"name,omitempty"`
-	Input     json.RawMessage `json:"input,omitempty"`
-	ToolUseID string          `json:"tool_use_id,omitempty"`
-	IsError   bool            `json:"is_error,omitempty"`
+	Type       string          `json:"type"`
+	Text       string          `json:"text,omitempty"`
+	ID         string          `json:"id,omitempty"`
+	Name       string          `json:"name,omitempty"`
+	Input      json.RawMessage `json:"input,omitempty"`
+	ToolUseID  string          `json:"tool_use_id,omitempty"`
+	IsError    bool            `json:"is_error,omitempty"`
+	CacheEdits []CacheEdit     `json:"cache_edits,omitempty"` // Anthropic cache_edits API
 }
 
 type contentBlockJSON struct {
-	Type      string          `json:"type"`
-	Text      string          `json:"text,omitempty"`
-	ID        string          `json:"id,omitempty"`
-	Name      string          `json:"name,omitempty"`
-	Input     json.RawMessage `json:"input,omitempty"`
-	ToolUseID string          `json:"tool_use_id,omitempty"`
-	IsError   bool            `json:"is_error,omitempty"`
+	Type       string          `json:"type"`
+	Text       string          `json:"text,omitempty"`
+	ID         string          `json:"id,omitempty"`
+	Name       string          `json:"name,omitempty"`
+	Input      json.RawMessage `json:"input,omitempty"`
+	ToolUseID  string          `json:"tool_use_id,omitempty"`
+	IsError    bool            `json:"is_error,omitempty"`
+	CacheEdits []CacheEdit     `json:"cache_edits,omitempty"`
 }
 
 func (c ContentBlock) MarshalJSON() ([]byte, error) {
 	return json.Marshal(contentBlockJSON{
-		Type:      c.Type,
-		Text:      c.Text,
-		ID:        c.ID,
-		Name:      c.Name,
-		Input:     marshalSafeRawJSON(c.Input),
-		ToolUseID: c.ToolUseID,
-		IsError:   c.IsError,
+		Type:       c.Type,
+		Text:       c.Text,
+		ID:         c.ID,
+		Name:       c.Name,
+		Input:      marshalSafeRawJSON(c.Input),
+		ToolUseID:  c.ToolUseID,
+		IsError:    c.IsError,
+		CacheEdits: c.CacheEdits,
 	})
 }
 


### PR DESCRIPTION
## Summary
- CacheEdit and CacheReference types in pkg/agentsdk for SDK consumers
- CachedMicrocompactService queues deletions of old tool results by tool_use_id
- QueueEdit(toolUseID) marks a tool result for deletion
- TakeEdits() returns and clears pending edits for serialization
- HasEdits() / Reset() for state inspection and cleanup
- Thread-safe with mutex, nil-safe when disabled
- ContentBlock extended with CacheEdits field
- Anthropic transformer converts CacheEdits to apiCacheEdit for serialization
- Ports Claude Code's microCompact.ts cached MC path to Go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cache edits functionality to manage and queue edit operations with Anthropic services.

* **Tests**
  * Added unit tests for cache edit operations and service behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->