### PR TITLE
[STRUCTURAL] MCP SDK types: MCPServerConfig, MCPToolDef with validation

### DIFF
--- a/pkg/agentsdk/mcp.go
+++ b/pkg/agentsdk/mcp.go
@@ -1,0 +1,80 @@
+package agentsdk
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// MCPTransportType identifies the transport protocol for an MCP server.
+type MCPTransportType string
+
+const (
+	MCPTransportStdio MCPTransportType = "stdio"
+	MCPTransportSSE   MCPTransportType = "sse"
+	MCPTransportHTTP  MCPTransportType = "http"
+	MCPTransportWS    MCPTransportType = "websocket"
+)
+
+// Valid returns true if the transport type is one of the supported constants.
+func (t MCPTransportType) Valid() bool {
+	switch t {
+	case MCPTransportStdio, MCPTransportSSE, MCPTransportHTTP, MCPTransportWS:
+		return true
+	}
+	return false
+}
+
+// MCPServerConfig defines how to connect to an MCP server.
+type MCPServerConfig struct {
+	Name      string            `json:"name"`
+	Transport MCPTransportType  `json:"transport"`
+	URL       string            `json:"url,omitempty"`
+	Command   string            `json:"command,omitempty"`
+	Args      []string          `json:"args,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
+	OAuth     *MCPOAuthConfig   `json:"oauth,omitempty"`
+}
+
+// Validate checks that the MCPServerConfig fields are consistent.
+func (c *MCPServerConfig) Validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("mcp server: name is required")
+	}
+	if !c.Transport.Valid() {
+		return fmt.Errorf("mcp server %q: unknown transport %q", c.Name, c.Transport)
+	}
+	switch c.Transport {
+	case MCPTransportStdio:
+		if c.Command == "" {
+			return fmt.Errorf("mcp server %q: command is required for stdio transport", c.Name)
+		}
+	case MCPTransportSSE, MCPTransportHTTP, MCPTransportWS:
+		if c.URL == "" {
+			return fmt.Errorf("mcp server %q: url is required for %s transport", c.Name, c.Transport)
+		}
+	}
+	if c.OAuth != nil {
+		if c.OAuth.ClientID == "" {
+			return fmt.Errorf("mcp server %q: oauth client_id is required", c.Name)
+		}
+		if c.OAuth.TokenURL == "" {
+			return fmt.Errorf("mcp server %q: oauth token_url is required", c.Name)
+		}
+	}
+	return nil
+}
+
+// MCPOAuthConfig holds OAuth credentials.
+type MCPOAuthConfig struct {
+	ClientID     string `json:"client_id"`
+	TokenURL     string `json:"token_url"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+}
+
+// MCPToolDef describes a tool exposed by an MCP server.
+type MCPToolDef struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema,omitempty"`
+	ServerName  string          `json:"server_name"`
+}

--- a/pkg/agentsdk/mcp_test.go
+++ b/pkg/agentsdk/mcp_test.go
@@ -1,0 +1,182 @@
+package agentsdk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPServerConfig(t *testing.T) {
+	cfg := MCPServerConfig{
+		Name:      "filesystem",
+		Transport: MCPTransportStdio,
+		Command:   "npx",
+		Args:      []string{"-y", "@modelcontextprotocol/server-filesystem"},
+	}
+	require.Equal(t, "filesystem", cfg.Name)
+	require.Equal(t, MCPTransportStdio, cfg.Transport)
+}
+
+func TestMCPToolDef(t *testing.T) {
+	tool := MCPToolDef{
+		Name:        "read_file",
+		Description: "Read a file",
+		ServerName:  "filesystem",
+	}
+	require.Equal(t, "filesystem", tool.ServerName)
+	require.Equal(t, "read_file", tool.Name)
+}
+
+func TestMCPTransportTypeValid(t *testing.T) {
+	assert.True(t, MCPTransportStdio.Valid())
+	assert.True(t, MCPTransportSSE.Valid())
+	assert.True(t, MCPTransportHTTP.Valid())
+	assert.True(t, MCPTransportWS.Valid())
+	assert.False(t, MCPTransportType("grpc").Valid())
+	assert.False(t, MCPTransportType("").Valid())
+}
+
+func TestMCPServerConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     MCPServerConfig
+		wantErr string
+	}{
+		{
+			name: "valid stdio",
+			cfg: MCPServerConfig{
+				Name:      "fs",
+				Transport: MCPTransportStdio,
+				Command:   "npx",
+			},
+		},
+		{
+			name: "valid sse",
+			cfg: MCPServerConfig{
+				Name:      "remote",
+				Transport: MCPTransportSSE,
+				URL:       "http://localhost:3000/sse",
+			},
+		},
+		{
+			name:    "missing name",
+			cfg:     MCPServerConfig{Transport: MCPTransportStdio, Command: "npx"},
+			wantErr: "name is required",
+		},
+		{
+			name:    "unknown transport",
+			cfg:     MCPServerConfig{Name: "x", Transport: MCPTransportType("grpc")},
+			wantErr: "unknown transport",
+		},
+		{
+			name:    "stdio missing command",
+			cfg:     MCPServerConfig{Name: "fs", Transport: MCPTransportStdio},
+			wantErr: "command is required",
+		},
+		{
+			name:    "sse missing url",
+			cfg:     MCPServerConfig{Name: "remote", Transport: MCPTransportSSE},
+			wantErr: "url is required",
+		},
+		{
+			name:    "http missing url",
+			cfg:     MCPServerConfig{Name: "remote", Transport: MCPTransportHTTP},
+			wantErr: "url is required",
+		},
+		{
+			name:    "websocket missing url",
+			cfg:     MCPServerConfig{Name: "remote", Transport: MCPTransportWS},
+			wantErr: "url is required",
+		},
+		{
+			name: "valid websocket",
+			cfg: MCPServerConfig{
+				Name:      "remote",
+				Transport: MCPTransportWS,
+				URL:       "ws://localhost:3000",
+			},
+		},
+		{
+			name: "oauth valid",
+			cfg: MCPServerConfig{
+				Name:      "remote",
+				Transport: MCPTransportSSE,
+				URL:       "http://localhost:3000",
+				OAuth: &MCPOAuthConfig{
+					ClientID: "client",
+					TokenURL: "http://auth/token",
+				},
+			},
+		},
+		{
+			name:    "oauth missing client_id",
+			cfg:     MCPServerConfig{Name: "remote", Transport: MCPTransportSSE, URL: "http://localhost:3000", OAuth: &MCPOAuthConfig{}},
+			wantErr: "oauth client_id is required",
+		},
+		{
+			name:    "oauth missing token_url",
+			cfg:     MCPServerConfig{Name: "remote", Transport: MCPTransportSSE, URL: "http://localhost:3000", OAuth: &MCPOAuthConfig{ClientID: "client"}},
+			wantErr: "oauth token_url is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMCPServerConfigJSONRoundTrip(t *testing.T) {
+	cfg := MCPServerConfig{
+		Name:      "test",
+		Transport: MCPTransportSSE,
+		URL:       "http://localhost:3000",
+		Env:       map[string]string{"KEY": "val"},
+		OAuth: &MCPOAuthConfig{
+			ClientID: "client",
+			TokenURL: "http://auth/token",
+		},
+	}
+
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	var decoded MCPServerConfig
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, cfg.Name, decoded.Name)
+	assert.Equal(t, cfg.Transport, decoded.Transport)
+	assert.Equal(t, cfg.URL, decoded.URL)
+	assert.Equal(t, cfg.Env, decoded.Env)
+	require.NotNil(t, decoded.OAuth)
+	assert.Equal(t, cfg.OAuth.ClientID, decoded.OAuth.ClientID)
+	assert.Equal(t, cfg.OAuth.TokenURL, decoded.OAuth.TokenURL)
+}
+
+func TestMCPToolDefJSONRoundTrip(t *testing.T) {
+	tool := MCPToolDef{
+		Name:        "read",
+		Description: "Read file",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		ServerName:  "fs",
+	}
+
+	data, err := json.Marshal(tool)
+	require.NoError(t, err)
+
+	var decoded MCPToolDef
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, tool.Name, decoded.Name)
+	assert.Equal(t, tool.ServerName, decoded.ServerName)
+	assert.Equal(t, string(tool.InputSchema), string(decoded.InputSchema))
+}


### PR DESCRIPTION
## Summary
- MCPTransportType with Valid() method for transport validation
- MCPServerConfig with Validate() using pointer receiver for transport-aware checks
- MCPToolDef with explicit fields (not embedding ToolDef) for SDK stability
- MCPOAuthConfig with omitempty on refresh_token
- JSON round-trip tests and validation error coverage
- Ports Claude Code's MCP config pattern to public SDK

## Changes
- `pkg/agentsdk/mcp.go`: SDK types for MCP server configuration and tool definitions
- `pkg/agentsdk/mcp_test.go`: Tests for validation, JSON round-trips, and transport type checking

## Review
- Simplify review: clean, no duplication issues
- PR review: addressed critical feedback (explicit fields over embedding, pointer receivers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced MCP server connection configuration with support for multiple transport types: standard I/O, SSE, HTTP, and WebSocket.
  * Added built-in validation for MCP server configuration parameters to prevent misconfigurations.
  * Enabled OAuth authentication support for secure MCP server connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->