### PR TITLE
[BEHAVIORAL] Wire lifecycle hooks: Activate, Deactivate, BeforeToolCall, AfterToolResult, AfterToolFailure

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2661,6 +2661,31 @@ func (a *Agent) executeSingleTool(ctx context.Context, ch chan<- TurnEvent, tc p
 			}
 		}
 	}()
+
+	// Dispatch HookOnBeforeToolCall. If a hook cancels the call, return
+	// an error result immediately without executing the tool.
+	if a.skillRuntime != nil {
+		hookResult, err := a.skillRuntime.DispatchHook(skills.HookEvent{
+			Phase: skills.HookOnBeforeToolCall,
+			Ctx:   ctx,
+			Data: map[string]any{
+				skills.HookDataToolName: tc.Name,
+				skills.HookDataInput:    tc.Input,
+			},
+		})
+		if err != nil {
+			a.logger.Warn("HookOnBeforeToolCall failed for %s: %v", tc.Name, err)
+		} else if hookResult != nil && hookResult.Cancel {
+			cancelMsg := fmt.Sprintf("tool %q cancelled by skill hook", tc.Name)
+			return toolExecResult{
+				toolUseID: tc.ID,
+				content:   cancelMsg,
+				isError:   true,
+				event:     makeToolResultEvent(tc.ID, tc.Name, cancelMsg, "", true),
+			}
+		}
+	}
+
 	emit := func(ev tools.ToolEvent) {
 		a.emit(ctx, ch, TurnEvent{
 			Type: "tool_progress",
@@ -2690,6 +2715,44 @@ func (a *Agent) executeSingleTool(ctx context.Context, ch chan<- TurnEvent, tc p
 		})
 		result.Content = capped.Content
 	}
+
+	// Dispatch HookOnAfterToolResult to allow skills to modify the result.
+	if a.skillRuntime != nil {
+		hookResult, err := a.skillRuntime.DispatchHook(skills.HookEvent{
+			Phase: skills.HookOnAfterToolResult,
+			Ctx:   ctx,
+			Data: map[string]any{
+				skills.HookDataToolName: tc.Name,
+				skills.HookDataInput:    tc.Input,
+				skills.HookDataContent:  result.Content,
+				skills.HookDataIsError:  result.IsError,
+			},
+		})
+		if err != nil {
+			a.logger.Warn("HookOnAfterToolResult failed for %s: %v", tc.Name, err)
+		} else if hookResult != nil && hookResult.Modified != nil {
+			if modifiedContent, ok := hookResult.Modified["content"].(string); ok {
+				result.Content = modifiedContent
+			}
+		}
+	}
+
+	// Dispatch HookOnAfterToolFailure for error results.
+	if result.IsError && a.skillRuntime != nil {
+		if _, err := a.skillRuntime.DispatchHook(skills.HookEvent{
+			Phase: skills.HookOnAfterToolFailure,
+			Ctx:   ctx,
+			Data: map[string]any{
+				skills.HookDataToolName: tc.Name,
+				skills.HookDataInput:    tc.Input,
+				skills.HookDataContent:  result.Content,
+				skills.HookDataIsError:  true,
+			},
+		}); err != nil {
+			a.logger.Warn("HookOnAfterToolFailure failed for %s: %v", tc.Name, err)
+		}
+	}
+
 	return toolExecResult{
 		toolUseID: tc.ID,
 		content:   result.Content,

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2737,22 +2737,6 @@ func (a *Agent) executeSingleTool(ctx context.Context, ch chan<- TurnEvent, tc p
 		}
 	}
 
-	// Dispatch HookOnAfterToolFailure for error results.
-	if result.IsError && a.skillRuntime != nil {
-		if _, err := a.skillRuntime.DispatchHook(skills.HookEvent{
-			Phase: skills.HookOnAfterToolFailure,
-			Ctx:   ctx,
-			Data: map[string]any{
-				skills.HookDataToolName: tc.Name,
-				skills.HookDataInput:    tc.Input,
-				skills.HookDataContent:  result.Content,
-				skills.HookDataIsError:  true,
-			},
-		}); err != nil {
-			a.logger.Warn("HookOnAfterToolFailure failed for %s: %v", tc.Name, err)
-		}
-	}
-
 	return toolExecResult{
 		toolUseID: tc.ID,
 		content:   result.Content,

--- a/internal/skills/runtime.go
+++ b/internal/skills/runtime.go
@@ -296,6 +296,7 @@ func (rt *Runtime) Activate(name string) error {
 	}
 
 	rt.mu.Lock()
+	defer rt.mu.Unlock()
 
 	var registeredTools []tools.Tool
 	for _, tool := range backend.Tools() {
@@ -438,9 +439,7 @@ func (rt *Runtime) Activate(name string) error {
 		})
 	}
 
-	rt.mu.Unlock()
-
-	// Dispatch HookOnActivate after the skill is fully active and lock released.
+	// Dispatch HookOnActivate after the skill is fully active.
 	// Fail-open: hook errors are logged but do not fail activation.
 	if _, err := rt.lifecycle.Dispatch(HookEvent{
 		Phase:     HookOnActivate,
@@ -458,10 +457,10 @@ func (rt *Runtime) Activate(name string) error {
 // tools, unregisters hooks, calls backend.Unload, and clears the backend.
 func (rt *Runtime) Deactivate(name string) error {
 	rt.mu.Lock()
+	defer rt.mu.Unlock()
 
 	sk, ok := rt.active[name]
 	if !ok {
-		rt.mu.Unlock()
 		return fmt.Errorf("skill %q is not active", name)
 	}
 
@@ -495,6 +494,20 @@ func (rt *Runtime) Deactivate(name string) error {
 			_ = rt.agentDefRegistrar.Unregister(def.Name)
 		}
 	}
+
+	// Dispatch HookOnDeactivate before unregistering hooks so handlers can fire.
+	// Fail-open: hook errors are logged but do not block deactivation.
+	if _, err := rt.lifecycle.Dispatch(HookEvent{
+		Phase:     HookOnDeactivate,
+		SkillName: name,
+		Ctx:       context.Background(),
+		Data:      map[string]any{"skill_name": name},
+	}); err != nil {
+		log.Printf("[skill-runtime] HookOnDeactivate for %q failed: %v", name, err)
+	}
+
+	// Unregister hooks after dispatch so they don't fire again.
+	rt.lifecycle.Unregister(name)
 
 	// Clean up integration state for all skill types.
 	for _, st := range sk.Manifest.Types {
@@ -539,22 +552,6 @@ func (rt *Runtime) Deactivate(name string) error {
 			State:     SkillStateInactive,
 		})
 	}
-
-	// Dispatch HookOnDeactivate before unregistering hooks so handlers can fire.
-	// Fail-open: hook errors are logged but do not block deactivation.
-	if _, err := rt.lifecycle.Dispatch(HookEvent{
-		Phase:     HookOnDeactivate,
-		SkillName: name,
-		Ctx:       context.Background(),
-		Data:      map[string]any{"skill_name": name},
-	}); err != nil {
-		log.Printf("[skill-runtime] HookOnDeactivate for %q failed: %v", name, err)
-	}
-
-	// Unregister hooks after dispatch so they don't fire again.
-	rt.lifecycle.Unregister(name)
-
-	rt.mu.Unlock()
 
 	if unloadErr != nil {
 		return fmt.Errorf("unload skill %q: %w", name, unloadErr)

--- a/internal/skills/runtime.go
+++ b/internal/skills/runtime.go
@@ -425,6 +425,17 @@ func (rt *Runtime) Activate(name string) error {
 	rt.active[name] = sk
 	activated = true
 
+	// Dispatch HookOnActivate after the skill is fully active.
+	// Fail-open: hook errors are logged but do not fail activation.
+	if _, err := rt.lifecycle.Dispatch(HookEvent{
+		Phase:     HookOnActivate,
+		SkillName: name,
+		Ctx:       context.Background(),
+		Data:      map[string]any{"skill_name": name},
+	}); err != nil {
+		log.Printf("[skill-runtime] HookOnActivate for %q failed: %v", name, err)
+	}
+
 	// Emit activation and state change events.
 	if rt.eventBus != nil {
 		rt.eventBus.Publish(SkillEvent{
@@ -482,6 +493,17 @@ func (rt *Runtime) Deactivate(name string) error {
 		for _, def := range manifestAgentDefinitions(sk.Manifest) {
 			_ = rt.agentDefRegistrar.Unregister(def.Name)
 		}
+	}
+
+	// Dispatch HookOnDeactivate before unregistering hooks.
+	// Fail-open: hook errors are logged but do not block deactivation.
+	if _, err := rt.lifecycle.Dispatch(HookEvent{
+		Phase:     HookOnDeactivate,
+		SkillName: name,
+		Ctx:       context.Background(),
+		Data:      map[string]any{"skill_name": name},
+	}); err != nil {
+		log.Printf("[skill-runtime] HookOnDeactivate for %q failed: %v", name, err)
 	}
 
 	// Unregister hooks.

--- a/internal/skills/runtime.go
+++ b/internal/skills/runtime.go
@@ -296,7 +296,6 @@ func (rt *Runtime) Activate(name string) error {
 	}
 
 	rt.mu.Lock()
-	defer rt.mu.Unlock()
 
 	var registeredTools []tools.Tool
 	for _, tool := range backend.Tools() {
@@ -425,17 +424,6 @@ func (rt *Runtime) Activate(name string) error {
 	rt.active[name] = sk
 	activated = true
 
-	// Dispatch HookOnActivate after the skill is fully active.
-	// Fail-open: hook errors are logged but do not fail activation.
-	if _, err := rt.lifecycle.Dispatch(HookEvent{
-		Phase:     HookOnActivate,
-		SkillName: name,
-		Ctx:       context.Background(),
-		Data:      map[string]any{"skill_name": name},
-	}); err != nil {
-		log.Printf("[skill-runtime] HookOnActivate for %q failed: %v", name, err)
-	}
-
 	// Emit activation and state change events.
 	if rt.eventBus != nil {
 		rt.eventBus.Publish(SkillEvent{
@@ -450,6 +438,19 @@ func (rt *Runtime) Activate(name string) error {
 		})
 	}
 
+	rt.mu.Unlock()
+
+	// Dispatch HookOnActivate after the skill is fully active and lock released.
+	// Fail-open: hook errors are logged but do not fail activation.
+	if _, err := rt.lifecycle.Dispatch(HookEvent{
+		Phase:     HookOnActivate,
+		SkillName: name,
+		Ctx:       context.Background(),
+		Data:      map[string]any{"skill_name": name},
+	}); err != nil {
+		log.Printf("[skill-runtime] HookOnActivate for %q failed: %v", name, err)
+	}
+
 	return nil
 }
 
@@ -457,10 +458,10 @@ func (rt *Runtime) Activate(name string) error {
 // tools, unregisters hooks, calls backend.Unload, and clears the backend.
 func (rt *Runtime) Deactivate(name string) error {
 	rt.mu.Lock()
-	defer rt.mu.Unlock()
 
 	sk, ok := rt.active[name]
 	if !ok {
+		rt.mu.Unlock()
 		return fmt.Errorf("skill %q is not active", name)
 	}
 
@@ -494,20 +495,6 @@ func (rt *Runtime) Deactivate(name string) error {
 			_ = rt.agentDefRegistrar.Unregister(def.Name)
 		}
 	}
-
-	// Dispatch HookOnDeactivate before unregistering hooks.
-	// Fail-open: hook errors are logged but do not block deactivation.
-	if _, err := rt.lifecycle.Dispatch(HookEvent{
-		Phase:     HookOnDeactivate,
-		SkillName: name,
-		Ctx:       context.Background(),
-		Data:      map[string]any{"skill_name": name},
-	}); err != nil {
-		log.Printf("[skill-runtime] HookOnDeactivate for %q failed: %v", name, err)
-	}
-
-	// Unregister hooks.
-	rt.lifecycle.Unregister(name)
 
 	// Clean up integration state for all skill types.
 	for _, st := range sk.Manifest.Types {
@@ -552,6 +539,22 @@ func (rt *Runtime) Deactivate(name string) error {
 			State:     SkillStateInactive,
 		})
 	}
+
+	// Dispatch HookOnDeactivate before unregistering hooks so handlers can fire.
+	// Fail-open: hook errors are logged but do not block deactivation.
+	if _, err := rt.lifecycle.Dispatch(HookEvent{
+		Phase:     HookOnDeactivate,
+		SkillName: name,
+		Ctx:       context.Background(),
+		Data:      map[string]any{"skill_name": name},
+	}); err != nil {
+		log.Printf("[skill-runtime] HookOnDeactivate for %q failed: %v", name, err)
+	}
+
+	// Unregister hooks after dispatch so they don't fire again.
+	rt.lifecycle.Unregister(name)
+
+	rt.mu.Unlock()
 
 	if unloadErr != nil {
 		return fmt.Errorf("unload skill %q: %w", name, unloadErr)

--- a/internal/skills/runtime_test.go
+++ b/internal/skills/runtime_test.go
@@ -1447,27 +1447,117 @@ func TestRuntimeEventBusEmitsDeactivation(t *testing.T) {
 	assert.Equal(t, SkillStateInactive, events[1].State)
 }
 
-func TestRuntimeActivateBundledSkill(t *testing.T) {
-	userDir := t.TempDir()
-	projectDir := t.TempDir()
+func TestRuntimeActivateDispatchesHookOnActivate(t *testing.T) {
+	hookCalled := false
+	hookData := make(map[string]any)
 
-	loader := NewLoader(userDir, projectDir)
-	loader.RegisterBundled(BundledSkill{
-		Name:        "bundled-test",
+	rt, _, _ := newTestRuntime(t, []string{"hook-activate-skill"}, nil)
+
+	// Override the backend factory to inject a hook that captures the event.
+	originalFactory := rt.backendFactory
+	rt.backendFactory = func(manifest SkillManifest, dir string) (SkillBackend, error) {
+		mb := &mockBackend{
+			hooks: map[HookPhase]HookHandler{
+				HookOnActivate: func(event HookEvent) (HookResult, error) {
+					hookCalled = true
+					hookData = event.Data
+					return HookResult{}, nil
+				},
+			},
+		}
+		return mb, nil
+	}
+	_ = originalFactory
+
+	m := testManifest("hook-activate-skill")
+	rt.loader.RegisterBuiltin(m)
+
+	require.NoError(t, rt.Discover(nil))
+	require.NoError(t, rt.Activate("hook-activate-skill"))
+
+	assert.True(t, hookCalled, "HookOnActivate should have been dispatched")
+	assert.Equal(t, "hook-activate-skill", hookData["skill_name"])
+}
+
+func TestRuntimeDeactivateDispatchesHookOnDeactivate(t *testing.T) {
+	hookCalled := false
+	hookData := make(map[string]any)
+
+	rt, _, _ := newTestRuntime(t, []string{"hook-deactivate-skill"}, nil)
+
+	// Override the backend factory to inject a hook.
+	originalFactory := rt.backendFactory
+	rt.backendFactory = func(manifest SkillManifest, dir string) (SkillBackend, error) {
+		mb := &mockBackend{
+			hooks: map[HookPhase]HookHandler{
+				HookOnDeactivate: func(event HookEvent) (HookResult, error) {
+					hookCalled = true
+					hookData = event.Data
+					return HookResult{}, nil
+				},
+			},
+		}
+		return mb, nil
+	}
+	_ = originalFactory
+
+	m := testManifest("hook-deactivate-skill")
+	rt.loader.RegisterBuiltin(m)
+
+	require.NoError(t, rt.Discover(nil))
+	require.NoError(t, rt.Activate("hook-deactivate-skill"))
+	require.NoError(t, rt.Deactivate("hook-deactivate-skill"))
+
+	assert.True(t, hookCalled, "HookOnDeactivate should have been dispatched")
+	assert.Equal(t, "hook-deactivate-skill", hookData["skill_name"])
+}
+
+func TestRuntimeActivateBundledSkill(t *testing.T) {
+	rt, _, _ := newTestRuntime(t, []string{"bundled-skill"}, nil)
+
+	// Register a bundled skill with inline content.
+	rt.loader.RegisterBundled(BundledSkill{
+		Name:        "bundled-skill",
 		Version:     "1.0.0",
 		Description: "A bundled test skill",
 		Types:       []SkillType{SkillTypeTool},
 		Content: &InlineContent{
 			Files: map[string]string{
-				"SKILL.yaml": "name: bundled-test\nversion: 1.0.0\ndescription: A bundled test skill\ntypes:\n  - tool\nimplementation:\n  backend: starlark\n  entrypoint: main.star",
-				"SKILL.md":   "# Bundled Test\n\nThis skill was bundled.",
+				"SKILL.md": "# Bundled Skill\n",
 			},
 		},
 	})
 
+	// Discover should include the bundled skill.
+	err := rt.Discover(nil)
+	require.NoError(t, err)
+	assert.Contains(t, rt.skills, "bundled-skill")
+
+	// Activate should materialize the bundled content.
+	err = rt.Activate("bundled-skill")
+	require.NoError(t, err)
+
+	// Verify the skill directory was set.
+	rt.mu.RLock()
+	sk := rt.skills["bundled-skill"]
+	rt.mu.RUnlock()
+	require.NotNil(t, sk)
+	assert.NotEmpty(t, sk.Dir, "bundled skill should have a directory after materialization")
+	assert.DirExists(t, sk.Dir)
+
+	// Verify the file was written.
+	_, err = os.ReadFile(filepath.Join(sk.Dir, "SKILL.md"))
+	require.NoError(t, err)
+}
+
+func TestRuntimeActivateBundledSkillMaterializes(t *testing.T) {
 	s, err := store.NewStore(":memory:")
 	require.NoError(t, err)
+	t.Cleanup(func() { s.Close() })
+
 	registry := tools.NewRegistry()
+	loader := NewLoader("", "")
+
 	var capturedDir string
 	backendFactory := func(manifest SkillManifest, dir string) (SkillBackend, error) {
 		capturedDir = dir
@@ -1480,8 +1570,20 @@ func TestRuntimeActivateBundledSkill(t *testing.T) {
 	cacheDir := t.TempDir()
 	rt := NewRuntime(loader, s, registry, nil, backendFactory, sandboxFactory)
 	rt.SetBundledCacheDir(cacheDir)
-	require.NoError(t, rt.Discover(nil))
 
+	loader.RegisterBundled(BundledSkill{
+		Name:        "bundled-test",
+		Version:     "1.0.0",
+		Description: "Test bundled skill",
+		Types:       []SkillType{SkillTypeTool},
+		Content: &InlineContent{
+			Files: map[string]string{
+				"SKILL.md": "# Test\n",
+			},
+		},
+	})
+
+	require.NoError(t, rt.Discover(nil))
 	require.NoError(t, rt.Activate("bundled-test"))
 
 	// Verify the skill was materialized.

--- a/internal/skills/runtime_test.go
+++ b/internal/skills/runtime_test.go
@@ -1447,16 +1447,55 @@ func TestRuntimeEventBusEmitsDeactivation(t *testing.T) {
 	assert.Equal(t, SkillStateInactive, events[1].State)
 }
 
+func TestRuntimeLifecycleHookDispatch(t *testing.T) {
+	tests := []struct {
+		name            string
+		phase           HookPhase
+		needsDeactivate bool
+	}{
+		{"Activate", HookOnActivate, false},
+		{"Deactivate", HookOnDeactivate, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hookCalled := false
+			hookData := make(map[string]any)
+
+			rt, _, _ := newTestRuntime(t, []string{"hook-" + tt.name + "-skill"}, nil)
+			rt.backendFactory = func(manifest SkillManifest, dir string) (SkillBackend, error) {
+				return &mockBackend{
+					hooks: map[HookPhase]HookHandler{
+						tt.phase: func(event HookEvent) (HookResult, error) {
+							hookCalled = true
+							hookData = event.Data
+							return HookResult{}, nil
+						},
+					},
+				}, nil
+			}
+
+			m := testManifest("hook-" + tt.name + "-skill")
+			rt.loader.RegisterBuiltin(m)
+
+			require.NoError(t, rt.Discover(nil))
+			require.NoError(t, rt.Activate("hook-"+tt.name+"-skill"))
+			if tt.needsDeactivate {
+				require.NoError(t, rt.Deactivate("hook-"+tt.name+"-skill"))
+			}
+
+			assert.True(t, hookCalled, "HookOn%s should have been dispatched", tt.name)
+			assert.Equal(t, "hook-"+tt.name+"-skill", hookData["skill_name"])
+		})
+	}
+}
+
 func TestRuntimeActivateDispatchesHookOnActivate(t *testing.T) {
 	hookCalled := false
 	hookData := make(map[string]any)
 
 	rt, _, _ := newTestRuntime(t, []string{"hook-activate-skill"}, nil)
-
-	// Override the backend factory to inject a hook that captures the event.
-	originalFactory := rt.backendFactory
 	rt.backendFactory = func(manifest SkillManifest, dir string) (SkillBackend, error) {
-		mb := &mockBackend{
+		return &mockBackend{
 			hooks: map[HookPhase]HookHandler{
 				HookOnActivate: func(event HookEvent) (HookResult, error) {
 					hookCalled = true
@@ -1464,10 +1503,8 @@ func TestRuntimeActivateDispatchesHookOnActivate(t *testing.T) {
 					return HookResult{}, nil
 				},
 			},
-		}
-		return mb, nil
+		}, nil
 	}
-	_ = originalFactory
 
 	m := testManifest("hook-activate-skill")
 	rt.loader.RegisterBuiltin(m)
@@ -1484,11 +1521,8 @@ func TestRuntimeDeactivateDispatchesHookOnDeactivate(t *testing.T) {
 	hookData := make(map[string]any)
 
 	rt, _, _ := newTestRuntime(t, []string{"hook-deactivate-skill"}, nil)
-
-	// Override the backend factory to inject a hook.
-	originalFactory := rt.backendFactory
 	rt.backendFactory = func(manifest SkillManifest, dir string) (SkillBackend, error) {
-		mb := &mockBackend{
+		return &mockBackend{
 			hooks: map[HookPhase]HookHandler{
 				HookOnDeactivate: func(event HookEvent) (HookResult, error) {
 					hookCalled = true
@@ -1496,10 +1530,8 @@ func TestRuntimeDeactivateDispatchesHookOnDeactivate(t *testing.T) {
 					return HookResult{}, nil
 				},
 			},
-		}
-		return mb, nil
+		}, nil
 	}
-	_ = originalFactory
 
 	m := testManifest("hook-deactivate-skill")
 	rt.loader.RegisterBuiltin(m)

--- a/internal/skills/types.go
+++ b/internal/skills/types.go
@@ -72,8 +72,6 @@ const (
 	HookOnBeforeToolCall
 	// HookOnAfterToolResult is called after a tool execution returns a result.
 	HookOnAfterToolResult
-	// HookOnAfterToolFailure is called after a tool execution fails.
-	HookOnAfterToolFailure
 	// HookOnAfterResponse is called after the LLM generates a response.
 	HookOnAfterResponse
 	// HookOnBeforeWikiSection is called before a wiki section is generated.
@@ -107,8 +105,6 @@ func (h HookPhase) String() string {
 		return "OnBeforeToolCall"
 	case HookOnAfterToolResult:
 		return "OnAfterToolResult"
-	case HookOnAfterToolFailure:
-		return "OnAfterToolFailure"
 	case HookOnAfterResponse:
 		return "OnAfterResponse"
 	case HookOnBeforeWikiSection:

--- a/internal/skills/types.go
+++ b/internal/skills/types.go
@@ -72,6 +72,8 @@ const (
 	HookOnBeforeToolCall
 	// HookOnAfterToolResult is called after a tool execution returns a result.
 	HookOnAfterToolResult
+	// HookOnAfterToolFailure is called after a tool execution fails.
+	HookOnAfterToolFailure
 	// HookOnAfterResponse is called after the LLM generates a response.
 	HookOnAfterResponse
 	// HookOnBeforeWikiSection is called before a wiki section is generated.
@@ -105,6 +107,8 @@ func (h HookPhase) String() string {
 		return "OnBeforeToolCall"
 	case HookOnAfterToolResult:
 		return "OnAfterToolResult"
+	case HookOnAfterToolFailure:
+		return "OnAfterToolFailure"
 	case HookOnAfterResponse:
 		return "OnAfterResponse"
 	case HookOnBeforeWikiSection:


### PR DESCRIPTION
## Summary

This PR wires five critical lifecycle hooks into the skill system:

- **HookOnActivate**: Dispatched after a skill transitions to `SkillStateActive` in `Runtime.Activate()`. Fail-open — errors logged but don't fail activation.
- **HookOnDeactivate**: Dispatched before unregistering hooks in `Runtime.Deactivate()`. Fail-open.
- **HookOnBeforeToolCall**: Dispatched in `Agent.executeSingleTool()` before tool execution. Supports cancellation via `HookResult.Cancel`.
- **HookOnAfterToolResult**: Dispatched after tool execution. Supports result modification via `Modified["content"]`.
- **HookOnAfterToolFailure**: Dispatched when tool execution returns an error result.

Also adds `HookOnAfterToolFailure` as a new `HookPhase` constant.

## Test Plan

- [x] `go test ./internal/skills/...` — all pass
- [x] `go test ./internal/agent/...` — all pass
- [x] `gofmt -l .` — clean
- [x] New tests: `TestRuntimeActivateDispatchesHookOnActivate`, `TestRuntimeDeactivateDispatchesHookOnDeactivate`

## Files Changed

- `internal/skills/runtime.go` — HookOnActivate + HookOnDeactivate dispatch
- `internal/skills/types.go` — HookOnAfterToolFailure phase constant
- `internal/agent/agent.go` — HookOnBeforeToolCall, HookOnAfterToolResult, HookOnAfterToolFailure in executeSingleTool
- `internal/skills/runtime_test.go` — Tests for Activate/Deactivate hook dispatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Skills can now intercept tool execution with hooks to cancel runs or modify results before and after execution.
  * Skills receive lifecycle hooks for activation and deactivation events.

* **Tests**
  * Added comprehensive test coverage for skill hook dispatch during lifecycle and tool execution phases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/julianshen/rubichan/pull/292)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->