### PR TITLE
[BEHAVIORAL] Dynamic skill reloading with fsnotify watcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,10 @@ require (
 	mvdan.cc/sh/v3 v3.13.0
 )
 
-require golang.org/x/tools v0.43.0 // indirect
+require (
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
+	golang.org/x/tools v0.43.0 // indirect
+)
 
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 h1:vymEbVwYFP/L05h5TKQxvkXoKxNvTpjxYKdF1Nlwuao=
 github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=

--- a/internal/skills/runtime.go
+++ b/internal/skills/runtime.go
@@ -876,6 +876,28 @@ func (rt *Runtime) EventBus() *SkillEventBus {
 	return rt.eventBus
 }
 
+// GetWatchedDirs returns the directories that should be watched for skill changes.
+func (rt *Runtime) GetWatchedDirs() []string {
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+
+	var dirs []string
+	if rt.loader != nil {
+		if d := rt.loader.userDir; d != "" {
+			dirs = append(dirs, d)
+		}
+		if d := rt.loader.projectDir; d != "" {
+			dirs = append(dirs, d)
+		}
+		for _, d := range rt.loader.skillDirs {
+			if d != "" {
+				dirs = append(dirs, d)
+			}
+		}
+	}
+	return dirs
+}
+
 // emitErrorEvent emits a SkillError event if the event bus is configured.
 func (rt *Runtime) emitErrorEvent(name string, err error) {
 	if rt.eventBus != nil {

--- a/internal/skills/runtime.go
+++ b/internal/skills/runtime.go
@@ -227,63 +227,18 @@ func (rt *Runtime) Activate(name string) error {
 	if !autoApproved {
 		for _, perm := range permissions {
 			if err := sb.CheckPermission(perm); err != nil {
-				rt.mu.Lock()
-				_ = sk.TransitionTo(SkillStateError)
-				_ = sk.TransitionTo(SkillStateInactive)
-				rt.mu.Unlock()
-				rt.emitErrorEvent(name, err)
-				return fmt.Errorf("activate skill %q: %w", name, err)
-			}
-
-			if !autoApproved {
-				for _, perm := range permissions {
-					if err := sb.CheckPermission(perm); err != nil {
-						rt.mu.Lock()
-						_ = sk.TransitionTo(SkillStateError)
-						_ = sk.TransitionTo(SkillStateInactive)
-						rt.mu.Unlock()
-						rt.emitErrorEvent(name, err)
-						return fmt.Errorf("activate skill %q: %w", name, err)
-					}
-				}
-			}
-
-			backend, err := backendFactory(manifest, skillDir)
-			if err != nil {
-				rt.mu.Lock()
-				_ = sk.TransitionTo(SkillStateError)
-				_ = sk.TransitionTo(SkillStateInactive)
-				rt.mu.Unlock()
-				rt.emitErrorEvent(name, err)
-				return fmt.Errorf("create backend for skill %q: %w", name, err)
-			}
-
-			if err := backend.Load(manifest, sb); err != nil {
-				rt.mu.Lock()
-				_ = sk.TransitionTo(SkillStateError)
-				_ = sk.TransitionTo(SkillStateInactive)
-				rt.mu.Unlock()
-				rt.emitErrorEvent(name, err)
-				return fmt.Errorf("load skill %q: %w", name, err)
+				return rt.failActivation(sk, name, err)
 			}
 		}
 	}
 
 	backend, err := backendFactory(manifest, skillDir)
 	if err != nil {
-		rt.mu.Lock()
-		_ = sk.TransitionTo(SkillStateError)
-		_ = sk.TransitionTo(SkillStateInactive)
-		rt.mu.Unlock()
-		return fmt.Errorf("create backend for skill %q: %w", name, err)
+		return rt.failActivation(sk, name, fmt.Errorf("create backend: %w", err))
 	}
 
 	if err := backend.Load(manifest, sb); err != nil {
-		rt.mu.Lock()
-		_ = sk.TransitionTo(SkillStateError)
-		_ = sk.TransitionTo(SkillStateInactive)
-		rt.mu.Unlock()
-		return fmt.Errorf("load skill %q: %w", name, err)
+		return rt.failActivation(sk, name, fmt.Errorf("load backend: %w", err))
 	}
 
 	// After a successful Load, any error must call backend.Unload() to release
@@ -896,6 +851,18 @@ func (rt *Runtime) GetWatchedDirs() []string {
 		}
 	}
 	return dirs
+}
+
+// failActivation handles the common error path during skill activation:
+// transitions the skill to Error then Inactive, emits an event, and returns
+// a wrapped error. The caller must NOT hold rt.mu.
+func (rt *Runtime) failActivation(sk *Skill, name string, err error) error {
+	rt.mu.Lock()
+	_ = sk.TransitionTo(SkillStateError)
+	_ = sk.TransitionTo(SkillStateInactive)
+	rt.mu.Unlock()
+	rt.emitErrorEvent(name, err)
+	return fmt.Errorf("activate skill %q: %w", name, err)
 }
 
 // emitErrorEvent emits a SkillError event if the event bus is configured.

--- a/internal/skills/runtime.go
+++ b/internal/skills/runtime.go
@@ -115,13 +115,29 @@ func (rt *Runtime) Discover(explicit []string) error {
 
 	rt.discoveryWarnings = append(rt.discoveryWarnings[:0], warnings...)
 
+	// Track which skills are still present after discovery.
+	present := make(map[string]bool, len(discovered))
 	for _, ds := range discovered {
+		present[ds.Manifest.Name] = true
+		// Preserve active state for skills that are already active.
+		state := SkillStateInactive
+		if existing, ok := rt.skills[ds.Manifest.Name]; ok && existing.State == SkillStateActive {
+			state = SkillStateActive
+		}
 		rt.skills[ds.Manifest.Name] = &Skill{
 			Manifest:        ds.Manifest,
-			State:           SkillStateInactive,
+			State:           state,
 			Dir:             ds.Dir,
 			Source:          ds.Source,
 			InstructionBody: ds.InstructionBody,
+		}
+	}
+
+	// Remove skills that no longer exist on disk, but only if inactive.
+	// Active skills are kept to avoid disrupting running backends.
+	for name, sk := range rt.skills {
+		if !present[name] && sk.State != SkillStateActive {
+			delete(rt.skills, name)
 		}
 	}
 

--- a/internal/skills/watcher.go
+++ b/internal/skills/watcher.go
@@ -120,10 +120,8 @@ func (sw *SkillWatcher) loop() {
 			}
 			if sw.isSkillFile(event.Name) {
 				sw.mu.Lock()
-				if !sw.pending {
-					sw.pending = true
-					debounceTimer.Reset(sw.debounce)
-				}
+				sw.pending = true
+				debounceTimer.Reset(sw.debounce)
 				sw.mu.Unlock()
 			}
 		case err, ok := <-sw.watcher.Errors:
@@ -138,7 +136,22 @@ func (sw *SkillWatcher) loop() {
 			sw.pending = false
 			sw.mu.Unlock()
 			if pending {
-				sw.reload()
+				// Non-blocking check: if new events arrived during reload,
+				// reset the timer instead of reloading immediately.
+				select {
+				case event, ok := <-sw.watcher.Events:
+					if !ok {
+						return
+					}
+					if sw.isSkillFile(event.Name) {
+						sw.mu.Lock()
+						sw.pending = true
+						debounceTimer.Reset(sw.debounce)
+						sw.mu.Unlock()
+					}
+				default:
+					sw.reload()
+				}
 			}
 		}
 	}
@@ -161,23 +174,18 @@ func (sw *SkillWatcher) isSkillFile(path string) bool {
 // isSkillDir checks if a path is within a skill directory.
 func isSkillDir(path string) bool {
 	// Use filepath separators to avoid false matches like "foo.kilo/skillsbar".
-	return containsPathSegment(path, ".kilo/skills") ||
-		containsPathSegment(path, ".claude/skills") ||
-		containsPathSegment(path, ".opencode/skills") ||
-		containsPathSegment(path, ".rubichan/skills")
-}
-
-// containsPathSegment checks if path contains the segment as a path component.
-func containsPathSegment(path, segment string) bool {
-	// Normalize to forward slashes for consistent matching.
 	normalized := filepath.ToSlash(path)
-	// Check for exact segment match bounded by path separators.
-	prefix := segment + "/"
-	if strings.HasPrefix(normalized, prefix) {
-		return true
+	for _, subdir := range wellKnownSkillSubdirs {
+		prefix := subdir + "/"
+		if strings.HasPrefix(normalized, prefix) {
+			return true
+		}
+		infix := "/" + subdir + "/"
+		if strings.Contains(normalized, infix) {
+			return true
+		}
 	}
-	infix := "/" + segment + "/"
-	return strings.Contains(normalized, infix)
+	return false
 }
 
 // reload triggers a skill rediscovery.

--- a/internal/skills/watcher.go
+++ b/internal/skills/watcher.go
@@ -47,11 +47,8 @@ func (sw *SkillWatcher) Start() error {
 		if dir == "" {
 			continue
 		}
-		// Watch the root directory and well-known subdirs.
-		sw.addWatch(dir)
-		for _, subdir := range wellKnownSkillSubdirs {
-			sw.addWatch(filepath.Join(dir, subdir))
-		}
+		// Watch the root directory recursively.
+		sw.addWatch(dir, true)
 	}
 
 	sw.wg.Add(1)
@@ -69,12 +66,33 @@ func (sw *SkillWatcher) Stop() {
 }
 
 // addWatch adds a directory to the watcher if it exists.
-func (sw *SkillWatcher) addWatch(dir string) {
+// If recursive is true, it also watches all subdirectories.
+func (sw *SkillWatcher) addWatch(dir string, recursive bool) {
 	if err := sw.watcher.Add(dir); err != nil {
 		// Directory may not exist; that's ok.
 		return
 	}
 	log.Printf("[skill-watcher] watching %s", dir)
+
+	if !recursive {
+		return
+	}
+
+	// Recursively watch all subdirectories.
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || !d.IsDir() || path == dir {
+			if err != nil {
+				log.Printf("[skill-watcher] walk error in %s: %v", dir, err)
+			}
+			return nil
+		}
+		if err := sw.watcher.Add(path); err != nil {
+			log.Printf("[skill-watcher] failed to watch %s: %v", path, err)
+			return nil
+		}
+		log.Printf("[skill-watcher] watching %s", path)
+		return nil
+	})
 }
 
 // loop processes fsnotify events with debouncing.
@@ -97,7 +115,7 @@ func (sw *SkillWatcher) loop() {
 			// Auto-add watches for newly created directories.
 			if event.Op&fsnotify.Create == fsnotify.Create {
 				if info, err := os.Stat(event.Name); err == nil && info.IsDir() && isSkillDir(event.Name) {
-					sw.addWatch(event.Name)
+					sw.addWatch(event.Name, true)
 				}
 			}
 			if sw.isSkillFile(event.Name) {
@@ -142,10 +160,24 @@ func (sw *SkillWatcher) isSkillFile(path string) bool {
 
 // isSkillDir checks if a path is within a skill directory.
 func isSkillDir(path string) bool {
-	return strings.Contains(path, ".kilo/skills") ||
-		strings.Contains(path, ".claude/skills") ||
-		strings.Contains(path, ".opencode/skills") ||
-		strings.Contains(path, ".rubichan/skills")
+	// Use filepath separators to avoid false matches like "foo.kilo/skillsbar".
+	return containsPathSegment(path, ".kilo/skills") ||
+		containsPathSegment(path, ".claude/skills") ||
+		containsPathSegment(path, ".opencode/skills") ||
+		containsPathSegment(path, ".rubichan/skills")
+}
+
+// containsPathSegment checks if path contains the segment as a path component.
+func containsPathSegment(path, segment string) bool {
+	// Normalize to forward slashes for consistent matching.
+	normalized := filepath.ToSlash(path)
+	// Check for exact segment match bounded by path separators.
+	prefix := segment + "/"
+	if strings.HasPrefix(normalized, prefix) {
+		return true
+	}
+	infix := "/" + segment + "/"
+	return strings.Contains(normalized, infix)
 }
 
 // reload triggers a skill rediscovery.

--- a/internal/skills/watcher.go
+++ b/internal/skills/watcher.go
@@ -1,0 +1,159 @@
+package skills
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// SkillWatcher watches skill directories for changes and triggers reloads.
+type SkillWatcher struct {
+	rt       *Runtime
+	watcher  *fsnotify.Watcher
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+	debounce time.Duration
+	mu       sync.Mutex
+	pending  bool
+}
+
+// NewSkillWatcher creates a new watcher for the given runtime.
+func NewSkillWatcher(rt *Runtime) (*SkillWatcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create fsnotify watcher: %w", err)
+	}
+
+	return &SkillWatcher{
+		rt:       rt,
+		watcher:  watcher,
+		stopCh:   make(chan struct{}),
+		debounce: 500 * time.Millisecond,
+	}, nil
+}
+
+// Start begins watching skill directories. It discovers all directories
+// that contain skills and adds them to the watcher.
+func (sw *SkillWatcher) Start() error {
+	dirs := sw.rt.GetWatchedDirs()
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		// Watch the root directory and well-known subdirs.
+		sw.addWatch(dir)
+		for _, subdir := range wellKnownSkillSubdirs {
+			sw.addWatch(filepath.Join(dir, subdir))
+		}
+	}
+
+	sw.wg.Add(1)
+	go sw.loop()
+	return nil
+}
+
+// Stop stops the watcher and cleans up resources.
+func (sw *SkillWatcher) Stop() {
+	sw.stopOnce.Do(func() {
+		close(sw.stopCh)
+		sw.watcher.Close()
+	})
+	sw.wg.Wait()
+}
+
+// addWatch adds a directory to the watcher if it exists.
+func (sw *SkillWatcher) addWatch(dir string) {
+	if err := sw.watcher.Add(dir); err != nil {
+		// Directory may not exist; that's ok.
+		return
+	}
+	log.Printf("[skill-watcher] watching %s", dir)
+}
+
+// loop processes fsnotify events with debouncing.
+func (sw *SkillWatcher) loop() {
+	defer sw.wg.Done()
+
+	debounceTimer := time.NewTimer(0)
+	<-debounceTimer.C // drain initial timer
+
+	for {
+		select {
+		case <-sw.stopCh:
+			debounceTimer.Stop()
+			return
+		case event, ok := <-sw.watcher.Events:
+			if !ok {
+				debounceTimer.Stop()
+				return
+			}
+			// Auto-add watches for newly created directories.
+			if event.Op&fsnotify.Create == fsnotify.Create {
+				if info, err := os.Stat(event.Name); err == nil && info.IsDir() && isSkillDir(event.Name) {
+					sw.addWatch(event.Name)
+				}
+			}
+			if sw.isSkillFile(event.Name) {
+				sw.mu.Lock()
+				if !sw.pending {
+					sw.pending = true
+					debounceTimer.Reset(sw.debounce)
+				}
+				sw.mu.Unlock()
+			}
+		case err, ok := <-sw.watcher.Errors:
+			if !ok {
+				debounceTimer.Stop()
+				return
+			}
+			log.Printf("[skill-watcher] error: %v", err)
+		case <-debounceTimer.C:
+			sw.mu.Lock()
+			pending := sw.pending
+			sw.pending = false
+			sw.mu.Unlock()
+			if pending {
+				sw.reload()
+			}
+		}
+	}
+}
+
+// isSkillFile checks if a path is a skill-related file or directory.
+func (sw *SkillWatcher) isSkillFile(path string) bool {
+	base := filepath.Base(path)
+	// Watch SKILL.yaml, SKILL.md, and .md files.
+	if base == "SKILL.yaml" || base == "SKILL.md" || strings.HasSuffix(base, ".md") {
+		return true
+	}
+	// Watch skill directories.
+	if isSkillDir(path) {
+		return true
+	}
+	return false
+}
+
+// isSkillDir checks if a path is within a skill directory.
+func isSkillDir(path string) bool {
+	return strings.Contains(path, ".kilo/skills") ||
+		strings.Contains(path, ".claude/skills") ||
+		strings.Contains(path, ".opencode/skills") ||
+		strings.Contains(path, ".rubichan/skills")
+}
+
+// reload triggers a skill rediscovery.
+func (sw *SkillWatcher) reload() {
+	log.Println("[skill-watcher] reloading skills...")
+	if err := sw.rt.Discover(nil); err != nil {
+		log.Printf("[skill-watcher] reload failed: %v", err)
+		return
+	}
+	log.Println("[skill-watcher] reload complete")
+}

--- a/internal/skills/watcher_test.go
+++ b/internal/skills/watcher_test.go
@@ -71,13 +71,50 @@ func TestSkillWatcherReloadOnChange(t *testing.T) {
 		0o644,
 	))
 
-	// Manually trigger reload to verify the watcher mechanism works.
-	// fsnotify in temp dirs on macOS is unreliable in tests.
-	w.reload()
+	// Trigger reload via the event loop by writing a file in a watched dir.
+	testFile := filepath.Join(userDir, "trigger.md")
+	require.NoError(t, os.WriteFile(testFile, []byte("trigger"), 0o644))
 
-	// Verify new skill was discovered.
-	rt.mu.RLock()
-	_, ok := rt.skills["new-skill"]
-	rt.mu.RUnlock()
-	assert.True(t, ok, "new skill should be discovered after reload")
+	// Wait for debounce + reload with retry.
+	require.Eventually(t, func() bool {
+		rt.mu.RLock()
+		_, ok := rt.skills["new-skill"]
+		rt.mu.RUnlock()
+		return ok
+	}, 2*time.Second, 100*time.Millisecond, "new skill should be discovered after reload")
+}
+
+func TestSkillWatcherAutoAddWatch(t *testing.T) {
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	loader := NewLoader(userDir, projectDir)
+	rt := NewRuntime(loader, nil, nil, nil, nil, nil)
+
+	w, err := NewSkillWatcher(rt)
+	require.NoError(t, err)
+	w.debounce = 100 * time.Millisecond
+	require.NoError(t, w.Start())
+	defer w.Stop()
+
+	// Create a new skill directory that matches isSkillDir pattern.
+	newSkillDir := filepath.Join(userDir, ".kilo", "skills", "auto-skill")
+	require.NoError(t, os.MkdirAll(newSkillDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(newSkillDir, "SKILL.yaml"),
+		[]byte("name: auto-skill\nversion: 1.0.0\ndescription: Auto discovered\ntypes:\n  - prompt\n"),
+		0o644,
+	))
+
+	// Trigger reload by touching a file in the watched userDir.
+	testFile := filepath.Join(userDir, "trigger.md")
+	require.NoError(t, os.WriteFile(testFile, []byte("trigger"), 0o644))
+
+	// Wait for debounce + reload with retry.
+	require.Eventually(t, func() bool {
+		rt.mu.RLock()
+		_, ok := rt.skills["auto-skill"]
+		rt.mu.RUnlock()
+		return ok
+	}, 2*time.Second, 100*time.Millisecond, "skill in auto-added watch dir should be discovered")
 }

--- a/internal/skills/watcher_test.go
+++ b/internal/skills/watcher_test.go
@@ -1,0 +1,83 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkillWatcherNew(t *testing.T) {
+	rt := NewRuntime(nil, nil, nil, nil, nil, nil)
+	w, err := NewSkillWatcher(rt)
+	require.NoError(t, err)
+	require.NotNil(t, w)
+	w.Stop()
+}
+
+func TestSkillWatcherIsSkillFile(t *testing.T) {
+	rt := NewRuntime(nil, nil, nil, nil, nil, nil)
+	w, err := NewSkillWatcher(rt)
+	require.NoError(t, err)
+	defer w.Stop()
+
+	assert.True(t, w.isSkillFile("/path/to/SKILL.yaml"))
+	assert.True(t, w.isSkillFile("/path/to/SKILL.md"))
+	assert.True(t, w.isSkillFile("/path/to/skill.md"))
+	assert.True(t, w.isSkillFile("/home/user/.kilo/skills/my-skill/SKILL.yaml"))
+	assert.False(t, w.isSkillFile("/path/to/random.txt"))
+	assert.False(t, w.isSkillFile("/path/to/main.go"))
+}
+
+func TestSkillWatcherStartStop(t *testing.T) {
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	loader := NewLoader(userDir, projectDir)
+	rt := NewRuntime(loader, nil, nil, nil, nil, nil)
+
+	w, err := NewSkillWatcher(rt)
+	require.NoError(t, err)
+
+	require.NoError(t, w.Start())
+	// Give it a moment to set up watches.
+	time.Sleep(100 * time.Millisecond)
+	w.Stop()
+}
+
+func TestSkillWatcherReloadOnChange(t *testing.T) {
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	loader := NewLoader(userDir, projectDir)
+	rt := NewRuntime(loader, nil, nil, nil, nil, nil)
+
+	// Start watcher with short debounce for testing.
+	w, err := NewSkillWatcher(rt)
+	require.NoError(t, err)
+	w.debounce = 200 * time.Millisecond
+	require.NoError(t, w.Start())
+	defer w.Stop()
+
+	// Create a new skill file in an already-watched directory.
+	newSkillDir := filepath.Join(userDir, "new-skill")
+	require.NoError(t, os.MkdirAll(newSkillDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(newSkillDir, "SKILL.yaml"),
+		[]byte("name: new-skill\nversion: 1.0.0\ndescription: A new skill\ntypes:\n  - prompt\n"),
+		0o644,
+	))
+
+	// Manually trigger reload to verify the watcher mechanism works.
+	// fsnotify in temp dirs on macOS is unreliable in tests.
+	w.reload()
+
+	// Verify new skill was discovered.
+	rt.mu.RLock()
+	_, ok := rt.skills["new-skill"]
+	rt.mu.RUnlock()
+	assert.True(t, ok, "new skill should be discovered after reload")
+}


### PR DESCRIPTION
## Summary

- Add `SkillWatcher` using `fsnotify` to watch skill directories for changes
- Auto-detect new/modified/deleted skills and trigger `Discover()` reload
- Debounced reload (500ms) to batch rapid file changes
- Auto-add watches for newly created skill directories
- Add `GetWatchedDirs()` to `Runtime` for watcher initialization

## Changes

### SkillWatcher (`internal/skills/watcher.go`)
- Watches `~/.kilo/skills/`, `./.kilo/skills/`, and other configured dirs
- Detects `SKILL.yaml`, `SKILL.md`, and `.md` file changes
- Debounces rapid changes to avoid excessive reloads
- Auto-adds watches for newly created directories
- `Start()` / `Stop()` lifecycle methods

### Runtime Integration
- `GetWatchedDirs()` returns directories to watch
- Watcher calls `Discover(nil)` on changes

## Test Plan

- [x] All existing tests pass
- [x] New tests for watcher creation
- [x] New tests for skill file detection
- [x] New tests for start/stop lifecycle
- [x] New tests for reload on file change
- [x] Lint clean
- [x] Format clean

## Dependencies

- Added `github.com/fsnotify/fsnotify v1.10.1`

## Backward Compatibility

Fully backward compatible — watcher is opt-in via `NewSkillWatcher()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic monitoring and detection of skill file changes across configured skill directories.
  * Skills are automatically reloaded when modified, enabling faster development workflows without requiring manual restarts.

* **Tests**
  * Added comprehensive test coverage for skill file detection and automatic reload mechanisms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/julianshen/rubichan/pull/289)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->