### PR TITLE
[BEHAVIORAL] Cached microcompact — review fixes

### DIFF
--- a/internal/agent/cached_microcompact.go
+++ b/internal/agent/cached_microcompact.go
@@ -2,51 +2,75 @@ package agent
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
+
+const maxPendingEdits = 1000
 
 // CachedMicrocompactService uses Anthropic's cache_edits API to remove tool
 // results without invalidating the cached prefix.
 type CachedMicrocompactService struct {
 	mu           sync.Mutex
 	pendingEdits []agentsdk.CacheEdit
-	enabled      bool
+	enabled      atomic.Bool
 }
 
 // NewCachedMicrocompactService creates a new service.
 func NewCachedMicrocompactService(enabled bool) *CachedMicrocompactService {
-	return &CachedMicrocompactService{
-		enabled: enabled,
-	}
+	s := &CachedMicrocompactService{}
+	s.enabled.Store(enabled)
+	s.pendingEdits = make([]agentsdk.CacheEdit, 0, 16)
+	return s
 }
 
 // IsEnabled returns whether the service is enabled.
 func (s *CachedMicrocompactService) IsEnabled() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.enabled
+	return s.enabled.Load()
 }
 
 // QueueEdit queues a deletion for a tool result by its tool_use_id.
 func (s *CachedMicrocompactService) QueueEdit(toolUseID string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if !s.enabled {
+	if !s.enabled.Load() {
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.pendingEdits) >= maxPendingEdits {
+		return // drop edits beyond cap to prevent unbounded growth
+	}
 	s.pendingEdits = append(s.pendingEdits, agentsdk.CacheEdit{
-		Type:           agentsdk.CacheEditDelete,
+		Type:           "delete",
 		CacheReference: toolUseID,
 	})
 }
 
-// TakeEdits returns and clears all pending edits.
+// QueueEdits queues multiple deletions in a single lock acquisition.
+func (s *CachedMicrocompactService) QueueEdits(toolUseIDs []string) {
+	if !s.enabled.Load() || len(toolUseIDs) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, id := range toolUseIDs {
+		if len(s.pendingEdits) >= maxPendingEdits {
+			break
+		}
+		s.pendingEdits = append(s.pendingEdits, agentsdk.CacheEdit{
+			Type:           "delete",
+			CacheReference: id,
+		})
+	}
+}
+
+// TakeEdits returns a defensive copy of all pending edits and clears them.
 func (s *CachedMicrocompactService) TakeEdits() []agentsdk.CacheEdit {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	edits := s.pendingEdits
-	s.pendingEdits = nil
+	edits := make([]agentsdk.CacheEdit, len(s.pendingEdits))
+	copy(edits, s.pendingEdits)
+	s.pendingEdits = s.pendingEdits[:0]
 	return edits
 }
 
@@ -61,5 +85,5 @@ func (s *CachedMicrocompactService) HasEdits() bool {
 func (s *CachedMicrocompactService) Reset() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.pendingEdits = nil
+	s.pendingEdits = s.pendingEdits[:0]
 }

--- a/internal/provider/anthropic/transformer.go
+++ b/internal/provider/anthropic/transformer.go
@@ -6,7 +6,6 @@ import (
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/provider/normalize"
 	"github.com/julianshen/rubichan/internal/tools"
-	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
 // API wire-format types for Anthropic v1 messages endpoint.
@@ -46,20 +45,14 @@ type apiTool struct {
 // apiContentBlock is the Anthropic-specific content block for serialization.
 // The Anthropic API uses "content" (not "text") for tool_result blocks.
 type apiContentBlock struct {
-	Type       string          `json:"type"`
-	Text       string          `json:"text,omitempty"`
-	ID         string          `json:"id,omitempty"`
-	Name       string          `json:"name,omitempty"`
-	Input      json.RawMessage `json:"input,omitempty"`
-	ToolUseID  string          `json:"tool_use_id,omitempty"`
-	Content    string          `json:"content,omitempty"`
-	IsError    bool            `json:"is_error,omitempty"`
-	CacheEdits []apiCacheEdit  `json:"cache_edits,omitempty"`
-}
-
-type apiCacheEdit struct {
-	Type           string `json:"type"`            // "delete"
-	CacheReference string `json:"cache_reference"` // tool_use_id
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   string          `json:"content,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
 }
 
 // Transformer implements provider.MessageTransformer for the Anthropic API.
@@ -174,13 +167,12 @@ func convertContentBlocks(blocks []provider.ContentBlock) []apiContentBlock {
 	var out []apiContentBlock
 	for _, b := range blocks {
 		cb := apiContentBlock{
-			Type:       b.Type,
-			ID:         b.ID,
-			Name:       b.Name,
-			Input:      b.Input,
-			ToolUseID:  b.ToolUseID,
-			IsError:    b.IsError,
-			CacheEdits: convertCacheEdits(b.CacheEdits),
+			Type:      b.Type,
+			ID:        b.ID,
+			Name:      b.Name,
+			Input:     b.Input,
+			ToolUseID: b.ToolUseID,
+			IsError:   b.IsError,
 		}
 		switch b.Type {
 		case "tool_result":
@@ -189,20 +181,6 @@ func convertContentBlocks(blocks []provider.ContentBlock) []apiContentBlock {
 			cb.Text = b.Text
 		}
 		out = append(out, cb)
-	}
-	return out
-}
-
-func convertCacheEdits(edits []agentsdk.CacheEdit) []apiCacheEdit {
-	if len(edits) == 0 {
-		return nil
-	}
-	var out []apiCacheEdit
-	for _, e := range edits {
-		out = append(out, apiCacheEdit{
-			Type:           string(e.Type),
-			CacheReference: e.CacheReference,
-		})
 	}
 	return out
 }

--- a/pkg/agentsdk/cache_edit.go
+++ b/pkg/agentsdk/cache_edit.go
@@ -1,20 +1,8 @@
 package agentsdk
 
-// CacheEditType represents the type of cache edit operation.
-type CacheEditType string
-
-const (
-	CacheEditDelete CacheEditType = "delete"
-)
-
 // CacheEdit represents an edit to remove content from the cached prefix.
+// Currently only "delete" operations are supported.
 type CacheEdit struct {
-	Type           CacheEditType `json:"type"`
-	CacheReference string        `json:"cache_reference"`
-}
-
-// CacheReference marks a block as referenceable for cache edits.
-type CacheReference struct {
-	Type string `json:"type"` // "cache_reference"
-	ID   string `json:"id"`   // references tool_use_id
+	Type           string `json:"type"`            // "delete"
+	CacheReference string `json:"cache_reference"` // tool_use_id of block to remove
 }

--- a/pkg/agentsdk/cache_edit_test.go
+++ b/pkg/agentsdk/cache_edit_test.go
@@ -8,17 +8,9 @@ import (
 )
 
 func TestCacheEditJSON(t *testing.T) {
-	edit := CacheEdit{Type: CacheEditDelete, CacheReference: "tu_01"}
+	edit := CacheEdit{Type: "delete", CacheReference: "tu_01"}
 	data, err := json.Marshal(edit)
 	require.NoError(t, err)
 	require.Contains(t, string(data), `"type":"delete"`)
 	require.Contains(t, string(data), `"cache_reference":"tu_01"`)
-}
-
-func TestCacheReferenceJSON(t *testing.T) {
-	ref := CacheReference{Type: "cache_reference", ID: "tu_01"}
-	data, err := json.Marshal(ref)
-	require.NoError(t, err)
-	require.Contains(t, string(data), `"type":"cache_reference"`)
-	require.Contains(t, string(data), `"id":"tu_01"`)
 }

--- a/pkg/agentsdk/types.go
+++ b/pkg/agentsdk/types.go
@@ -110,37 +110,34 @@ type Message struct {
 
 // ContentBlock represents a block of content within a message.
 type ContentBlock struct {
-	Type       string          `json:"type"`
-	Text       string          `json:"text,omitempty"`
-	ID         string          `json:"id,omitempty"`
-	Name       string          `json:"name,omitempty"`
-	Input      json.RawMessage `json:"input,omitempty"`
-	ToolUseID  string          `json:"tool_use_id,omitempty"`
-	IsError    bool            `json:"is_error,omitempty"`
-	CacheEdits []CacheEdit     `json:"cache_edits,omitempty"` // Anthropic cache_edits API
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
 }
 
 type contentBlockJSON struct {
-	Type       string          `json:"type"`
-	Text       string          `json:"text,omitempty"`
-	ID         string          `json:"id,omitempty"`
-	Name       string          `json:"name,omitempty"`
-	Input      json.RawMessage `json:"input,omitempty"`
-	ToolUseID  string          `json:"tool_use_id,omitempty"`
-	IsError    bool            `json:"is_error,omitempty"`
-	CacheEdits []CacheEdit     `json:"cache_edits,omitempty"`
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
 }
 
 func (c ContentBlock) MarshalJSON() ([]byte, error) {
 	return json.Marshal(contentBlockJSON{
-		Type:       c.Type,
-		Text:       c.Text,
-		ID:         c.ID,
-		Name:       c.Name,
-		Input:      marshalSafeRawJSON(c.Input),
-		ToolUseID:  c.ToolUseID,
-		IsError:    c.IsError,
-		CacheEdits: c.CacheEdits,
+		Type:      c.Type,
+		Text:      c.Text,
+		ID:        c.ID,
+		Name:      c.Name,
+		Input:     marshalSafeRawJSON(c.Input),
+		ToolUseID: c.ToolUseID,
+		IsError:   c.IsError,
 	})
 }
 


### PR DESCRIPTION
## Summary
Fixes from /simplify and /pr-review on PR #280:

- Remove CacheEditType alias, use plain string (simpler, no indirection)
- Remove unused CacheReference struct (dead code)
- Use atomic.Bool for enabled flag (lock-free IsEnabled check)
- TakeEdits returns defensive copy instead of internal slice
- Add maxPendingEdits cap (1000) to prevent unbounded growth
- Add QueueEdits batch method for single-lock multi-insert
- Remove CacheEdits from generic ContentBlock (Anthropic-specific leak into SDK)
- Pre-allocate pendingEdits slice in constructor

## Review findings addressed
- HIGH: TakeEdits() exposed internal slice — now returns defensive copy
- HIGH: CacheEdits in generic ContentBlock — removed, kept provider-specific
- MEDIUM: CacheReference unused — removed
- MEDIUM: enabled mutable but never mutated — now atomic.Bool with lock-free check
- MEDIUM: pendingEdits unbounded — capped at 1000
- LOW: convertCacheEdits per-block overhead — removed entirely (not needed without ContentBlock field)