### PR TITLE
[BEHAVIORAL] Skill system Phase 1: Multi-tool discovery paths and pure markdown skills

### DIFF
--- a/docs/superpowers/plans/2026-05-10-skill-system-phase1.md
+++ b/docs/superpowers/plans/2026-05-10-skill-system-phase1.md
@@ -1,0 +1,587 @@
+# Skill System Improvements — Phase 1: Discovery & Markdown Skills
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `.kilo/skills/` discovery paths and pure markdown skill support to rubichan's skill loader, lowering the barrier to skill authoring and improving brand consistency.
+
+**Architecture:** Extend the existing `Loader` in `internal/skills/loader.go` to search additional well-known directories (`~/.kilo/skills/`, `./.kilo/skills/`) and support pure markdown skills (`.md` files without YAML frontmatter) as simple prompt-only skills. Both changes are additive and backward-compatible.
+
+**Tech Stack:** Go, existing `internal/skills` package.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `internal/skills/loader.go` | Discovery logic — add `.kilo/skills/` paths and pure markdown support |
+| `internal/skills/loader_test.go` | Tests for new discovery paths and markdown skills |
+| `internal/skills/manifest.go` | Add `ParsePureMarkdownSkill` for markdown without frontmatter |
+| `internal/skills/manifest_test.go` | Tests for pure markdown parsing |
+
+---
+
+## Chunk 1: `.kilo/skills/` Discovery Paths
+
+### Task 1: Add `.kilo/skills/` to default discovery paths
+
+**Files:**
+- Modify: `internal/skills/loader.go`
+
+**Context:** The `Loader` currently discovers skills from `userDir` and `projectDir` which are passed in at construction. The caller (agent initialization) sets these directories. We need to ensure `.claude/skills/` paths are included in the default search paths alongside `.kilo/skills/` and `.opencode/skills/`.
+
+However, looking at the current code, `Loader` takes `userDir` and `projectDir` as explicit parameters. The caller sets these. The gap analysis noted that ccgo searches multiple paths:
+- `~/.claude/skills/`, `~/.opencode/skills/`, `~/.kilo/skills/`
+- `./.claude/skills/`, `./.opencode/skills/`, `./.kilo/skills/`
+
+Currently rubichan's `Loader` takes a single `userDir` and `projectDir`. We should modify the initialization to search multiple paths per level.
+
+**Step 1: Write the failing test**
+
+Add to `internal/skills/loader_test.go`:
+
+```go
+func TestDiscoverKiloSkillsPaths(t *testing.T) {
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	// Create a skill in a .kilo/skills/ subdirectory of userDir
+	kiloDir := filepath.Join(userDir, ".kilo", "skills")
+	require.NoError(t, os.MkdirAll(kiloDir, 0o755))
+	writeSkillYAML(t, kiloDir, "kilo-skill", minimalManifestYAML("kilo-skill"))
+
+	// Create a skill in a .kilo/skills/ subdirectory of projectDir
+	projKiloDir := filepath.Join(projectDir, ".kilo", "skills")
+	require.NoError(t, os.MkdirAll(projKiloDir, 0o755))
+	writeSkillYAML(t, projKiloDir, "proj-kilo-skill", minimalManifestYAML("proj-kilo-skill"))
+
+	loader := NewLoader(userDir, projectDir)
+	skills, warnings, err := loader.Discover(nil)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	
+	byName := indexByName(skills)
+	require.Contains(t, byName, "kilo-skill", "should discover .kilo/skills/ under user dir")
+	require.Contains(t, byName, "proj-kilo-skill", "should discover .kilo/skills/ under project dir")
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/skills/... -run TestDiscoverKiloSkillsPaths -v
+```
+
+Expected: FAIL — `.kilo/skills/` paths not searched.
+
+**Step 3: Modify `Loader` to search `.kilo/skills/` subdirectories**
+
+Modify `internal/skills/loader.go`:
+
+```go
+// Discover finds all available skills and returns them in a deduplicated list.
+// The explicit parameter lists skill names explicitly requested (e.g. via --skills flag);
+// these are marked as SourceInline if found.
+//
+// It returns:
+//   - the list of discovered skills (deduplicated by name, highest priority wins)
+//   - a list of warning strings (e.g. missing optional dependencies)
+//   - an error if a required dependency is missing or a manifest can't be parsed
+func (l *Loader) Discover(explicit []string) ([]DiscoveredSkill, []string, error) {
+	explicitSet := make(map[string]bool, len(explicit))
+	for _, name := range explicit {
+		explicitSet[name] = true
+	}
+
+	// Collect skills from all directory sources.
+	// We build a map keyed by skill name; higher-priority sources overwrite lower ones.
+	byName := make(map[string]DiscoveredSkill)
+
+	// 1. Configured skill roots (lowest directory priority).
+	for _, dir := range l.skillDirs {
+		configuredSkills, err := scanDir(dir, SourceConfigured)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, ds := range configuredSkills {
+			if _, exists := byName[ds.Manifest.Name]; !exists {
+				byName[ds.Manifest.Name] = ds
+			}
+		}
+	}
+
+	// 2. Project skills override configured skill roots.
+	// Search both .kilo/skills/ and the root projectDir for backward compatibility.
+	projectSkills, err := l.scanProjectOrUserDir(l.projectDir, SourceProject)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, ds := range projectSkills {
+		byName[ds.Manifest.Name] = ds
+	}
+
+	// 3. User skills override project skills.
+	// Search both .kilo/skills/ and the root userDir for backward compatibility.
+	userSkills, err := l.scanProjectOrUserDir(l.userDir, SourceUser)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, ds := range userSkills {
+		byName[ds.Manifest.Name] = ds
+	}
+
+	// 4. Built-in skills override everything from directories.
+	for name, ds := range l.builtins {
+		byName[name] = ds
+	}
+
+	// 4.5. MCP servers from config become synthetic skills.
+	for _, srv := range l.mcpServers {
+		name := "mcp-" + srv.Name
+		// Skip if a higher-priority skill already has this name.
+		if _, exists := byName[name]; exists {
+			continue
+		}
+		// Only stdio transport spawns a child process — grant shell:exec accordingly.
+		var perms []Permission
+		if srv.Transport == "stdio" {
+			perms = []Permission{PermShellExec}
+		}
+		byName[name] = DiscoveredSkill{
+			Manifest: &SkillManifest{
+				Name:        name,
+				Version:     "0.0.0",
+				Description: fmt.Sprintf("MCP server: %s", srv.Name),
+				Types:       []SkillType{SkillTypeTool},
+				Permissions: perms,
+				Implementation: ImplementationConfig{
+					Backend:      BackendMCP,
+					MCPTransport: srv.Transport,
+					MCPCommand:   srv.Command,
+					MCPArgs:      srv.Args,
+					MCPURL:       srv.URL,
+				},
+			},
+			Dir:    "",
+			Source: SourceMCP,
+		}
+	}
+
+	// 5. Mark explicitly requested skills as SourceInline.
+	for name := range explicitSet {
+		ds, ok := byName[name]
+		if !ok {
+			return nil, nil, fmt.Errorf("explicit skill %q not found in any source", name)
+		}
+		ds.Source = SourceInline
+		byName[name] = ds
+	}
+
+	// Build sorted result slice for deterministic output.
+	result := make([]DiscoveredSkill, 0, len(byName))
+	for _, ds := range byName {
+		result = append(result, ds)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Manifest.Name < result[j].Manifest.Name
+	})
+
+	// Validate dependencies.
+	nameSet := make(map[string]bool, len(result))
+	for _, ds := range result {
+		nameSet[ds.Manifest.Name] = true
+	}
+
+	var warnings []string
+	for _, ds := range result {
+		for _, dep := range ds.Manifest.Dependencies {
+			if nameSet[dep.Name] {
+				continue
+			}
+			if dep.Optional {
+				warnings = append(warnings, fmt.Sprintf(
+					"skill %q: optional dependency %q not found",
+					ds.Manifest.Name, dep.Name,
+				))
+			} else {
+				return nil, nil, fmt.Errorf(
+					"skill %q: required dependency %q not found",
+					ds.Manifest.Name, dep.Name,
+				)
+			}
+		}
+	}
+
+	return result, warnings, nil
+}
+
+// scanProjectOrUserDir searches both the root directory and its .kilo/skills/
+// subdirectory for skills. This allows users to organize skills under
+// ~/.kilo/skills/ or ./.kilo/skills/ while maintaining backward compatibility
+// with skills placed directly in the user/project directories.
+func (l *Loader) scanProjectOrUserDir(rootDir string, source Source) ([]DiscoveredSkill, error) {
+	var results []DiscoveredSkill
+
+	// Search the root directory first (backward compatibility).
+	rootSkills, err := scanDir(rootDir, source)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, rootSkills...)
+
+	// Search .kilo/skills/ subdirectory.
+	kiloDir := filepath.Join(rootDir, ".kilo", "skills")
+	kiloSkills, err := scanDir(kiloDir, source)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, kiloSkills...)
+
+	return results, nil
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/skills/... -run TestDiscoverKiloSkillsPaths -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add internal/skills/loader.go internal/skills/loader_test.go
+git commit -m "[BEHAVIORAL] Add .kilo/skills/ discovery paths to skill loader"
+```
+
+---
+
+## Chunk 2: Pure Markdown Skill Support
+
+### Task 2: Add `ParsePureMarkdownSkill` for markdown without frontmatter
+
+**Files:**
+- Modify: `internal/skills/manifest.go`
+- Test: `internal/skills/manifest_test.go`
+
+**Context:** Currently rubichan supports `SKILL.yaml` and `SKILL.md` with YAML frontmatter. We want to support pure markdown skills — a `.md` file with no frontmatter that is treated as a simple prompt-only skill. The filename becomes the skill name.
+
+**Step 1: Write the failing test**
+
+Add to `internal/skills/manifest_test.go`:
+
+```go
+func TestParsePureMarkdownSkill(t *testing.T) {
+	content := []byte(`# Git Commit Skill
+
+Analyze the staged changes and write a conventional commit message.
+
+Follow these rules:
+- Use present tense
+- Keep the first line under 50 characters
+- Use the body to explain what and why, not how
+`)
+	m, body, err := ParsePureMarkdownSkill("commit", content)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+
+	assert.Equal(t, "commit", m.Name)
+	assert.Equal(t, "1.0.0", m.Version)
+	assert.Contains(t, m.Description, "Git Commit")
+	assert.Equal(t, []SkillType{SkillTypePrompt}, m.Types)
+	assert.Contains(t, body, "conventional commit")
+}
+
+func TestParsePureMarkdownSkillEmptyContent(t *testing.T) {
+	m, body, err := ParsePureMarkdownSkill("empty", []byte(""))
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, "empty", m.Name)
+	assert.Equal(t, "", body)
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/skills/... -run TestParsePureMarkdownSkill -v
+```
+
+Expected: FAIL — `ParsePureMarkdownSkill` not defined.
+
+**Step 3: Implement `ParsePureMarkdownSkill`**
+
+Add to `internal/skills/manifest.go` (after `ParseInstructionSkill`):
+
+```go
+// ParsePureMarkdownSkill parses a plain markdown file (no frontmatter) into a
+// synthetic SkillManifest. The name parameter is derived from the filename.
+// The entire markdown body becomes the instruction body. This is the simplest
+// skill format — just a markdown file with instructions.
+func ParsePureMarkdownSkill(name string, data []byte) (*SkillManifest, string, error) {
+	if name == "" {
+		return nil, "", fmt.Errorf("pure markdown skill: name is required")
+	}
+
+	// Generate a description from the first line or heading.
+	description := generateDescriptionFromMarkdown(string(data))
+
+	m := &SkillManifest{
+		Name:        name,
+		Version:     "1.0.0",
+		Description: description,
+		Types:       []SkillType{SkillTypePrompt},
+	}
+
+	// Pure markdown skills don't need validation of name format since the
+	// name comes from the filename which may have different conventions.
+	// But we still validate other manifest constraints.
+	if err := validateManifest(m); err != nil {
+		return nil, "", fmt.Errorf("pure markdown skill: %w", err)
+	}
+
+	return m, string(data), nil
+}
+
+// generateDescriptionFromMarkdown extracts a short description from markdown content.
+// It prefers the first H1 heading, then the first line of text.
+func generateDescriptionFromMarkdown(content string) string {
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Prefer H1 heading.
+		if strings.HasPrefix(line, "# ") {
+			return strings.TrimPrefix(line, "# ")
+		}
+		// Fallback to first non-empty line, truncated.
+		if len(line) > 80 {
+			return line[:77] + "..."
+		}
+		return line
+	}
+	return "Markdown skill"
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/skills/... -run TestParsePureMarkdownSkill -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add internal/skills/manifest.go internal/skills/manifest_test.go
+git commit -m "[BEHAVIORAL] Add ParsePureMarkdownSkill for frontmatter-less skills"
+```
+
+---
+
+## Chunk 3: Loader Integration for Pure Markdown Skills
+
+### Task 3: Wire pure markdown support into `scanDir`
+
+**Files:**
+- Modify: `internal/skills/loader.go`
+- Test: `internal/skills/loader_test.go`
+
+**Context:** The `scanDir` function currently looks for `SKILL.yaml` then `SKILL.md` (with frontmatter). We need to also support `.md` files that are pure markdown (no frontmatter). The filename (without extension) becomes the skill name.
+
+**Step 1: Write the failing test**
+
+Add to `internal/skills/loader_test.go`:
+
+```go
+func TestDiscoverPureMarkdownSkill(t *testing.T) {
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	// Create a pure markdown skill (no frontmatter).
+	skillDir := filepath.Join(userDir, "commit-helper")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skillDir, "skill.md"),
+		[]byte("# Commit Helper\n\nWrite good commit messages."),
+		0o644,
+	))
+
+	loader := NewLoader(userDir, projectDir)
+	skills, warnings, err := loader.Discover(nil)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	require.Len(t, skills, 1)
+
+	assert.Equal(t, "commit-helper", skills[0].Manifest.Name)
+	assert.Equal(t, []SkillType{SkillTypePrompt}, skills[0].Manifest.Types)
+	assert.Equal(t, "Commit Helper", skills[0].Manifest.Description)
+	assert.Equal(t, "Write good commit messages.", skills[0].InstructionBody)
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/skills/... -run TestDiscoverPureMarkdownSkill -v
+```
+
+Expected: FAIL — `scanDir` doesn't handle pure markdown files.
+
+**Step 3: Modify `scanDir` to support pure markdown**
+
+Modify `internal/skills/loader.go` in the `scanDir` function:
+
+```go
+func scanDir(dir string, source Source) ([]DiscoveredSkill, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("scan skills dir %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, nil
+	}
+
+	var results []DiscoveredSkill
+	err = filepath.WalkDir(dir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if path == dir {
+			return nil
+		}
+
+		// Try SKILL.yaml first.
+		yamlPath := filepath.Join(path, "SKILL.yaml")
+		data, err := os.ReadFile(yamlPath)
+		if err == nil {
+			manifest, parseErr := ParseManifest(data)
+			if parseErr != nil {
+				return fmt.Errorf("parse skill %q: %w", filepath.Base(path), parseErr)
+			}
+			results = append(results, DiscoveredSkill{
+				Manifest: manifest,
+				Dir:      path,
+				Source:   source,
+				RootDir:  dir,
+			})
+			return filepath.SkipDir
+		}
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("read skill manifest %q: %w", yamlPath, err)
+		}
+
+		// Fall back to SKILL.md (instruction skill with frontmatter).
+		mdPath := filepath.Join(path, "SKILL.md")
+		mdData, err := os.ReadFile(mdPath)
+		if err == nil {
+			manifest, body, parseErr := ParseInstructionSkill(mdData)
+			if parseErr != nil {
+				return fmt.Errorf("parse instruction skill %q: %w", filepath.Base(path), parseErr)
+			}
+			results = append(results, DiscoveredSkill{
+				Manifest:        manifest,
+				Dir:             path,
+				Source:          source,
+				RootDir:         dir,
+				InstructionBody: body,
+			})
+			return filepath.SkipDir
+		}
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("read instruction skill %q: %w", mdPath, err)
+		}
+
+		// Fall back to any .md file (pure markdown skill).
+		entries, readErr := os.ReadDir(path)
+		if readErr != nil {
+			return fmt.Errorf("read skill dir %q: %w", path, readErr)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if strings.HasSuffix(name, ".md") {
+				mdData, readErr := os.ReadFile(filepath.Join(path, name))
+				if readErr != nil {
+					return fmt.Errorf("read markdown skill %q: %w", name, readErr)
+				}
+				skillName := strings.TrimSuffix(name, ".md")
+				manifest, body, parseErr := ParsePureMarkdownSkill(skillName, mdData)
+				if parseErr != nil {
+					return fmt.Errorf("parse markdown skill %q: %w", name, parseErr)
+				}
+				results = append(results, DiscoveredSkill{
+					Manifest:        manifest,
+					Dir:             path,
+					Source:          source,
+					RootDir:         dir,
+					InstructionBody: body,
+				})
+				return filepath.SkipDir
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan skills dir %q: %w", dir, err)
+	}
+
+	return results, nil
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/skills/... -run TestDiscoverPureMarkdownSkill -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add internal/skills/loader.go internal/skills/loader_test.go
+git commit -m "[BEHAVIORAL] Support pure markdown skills in loader"
+```
+
+---
+
+## Validation Commands
+
+```bash
+go test ./internal/skills/...
+go test -cover ./internal/skills/...
+golangci-lint run ./internal/skills/...
+gofmt -l .
+```
+
+---
+
+## PR Description
+
+**Title:** `[BEHAVIORAL] Skill system Phase 1: .kilo/skills/ paths and pure markdown skills`
+
+**Body:**
+- Add `.kilo/skills/` discovery paths alongside existing `.claude/skills/` and `.opencode/skills/`
+- Support pure markdown skills (`.md` files without YAML frontmatter) for simpler skill authoring
+- `ParsePureMarkdownSkill` generates synthetic manifest from filename and content
+- Backward compatible — existing `SKILL.yaml` and `SKILL.md` skills unchanged
+- All changes additive, no breaking modifications to existing APIs
+
+**Commit prefix:** `[BEHAVIORAL]`

--- a/docs/superpowers/specs/2026-05-10-skill-system-gap-analysis.md
+++ b/docs/superpowers/specs/2026-05-10-skill-system-gap-analysis.md
@@ -1,0 +1,341 @@
+# Skill System Gap Analysis: ccgo, claude-code, rubichan
+
+**Date:** 2026-05-10
+**Scope:** Cross-project skill system research to identify port opportunities for rubichan
+
+---
+
+## Executive Summary
+
+| System | Paradigm | Strengths | Key Gaps in Rubichan |
+|--------|----------|-----------|---------------------|
+| **ccgo** | File-based markdown skills | Simple discovery, async prefetch, compaction rules | No prefetch, no `.kilo/skills/` discovery paths |
+| **claude-code** | Prompt-template skills | Rich frontmatter, forked execution, permission integration, bundled skills | No markdown skill format, no forked execution, no bundled skill API |
+| **rubichan** | Multi-runtime (Starlark/Go/MCP/Process) | Full lifecycle, hooks, triggers, sandbox, registry | No simple markdown authoring, no async prefetch, no skill event bus |
+
+---
+
+## 1. ccgo Skill System
+
+### Architecture
+
+ccgo's skill system is **minimal and file-based**. Skills are markdown files discovered from well-known directories:
+
+```text
+~/.claude/skills/<name>/SKILL.md
+~/.claude/skills/<name>.md
+~/.opencode/skills/<name>/SKILL.md
+~/.kilo/skills/<name>/SKILL.md
+./.claude/skills/<name>/SKILL.md
+./.opencode/skills/<name>/SKILL.md
+./.kilo/skills/<name>/SKILL.md
+```
+
+### Key Components
+
+#### 1.1 SkillTool (`tool/skills_todos.go:405-513`)
+
+- **Single tool** that loads skill content by name
+- **No formal registration** — skills are discovered at call time
+- **Security:** Rejects `..`, `/`, and path separators in skill names
+- **Returns raw markdown** as tool result for the LLM to process
+- **Search precedence:** User dirs > project dirs (implicit via iteration order)
+
+#### 1.2 SkillPrefetch (`query/prefetch.go`)
+
+- **Async preloading** of skills before explicit request
+- `SkillPrefetchHandle` with states: Pending, Settled, Consumed, Error
+- Thread-safe with mutex + done channel
+- Settled skills are consumed once, then marked Consumed
+
+#### 1.3 Compaction Rules (`compact/compact.go:179-188`)
+
+- **Strips skill discovery messages** during compaction
+- `isReinjectedAttachmentType()` filters `skill_discovery` and `skill_listing` roles
+- Prevents skill metadata from bloating context window
+
+#### 1.4 System Prompt Integration (`query/context.go`)
+
+- Skills advertised via `SkillPrompt` struct in `<skills>` XML tags
+- Token budget for skills: 8K characters (1% of context window)
+
+### What Rubichan Can Port
+
+| Feature | Priority | Effort | Value |
+|---------|----------|--------|-------|
+| `.kilo/skills/` discovery paths | P1 | Low | Immediate compatibility |
+| Async skill prefetch | P2 | Medium | Latency reduction |
+| Skill compaction rules | P3 | Low | Context efficiency |
+| Skill token budgeting | P2 | Medium | Context management |
+
+---
+
+## 2. Claude-Code Skill System
+
+### Architecture
+
+claude-code's skill system is **rich and declarative**. Skills are markdown files with YAML frontmatter that act as **prompt templates**:
+
+```markdown
+---
+name: commit
+description: Generate a conventional commit message
+allowed-tools: [Read, Git]
+context: inline
+---
+
+Analyze the staged changes and write a commit message...
+```
+
+### Key Components
+
+#### 2.1 Skill Format (`src/skills/loadSkillsDir.ts`)
+
+- **YAML frontmatter** with rich metadata:
+  - `name`, `description`, `version`
+  - `allowed-tools`: Tool permission restrictions
+  - `model`: LLM model override
+  - `context`: `inline` (default) or `fork` (isolated sub-agent)
+  - `effort`: Token budget/thinking level
+  - `paths`: Conditional activation (gitignore-style matching)
+  - `hooks`: Lifecycle hooks
+  - `arguments`: Parameter definitions with `$ARGUMENTS` substitution
+- **Shell execution**: `!command` and `` ```! ... ``` `` blocks execute and substitute output
+- **Conditional skills**: Only activate when matching files are touched
+
+#### 2.2 Skill Tool (`src/tools/SkillTool.ts`)
+
+- **Input schema:** `{ skill: string, args?: string }`
+- **Two execution modes:**
+  - **Inline:** Expands into current conversation
+  - **Forked:** Runs in isolated sub-agent with separate context
+- **Permission integration:** Skills participate in general permission framework
+- **Auto-allow:** Safe skills (no custom permissions, no dangerous flags) bypass user prompt
+- **Context modifiers:** `allowedTools`, `model`, `effort`
+
+#### 2.3 Bundled Skills (`src/skills/bundledSkills.ts`)
+
+- **Registration API:** `registerBundledSkill(definition)`
+- **File extraction:** Reference docs lazily extracted to temp directory
+- **Lazy loading:** Heavy content dynamically imported
+- Examples: `/simplify`, `/batch`, `/skillify`, `/claude-api`
+
+#### 2.4 Commands Registry (`src/commands.ts`)
+
+- **Loading order (precedence):** bundled > builtin plugin > skill dir > workflow > plugin > built-in
+- **Dynamic insertion:** Discovered skills inserted at specific registry positions
+- **Availability filtering:** Gates by auth type and feature flags
+
+#### 2.5 MCP Skill Bridge (`src/skills/mcpSkillBuilders.ts`)
+
+- **Dependency cycle breaker:** Write-once registry for MCP skill builders
+- MCP skills use same frontmatter parser as file-based skills
+
+### What Rubichan Can Port
+
+| Feature | Priority | Effort | Value |
+|---------|----------|--------|-------|
+| Markdown skill format with frontmatter | P1 | Medium | Simpler skill authoring |
+| `allowed-tools` permission restrictions | P2 | Medium | Better security model |
+| Forked execution (`context: fork`) | P3 | High | Isolation for untrusted skills |
+| Bundled skill registration API | P2 | Medium | Built-in capabilities |
+| Argument substitution (`$ARGUMENTS`) | P2 | Low | Better UX |
+| Conditional activation (`paths:`) | P2 | Medium | Smart skill loading |
+| Skill token budgeting (1% context) | P2 | Low | Context management |
+| Skill extraction (`/skillify`) | P4 | High | Workflow capture |
+
+---
+
+## 3. Rubichan Existing Skill System
+
+### Architecture
+
+rubichan has a **multi-runtime skill system** with full lifecycle management:
+
+```text
+internal/skills/
+  manifest.go          # SKILL.yaml parsing, validation
+  loader.go            # Discovery from user/project/MCP dirs
+  runtime.go           # Activation, deactivation, registry integration
+  types.go             # SkillBackend interface, lifecycle states
+  broker.go            # CapabilityBroker for permission enforcement
+  hooks.go             # LifecycleManager for hook dispatch
+  triggers.go          # Trigger evaluation for auto-activation
+  integration.go       # PromptCollector, WorkflowRunner, SecurityAdapter
+  registry.go          # Remote registry client (HTTP API)
+  declarative.go       # Manifest-defined slash commands
+  
+  starlark/            # Starlark backend (sandboxed Python-like)
+  goplugin/            # Go plugin backend (shared library)
+  process/             # External process backend (JSON-RPC)
+  mcpbackend/          # MCP server backend
+  sandbox/             # Sandboxed execution
+  builtin/             # Built-in skills (git, wiki, code review, etc.)
+```
+
+### Strengths
+
+1. **Full lifecycle:** Inactive → Activating → Active → Error with valid transitions
+2. **Multi-backend:** Starlark, Go plugin, external process, MCP
+3. **Hook system:** 14 hook phases with priority-based dispatch
+4. **Trigger system:** File, keyword, language, mode matching with scoring
+5. **Sandbox:** PermissionChecker with per-call enforcement via CapabilityBroker
+6. **Context budget:** Token-based prompt fragment budgeting
+7. **Registry client:** Remote skill registry with caching
+8. **Instruction skills:** SKILL.md with YAML frontmatter (already supported!)
+
+### Gaps
+
+| Gap | Description | Impact |
+|-----|-------------|--------|
+| **No markdown-native skills** | Only SKILL.md with frontmatter; no pure markdown skill format like ccgo/claude-code | Higher barrier to entry |
+| **No async prefetch** | Skills loaded synchronously on first use | Latency on skill invocation |
+| **No `.kilo/skills/` paths** | Only `.claude/skills/` and `.opencode/skills/` in some contexts | Branding inconsistency |
+| **No forked execution** | All skills run in main agent context | No isolation for untrusted skills |
+| **No bundled skill API** | Built-in skills registered manually | No standardized bundled skill pattern |
+| **No skill event bus** | No pub/sub for skill state changes | Limited observability |
+| **No dynamic reloading** | Skills discovered once at startup | No hot-reload during development |
+| **Limited permission granularity** | `ToolsAllow`/`ToolsDeny` exist but not enforced per-call | Security gap |
+| **No skill compaction** | Skill discovery messages not stripped | Context bloat |
+
+---
+
+## 4. Priority Recommendations
+
+### Phase 1: Quick Wins (P1)
+
+1. **Add `.kilo/skills/` discovery paths**
+   - Update `Loader` to search `~/.kilo/skills/` and `./.kilo/skills/`
+   - Effort: ~20 lines in `loader.go`
+
+2. **Enhance markdown skill support**
+   - Pure markdown skills (no frontmatter) — just load and return content
+   - Effort: ~50 lines in `loader.go` + `scanDir()`
+
+### Phase 2: Core Improvements (P2)
+
+3. **Async skill prefetch**
+   - Add `PrefetchHandle` pattern from ccgo
+   - Preload likely-to-activate skills based on triggers
+   - Effort: New file `internal/skills/prefetch.go` + integration in runtime
+
+4. **Skill token budgeting**
+   - Cap skill descriptions in system prompt (1% context window)
+   - Truncate non-bundled skill descriptions
+   - Effort: ~30 lines in prompt building
+
+5. **ToolsAllow/ToolsDeny enforcement**
+   - Actually enforce `ToolsAllow`/`ToolsDeny` in CapabilityBroker
+   - Effort: ~20 lines in `broker.go`
+
+6. **Bundled skill registration API**
+   - `RegisterBundledSkill()` pattern from claude-code
+   - Effort: New method on `Loader` + `Runtime`
+
+### Phase 3: Advanced Features (P3)
+
+7. **Forked skill execution**
+   - `context: fork` equivalent — run skill in sub-agent
+   - Effort: Integration with existing subagent system
+
+8. **Skill event bus**
+   - Pub/sub for skill state changes
+   - Effort: New file `internal/skills/events.go`
+
+9. **Skill compaction**
+   - Strip skill discovery messages during compaction
+   - Effort: Integration with existing compaction system
+
+### Phase 4: Nice-to-Have (P4)
+
+10. **Skill extraction (`/skillify`)**
+    - Capture session as reusable skill
+    - Effort: New skill + UI integration
+
+11. **Dynamic skill reloading**
+    - Watch skill directories for changes
+    - Effort: File watcher + hot-reload logic
+
+---
+
+## 5. Implementation Order
+
+```text
+P1.1: .kilo/skills/ discovery paths
+P1.2: Pure markdown skill support
+P2.1: Async skill prefetch
+P2.2: Skill token budgeting
+P2.3: ToolsAllow/ToolsDeny enforcement
+P2.4: Bundled skill registration API
+P3.1: Forked skill execution
+P3.2: Skill event bus
+P3.3: Skill compaction
+P4.1: Skill extraction
+P4.2: Dynamic skill reloading
+```
+
+Each phase should be a separate PR with tests, following TDD.
+
+---
+
+## 6. Key Design Decisions
+
+### 6.1 Markdown vs YAML Skills
+
+- **Keep SKILL.yaml** for complex skills (multi-backend, hooks, workflows)
+- **Add pure markdown** for simple prompt skills (like ccgo/claude-code)
+- **SKILL.md with frontmatter** already works — enhance it
+
+### 6.2 Discovery Paths
+
+```text
+Priority (highest first):
+1. Built-in skills (code-registered)
+2. Inline/explicit skills (--skills flag)
+3. User skills: ~/.kilo/skills/ > ~/.claude/skills/ > ~/.opencode/skills/
+4. Project skills: ./.kilo/skills/ > ./.claude/skills/ > ./.opencode/skills/
+5. Configured skill roots
+6. MCP servers
+```
+
+### 6.3 Prefetch Strategy
+
+- Evaluate triggers against current context
+- Preload skills with score >= threshold
+- Use `SkillPrefetchHandle` pattern (async, cancellable)
+- Consume on first use, skip if not needed
+
+### 6.4 Permission Model
+
+- **Current:** `Permissions` array checked at activation
+- **Gap:** `ToolsAllow`/`ToolsDeny` declared but not enforced
+- **Fix:** Add to CapabilityBroker.CheckExecution()
+- **Future:** Consider claude-code's `allowed-tools` model
+
+---
+
+## 7. Files to Modify
+
+| File | Changes |
+|------|---------|
+| `internal/skills/loader.go` | Add `.kilo/skills/` paths, pure markdown support |
+| `internal/skills/runtime.go` | Add prefetch integration, bundled skill API |
+| `internal/skills/broker.go` | Enforce ToolsAllow/ToolsDeny |
+| `internal/skills/prefetch.go` | New: async prefetch handles |
+| `internal/skills/events.go` | New: skill event bus |
+| `internal/skills/types.go` | Add BundledSkillDefinition type |
+| `internal/agent/prompt.go` | Add skill token budgeting |
+| `internal/compact/` | Add skill message stripping |
+
+---
+
+## 8. Testing Strategy
+
+- **Unit tests** for each new component (prefetch, events, broker changes)
+- **Integration tests** for discovery path precedence
+- **End-to-end tests** for full skill lifecycle with new features
+- **Benchmarks** for prefetch latency improvement
+
+---
+
+*This analysis is based on code review of ccgo (commit unknown), claude-code-source-code-leak (commit unknown), and rubichan (current working tree).*

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -1,10 +1,12 @@
 package skills
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/julianshen/rubichan/internal/config"
 )
@@ -118,7 +120,7 @@ func (l *Loader) Discover(explicit []string) ([]DiscoveredSkill, []string, error
 	}
 
 	// 2. Project skills override configured skill roots.
-	projectSkills, err := scanDir(l.projectDir, SourceProject)
+	projectSkills, err := scanProjectOrUserDir(l.projectDir, SourceProject)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -127,7 +129,7 @@ func (l *Loader) Discover(explicit []string) ([]DiscoveredSkill, []string, error
 	}
 
 	// 3. User skills override project skills.
-	userSkills, err := scanDir(l.userDir, SourceUser)
+	userSkills, err := scanProjectOrUserDir(l.userDir, SourceUser)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -220,6 +222,10 @@ func (l *Loader) Discover(explicit []string) ([]DiscoveredSkill, []string, error
 	return result, warnings, nil
 }
 
+// wellKnownSkillSubdirs lists the subdirectories within a user or project
+// root that are searched for skills. This supports multiple tools' conventions.
+var wellKnownSkillSubdirs = []string{".rubichan/skills", ".kilo/skills", ".claude/skills", ".opencode/skills"}
+
 // scanDir walks a directory tree recursively looking for directories that
 // contain SKILL.yaml files (and SKILL.md instruction skills as a fallback).
 // If a directory contains a skill manifest, it is treated as a skill root and
@@ -269,32 +275,125 @@ func scanDir(dir string, source Source) ([]DiscoveredSkill, error) {
 			return fmt.Errorf("read skill manifest %q: %w", yamlPath, err)
 		}
 
-		// Fall back to SKILL.md (instruction skill).
+		// Fall back to SKILL.md (instruction skill with frontmatter).
 		mdPath := filepath.Join(path, "SKILL.md")
 		mdData, err := os.ReadFile(mdPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
+		if err == nil {
+			// Try parsing as instruction skill (with frontmatter) first.
+			manifest, body, parseErr := ParseInstructionSkill(mdData)
+			if parseErr == nil {
+				results = append(results, DiscoveredSkill{
+					Manifest:        manifest,
+					Dir:             path,
+					Source:          source,
+					RootDir:         dir,
+					InstructionBody: body,
+				})
+				return filepath.SkipDir
 			}
+			// Only fall back to pure markdown if there was no frontmatter at all.
+			// Malformed frontmatter (bad YAML, missing required fields, etc.) should
+			// surface as an error so authors know their SKILL.md is broken.
+			if errors.Is(parseErr, ErrNoFrontmatter) {
+				manifest, body, parseErr = ParsePureMarkdownSkill(filepath.Base(path), mdData)
+				if parseErr == nil {
+					results = append(results, DiscoveredSkill{
+						Manifest:        manifest,
+						Dir:             path,
+						Source:          source,
+						RootDir:         dir,
+						InstructionBody: body,
+					})
+					return filepath.SkipDir
+				}
+				return fmt.Errorf("parse skill %q: %w", filepath.Base(path), parseErr)
+			}
+			return fmt.Errorf("parse skill %q: %w", filepath.Base(path), parseErr)
+		}
+		if !os.IsNotExist(err) {
 			return fmt.Errorf("read instruction skill %q: %w", mdPath, err)
 		}
 
-		manifest, body, parseErr := ParseInstructionSkill(mdData)
-		if parseErr != nil {
-			return fmt.Errorf("parse instruction skill %q: %w", filepath.Base(path), parseErr)
+		// Fall back to any .md file (pure markdown skill).
+		entries, readErr := os.ReadDir(path)
+		if readErr != nil {
+			return fmt.Errorf("read skill dir %q: %w", path, readErr)
 		}
-		results = append(results, DiscoveredSkill{
-			Manifest:        manifest,
-			Dir:             path,
-			Source:          source,
-			RootDir:         dir,
-			InstructionBody: body,
-		})
-		return filepath.SkipDir
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if strings.HasSuffix(name, ".md") {
+				mdData, readErr := os.ReadFile(filepath.Join(path, name))
+				if readErr != nil {
+					return fmt.Errorf("read markdown skill %q: %w", name, readErr)
+				}
+				skillName := strings.TrimSuffix(name, ".md")
+				manifest, body, parseErr := ParsePureMarkdownSkill(skillName, mdData)
+				if parseErr != nil {
+					return fmt.Errorf("parse markdown skill %q: %w", name, parseErr)
+				}
+				results = append(results, DiscoveredSkill{
+					Manifest:        manifest,
+					Dir:             path,
+					Source:          source,
+					RootDir:         dir,
+					InstructionBody: body,
+				})
+				return filepath.SkipDir
+			}
+		}
+
+		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("scan skills dir %q: %w", dir, err)
 	}
 
+	return results, nil
+}
+
+// scanProjectOrUserDir searches both the root directory and well-known
+// skill subdirectories (.rubichan/skills, .kilo/skills, .claude/skills, .opencode/skills)
+// for skills. This allows users to organize skills under any supported
+// tool's convention while maintaining backward compatibility.
+//
+// Within the same source level, skills are deduplicated by name with
+// earlier subdirectories taking precedence over later ones.
+func scanProjectOrUserDir(rootDir string, source Source) ([]DiscoveredSkill, error) {
+	byName := make(map[string]DiscoveredSkill)
+
+	// Search the root directory first (backward compatibility).
+	rootSkills, err := scanDir(rootDir, source)
+	if err != nil {
+		return nil, err
+	}
+	for _, ds := range rootSkills {
+		byName[ds.Manifest.Name] = ds
+	}
+
+	// Search well-known skill subdirectories.
+	// Earlier subdirs in wellKnownSkillSubdirs take precedence.
+	for _, subdir := range wellKnownSkillSubdirs {
+		skillDir := filepath.Join(rootDir, subdir)
+		if _, err := os.Stat(skillDir); os.IsNotExist(err) {
+			continue
+		}
+		subSkills, err := scanDir(skillDir, source)
+		if err != nil {
+			return nil, err
+		}
+		for _, ds := range subSkills {
+			if _, exists := byName[ds.Manifest.Name]; !exists {
+				byName[ds.Manifest.Name] = ds
+			}
+		}
+	}
+
+	results := make([]DiscoveredSkill, 0, len(byName))
+	for _, ds := range byName {
+		results = append(results, ds)
+	}
 	return results, nil
 }

--- a/internal/skills/loader_test.go
+++ b/internal/skills/loader_test.go
@@ -3,6 +3,7 @@ package skills
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/julianshen/rubichan/internal/config"
@@ -486,6 +487,114 @@ func TestDiscoverMCPNameCollision(t *testing.T) {
 
 	// User skill should win — MCP auto-discovery skips if name already exists.
 	assert.Equal(t, SourceUser, discovered[0].Source)
+}
+
+func TestDiscoverWellKnownSubdirs(t *testing.T) {
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	// Create skills in each well-known subdirectory.
+	for _, subdir := range []string{".rubichan/skills", ".kilo/skills", ".claude/skills", ".opencode/skills"} {
+		skillDir := filepath.Join(userDir, subdir)
+		require.NoError(t, os.MkdirAll(skillDir, 0o755))
+		name := strings.ReplaceAll(subdir, "/skills", "")
+		name = strings.ReplaceAll(name, ".", "")
+		writeSkillYAML(t, skillDir, name+"-skill", minimalManifestYAML(name+"-skill"))
+	}
+
+	loader := NewLoader(userDir, projectDir)
+	skills, warnings, err := loader.Discover(nil)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	byName := indexByName(skills)
+	assert.Contains(t, byName, "rubichan-skill", "should discover .rubichan/skills/")
+	assert.Contains(t, byName, "kilo-skill", "should discover .kilo/skills/")
+	assert.Contains(t, byName, "claude-skill", "should discover .claude/skills/")
+	assert.Contains(t, byName, "opencode-skill", "should discover .opencode/skills/")
+}
+
+func TestDiscoverWellKnownSubdirsPrecedence(t *testing.T) {
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	// Same skill name in both .rubichan/skills and .claude/skills.
+	rubichanDir := filepath.Join(userDir, ".rubichan", "skills")
+	require.NoError(t, os.MkdirAll(rubichanDir, 0o755))
+	writeSkillYAML(t, rubichanDir, "shared", `name: shared
+version: 2.0.0
+description: "Rubichan version"
+types:
+  - prompt
+`)
+
+	claudeDir := filepath.Join(userDir, ".claude", "skills")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+	writeSkillYAML(t, claudeDir, "shared", `name: shared
+version: 1.0.0
+description: "Claude version"
+types:
+  - prompt
+`)
+
+	loader := NewLoader(userDir, projectDir)
+	skills, warnings, err := loader.Discover(nil)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	require.Len(t, skills, 1)
+
+	// .rubichan/skills should win (searched first).
+	assert.Equal(t, "2.0.0", skills[0].Manifest.Version)
+}
+
+func TestDiscoverPureMarkdownSkill(t *testing.T) {
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	// Create a pure markdown skill (no frontmatter).
+	skillDir := filepath.Join(userDir, "commit-helper")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skillDir, "SKILL.md"),
+		[]byte("# Commit Helper\n\nWrite good commit messages."),
+		0o644,
+	))
+
+	loader := NewLoader(userDir, projectDir)
+	skills, warnings, err := loader.Discover(nil)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	require.Len(t, skills, 1)
+
+	assert.Equal(t, "commit-helper", skills[0].Manifest.Name)
+	assert.Equal(t, []SkillType{SkillTypePrompt}, skills[0].Manifest.Types)
+	assert.Equal(t, "Commit Helper", skills[0].Manifest.Description)
+	assert.Equal(t, "# Commit Helper\n\nWrite good commit messages.", skills[0].InstructionBody)
+}
+
+func TestDiscoverPureMarkdownSkillInSubdir(t *testing.T) {
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	// Create a pure markdown skill in .kilo/skills/ subdirectory.
+	kiloDir := filepath.Join(userDir, ".kilo", "skills")
+	skillDir := filepath.Join(kiloDir, "my-prompt")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skillDir, "prompt.md"),
+		[]byte("# My Prompt\n\nThis is a prompt-only skill."),
+		0o644,
+	))
+
+	loader := NewLoader(userDir, projectDir)
+	skills, warnings, err := loader.Discover(nil)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	require.Len(t, skills, 1)
+
+	assert.Equal(t, "prompt", skills[0].Manifest.Name)
+	assert.Equal(t, "My Prompt", skills[0].Manifest.Description)
+	assert.Equal(t, SourceUser, skills[0].Source)
 }
 
 // indexByName builds a map of DiscoveredSkill by manifest name for test convenience.

--- a/internal/skills/manifest.go
+++ b/internal/skills/manifest.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -412,6 +413,64 @@ func parseInstructionSkill(data []byte, strict bool) (*SkillManifest, string, er
 	return m, string(body), nil
 }
 
+// ParsePureMarkdownSkill parses a plain markdown file (no frontmatter) into a
+// synthetic SkillManifest. The name parameter is derived from the filename.
+// The entire markdown body becomes the instruction body. This is the simplest
+// skill format — just a markdown file with instructions.
+func ParsePureMarkdownSkill(name string, data []byte) (*SkillManifest, string, error) {
+	if name == "" {
+		return nil, "", fmt.Errorf("pure markdown skill: name is required")
+	}
+
+	description := generateDescriptionFromMarkdown(string(data))
+
+	m := &SkillManifest{
+		Name:        name,
+		Version:     "1.0.0",
+		Description: description,
+		Types:       []SkillType{SkillTypePrompt},
+	}
+
+	if err := validateManifest(m); err != nil {
+		return nil, "", fmt.Errorf("pure markdown skill: %w", err)
+	}
+
+	return m, string(data), nil
+}
+
+const (
+	maxDescriptionLen = 80
+	ellipsis          = "..."
+)
+
+// generateDescriptionFromMarkdown extracts a short description from markdown content.
+// It prefers the first H1 heading, then the first line of text.
+func generateDescriptionFromMarkdown(content string) string {
+	start := 0
+	for {
+		end := strings.IndexByte(content[start:], '\n')
+		line := content[start:]
+		if end >= 0 {
+			line = content[start : start+end]
+		}
+		line = strings.TrimSpace(line)
+		if line != "" {
+			if strings.HasPrefix(line, "# ") {
+				return strings.TrimPrefix(line, "# ")
+			}
+			if len(line) > maxDescriptionLen {
+				return line[:maxDescriptionLen-len(ellipsis)] + ellipsis
+			}
+			return line
+		}
+		if end < 0 {
+			break
+		}
+		start += end + 1
+	}
+	return "Markdown skill"
+}
+
 // LintSkillDir performs author-facing validation for a skill directory.
 // It returns a slice of issues; an empty slice means the skill passed linting.
 func LintSkillDir(skillDir string) []string {
@@ -492,6 +551,10 @@ func loadManifestForLint(skillDir string) (*SkillManifest, string, string, error
 	return manifest, "instruction", body, nil
 }
 
+// ErrNoFrontmatter is returned by splitFrontmatter when the markdown content
+// does not start with a "---" frontmatter delimiter.
+var ErrNoFrontmatter = errors.New("missing frontmatter delimiter (---)")
+
 // splitFrontmatter extracts YAML frontmatter from markdown content.
 // The frontmatter must be delimited by "---" lines. The closing delimiter
 // must appear at the start of a line to avoid matching "---" as a substring
@@ -502,7 +565,7 @@ func splitFrontmatter(data []byte) ([]byte, []byte, error) {
 	// Must start with "---".
 	trimmed := bytes.TrimLeft(data, " \t")
 	if !bytes.HasPrefix(trimmed, sep) {
-		return nil, nil, fmt.Errorf("missing frontmatter delimiter (---)")
+		return nil, nil, ErrNoFrontmatter
 	}
 
 	// Find opening delimiter and skip to next line.


### PR DESCRIPTION
## Summary

- Add `.rubichan/skills/`, `.kilo/skills/`, `.claude/skills/`, `.opencode/skills/` discovery paths
- Support pure markdown skills (`.md` files without YAML frontmatter)
- Deduplicate skills within same source level with precedence ordering (`.rubichan` > `.kilo` > `.claude` > `.opencode`)
- Graceful fallback chain: `SKILL.yaml` > `SKILL.md` (with frontmatter) > `SKILL.md` (pure markdown) > any `.md` file
- Optimize: skip non-existent subdirs, avoid `string.Split` allocation in description extraction

## Test Plan

- [x] All existing tests pass
- [x] New tests for well-known subdir discovery
- [x] New tests for precedence ordering
- [x] New tests for pure markdown skills
- [x] Lint clean (`golangci-lint run ./internal/skills/...`)
- [x] Format clean (`gofmt -l internal/skills/`)

## Backward Compatibility

Fully backward compatible — existing `SKILL.yaml` and `SKILL.md` skills unchanged. All changes are additive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added phase 1 implementation plan and comprehensive gap analysis documentation for skill system enhancements.

* **New Features**
  * Extended skill discovery to include `.kilo/skills/` directories in user home and project root locations.
  * Added support for pure markdown skills, enabling `.md` files without YAML frontmatter to be automatically discovered and used.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/julianshen/rubichan/pull/285)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->