### PR TITLE
Phase 0: unify tool Registry between pkg/agentsdk and internal/tools

### DIFF
--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -2756,7 +2756,7 @@ func registerCoreTools(cwd string, registry *tools.Registry, cfg *config.Config,
 	}
 	// Register common aliases so models that hallucinate tool names like
 	// "run_command" or "write_file" still resolve to the correct tool.
-	registry.RegisterDefaultAliases()
+	tools.RegisterDefaultAliases(registry)
 
 	if err := wireExtendedTools(cwd, registry, cfg, toolsCfg); err != nil {
 		return nil, err

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1536,7 +1536,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		systemPrompt, cacheBreakpoints, skillPromptText := a.buildSystemPromptWithFragments(ctx, lastUserMessage)
 
 		// Select tools via DeferralManager to stay within budget.
-		allToolDefs := a.tools.SelectForContext(a.conversation.Messages())
+		allToolDefs := tools.SelectForContext(a.tools, a.conversation.Messages())
 		// Apply agent definition tool filter before deferral.
 		allToolDefs = FilterTools(allToolDefs, a.agentDef, nil)
 		budget := a.context.Budget()

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -1,175 +1,32 @@
 package tools
 
 import (
-	"fmt"
 	"log"
-	"sync"
 
 	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
-// Registry manages a collection of tools. All methods are safe for
-// concurrent use.
-type Registry struct {
-	mu      sync.RWMutex
-	tools   map[string]Tool
-	aliases map[string]string // alias name -> canonical tool name
-}
+// Registry is the canonical tool registry, defined in pkg/agentsdk so that
+// external embedders and the internal agent share one implementation
+// (Phase 0 of docs/MODULAR_CORE_REDESIGN.md). The alias keeps existing
+// code using tools.Registry compiling unchanged.
+type Registry = agentsdk.Registry
 
 // NewRegistry creates a new empty tool registry.
 func NewRegistry() *Registry {
-	return &Registry{
-		tools:   make(map[string]Tool),
-		aliases: make(map[string]string),
-	}
-}
-
-// Register adds a tool to the registry. Returns an error if a tool with the
-// same name is already registered.
-func (r *Registry) Register(t Tool) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if t == nil {
-		return fmt.Errorf("cannot register nil tool")
-	}
-	if _, exists := r.tools[t.Name()]; exists {
-		return fmt.Errorf("tool already registered: %s", t.Name())
-	}
-	r.tools[t.Name()] = t
-	return nil
-}
-
-// Unregister removes a tool from the registry by name. Returns an error
-// if the tool is not registered.
-func (r *Registry) Unregister(name string) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if _, exists := r.tools[name]; !exists {
-		return fmt.Errorf("tool not registered: %s", name)
-	}
-	delete(r.tools, name)
-	return nil
-}
-
-// Get retrieves a tool by name. If the name is not a registered tool,
-// it checks aliases and resolves to the canonical tool. Returns the tool
-// and true if found, or nil and false if not found.
-func (r *Registry) Get(name string) (Tool, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	if t, ok := r.tools[name]; ok {
-		return t, true
-	}
-	if canonical, ok := r.aliases[name]; ok {
-		t, ok := r.tools[canonical]
-		return t, ok
-	}
-	return nil, false
-}
-
-// RegisterAlias maps an alias name to a canonical tool name. When Get is
-// called with the alias, it resolves to the canonical tool. Aliases do not
-// appear in All() — they are transparent to the model.
-//
-// Returns an error if the alias shadows a registered canonical tool name
-// or if the alias is already registered with a different target.
-func (r *Registry) RegisterAlias(alias, canonicalName string) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if _, exists := r.tools[alias]; exists {
-		return fmt.Errorf("alias %q shadows canonical tool name", alias)
-	}
-	if existing, exists := r.aliases[alias]; exists && existing != canonicalName {
-		return fmt.Errorf("alias %q already registered for %q", alias, existing)
-	}
-	r.aliases[alias] = canonicalName
-	return nil
-}
-
-// Names returns the canonical names of all registered tools.
-func (r *Registry) Names() []string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	names := make([]string, 0, len(r.tools))
-	for name := range r.tools {
-		names = append(names, name)
-	}
-	return names
-}
-
-// All returns provider.ToolDef representations of all registered tools.
-func (r *Registry) All() []provider.ToolDef {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	var defs []provider.ToolDef
-	for _, t := range r.tools {
-		td := provider.ToolDef{
-			Name:        t.Name(),
-			Description: t.Description(),
-			InputSchema: t.InputSchema(),
-		}
-		if hinter, ok := t.(SearchHinter); ok {
-			td.SearchHint = hinter.SearchHint()
-		}
-		defs = append(defs, td)
-	}
-	return defs
-}
-
-// Filter creates a new Registry containing only the tools whose names appear
-// in the given slice. Unknown names are silently ignored. If names is nil,
-// all tools are copied into the new registry. The returned registry is
-// independent — registering or unregistering tools in it does not affect
-// the original.
-func (r *Registry) Filter(names []string) *Registry {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	filtered := NewRegistry()
-	if names == nil {
-		for _, tool := range r.tools {
-			_ = filtered.Register(tool)
-		}
-		r.copyAliasesTo(filtered, nil)
-		return filtered
-	}
-
-	nameSet := make(map[string]struct{}, len(names))
-	for _, n := range names {
-		nameSet[n] = struct{}{}
-	}
-	for name, tool := range r.tools {
-		if _, ok := nameSet[name]; ok {
-			_ = filtered.Register(tool)
-		}
-	}
-	r.copyAliasesTo(filtered, nameSet)
-	return filtered
-}
-
-// copyAliasesTo copies aliases whose canonical targets exist in the destination
-// registry. If allowedTargets is nil, all aliases are copied.
-func (r *Registry) copyAliasesTo(dst *Registry, allowedTargets map[string]struct{}) {
-	for alias, canonical := range r.aliases {
-		if allowedTargets != nil {
-			if _, ok := allowedTargets[canonical]; !ok {
-				continue
-			}
-		}
-		dst.aliases[alias] = canonical
-	}
+	return agentsdk.NewRegistry()
 }
 
 // SelectForContext returns tool definitions filtered for relevance to the
 // current conversation context. Uses keyword heuristics and recent tool
 // usage to select relevant tools, falling back to a safe baseline when no
 // heuristic matches.
-func (r *Registry) SelectForContext(messages []provider.Message) []provider.ToolDef {
+//
+// This is a package function rather than a Registry method because the
+// selection heuristic is rubichan product policy, while Registry itself
+// lives in the public SDK.
+func SelectForContext(r *Registry, messages []provider.Message) []provider.ToolDef {
 	all := r.All()
 	selector := NewToolSelector()
 	return selector.Select(messages, all)
@@ -178,7 +35,10 @@ func (r *Registry) SelectForContext(messages []provider.Message) []provider.Tool
 // RegisterDefaultAliases registers common aliases that open-source models
 // often hallucinate when attempting to call tools. These map commonly used
 // tool names from other frameworks to rubichan's canonical tool names.
-func (r *Registry) RegisterDefaultAliases() {
+//
+// Like SelectForContext, this alias table is rubichan product policy and
+// therefore stays out of the SDK Registry.
+func RegisterDefaultAliases(r *Registry) {
 	aliases := [][2]string{
 		// Shell tool aliases — models often guess these names.
 		{"shell_exec", "shell"},

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -281,7 +281,7 @@ func TestRegistryDefaultAliases(t *testing.T) {
 	require.NoError(t, reg.Register(newMockTool("search", "search")))
 	require.NoError(t, reg.Register(newMockTool("process", "process")))
 
-	reg.RegisterDefaultAliases()
+	RegisterDefaultAliases(reg)
 
 	// Shell aliases resolve.
 	for _, alias := range []string{"shell_exec", "run_command", "bash", "exec"} {
@@ -312,7 +312,7 @@ func TestRegistryHallucinationAliases(t *testing.T) {
 	require.NoError(t, reg.Register(newMockTool("file", "file")))
 	require.NoError(t, reg.Register(newMockTool("process", "process")))
 
-	reg.RegisterDefaultAliases()
+	RegisterDefaultAliases(reg)
 
 	// Shell hallucination aliases — Qwen 3.5 and similar models.
 	for _, alias := range []string{"tool_shell", "execute_command"} {
@@ -353,4 +353,19 @@ func TestRegistryNames(t *testing.T) {
 	assert.Len(t, names, 2)
 	assert.Contains(t, names, "shell")
 	assert.Contains(t, names, "file")
+}
+
+func TestSelectForContextWiresRegistryThroughSelector(t *testing.T) {
+	reg := NewRegistry()
+	require.NoError(t, reg.Register(newMockTool("shell", "run commands")))
+	require.NoError(t, reg.Register(newMockTool("db_query", "query databases")))
+
+	// Empty conversation → safe baseline: core tools only.
+	defs := SelectForContext(reg, nil)
+	names := make([]string, 0, len(defs))
+	for _, d := range defs {
+		names = append(names, d.Name)
+	}
+	assert.Contains(t, names, "shell")
+	assert.NotContains(t, names, "db_query")
 }

--- a/pkg/agentsdk/registry.go
+++ b/pkg/agentsdk/registry.go
@@ -10,13 +10,17 @@ import (
 // concurrent use. This is a standalone implementation with no internal
 // package dependencies.
 type Registry struct {
-	mu    sync.RWMutex
-	tools map[string]Tool
+	mu      sync.RWMutex
+	tools   map[string]Tool
+	aliases map[string]string // alias name -> canonical tool name
 }
 
 // NewRegistry creates a new empty tool registry.
 func NewRegistry() *Registry {
-	return &Registry{tools: make(map[string]Tool)}
+	return &Registry{
+		tools:   make(map[string]Tool),
+		aliases: make(map[string]string),
+	}
 }
 
 // Register adds a tool to the registry. Returns an error if a tool with the
@@ -49,34 +53,121 @@ func (r *Registry) Unregister(name string) error {
 	return nil
 }
 
-// Get retrieves a tool by name. Returns the tool and true if found,
-// or nil and false if not found.
+// Get retrieves a tool by name. If the name is not a registered tool,
+// it checks aliases and resolves to the canonical tool. Returns the tool
+// and true if found, or nil and false if not found.
 func (r *Registry) Get(name string) (Tool, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	t, ok := r.tools[name]
-	return t, ok
+	if t, ok := r.tools[name]; ok {
+		return t, true
+	}
+	if canonical, ok := r.aliases[name]; ok {
+		t, ok := r.tools[canonical]
+		return t, ok
+	}
+	return nil, false
+}
+
+// RegisterAlias maps an alias name to a canonical tool name. When Get is
+// called with the alias, it resolves to the canonical tool. Aliases do not
+// appear in All() — they are transparent to the model.
+//
+// Returns an error if the alias shadows a registered canonical tool name
+// or if the alias is already registered with a different target.
+func (r *Registry) RegisterAlias(alias, canonicalName string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.tools[alias]; exists {
+		return fmt.Errorf("alias %q shadows canonical tool name", alias)
+	}
+	if existing, exists := r.aliases[alias]; exists && existing != canonicalName {
+		return fmt.Errorf("alias %q already registered for %q", alias, existing)
+	}
+	r.aliases[alias] = canonicalName
+	return nil
+}
+
+// Names returns the canonical names of all registered tools.
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.tools))
+	for name := range r.tools {
+		names = append(names, name)
+	}
+	return names
 }
 
 // All returns ToolDef representations of all registered tools,
-// sorted alphabetically by name for deterministic ordering.
+// sorted alphabetically by name for deterministic ordering. Tools
+// implementing SearchHinter contribute their hint to the definition.
 func (r *Registry) All() []ToolDef {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	defs := make([]ToolDef, 0, len(r.tools))
 	for _, t := range r.tools {
-		defs = append(defs, ToolDef{
+		td := ToolDef{
 			Name:        t.Name(),
 			Description: t.Description(),
 			InputSchema: t.InputSchema(),
-		})
+		}
+		if hinter, ok := t.(SearchHinter); ok {
+			td.SearchHint = hinter.SearchHint()
+		}
+		defs = append(defs, td)
 	}
 	sort.Slice(defs, func(i, j int) bool {
 		return defs[i].Name < defs[j].Name
 	})
 	return defs
+}
+
+// Filter creates a new Registry containing only the tools whose names appear
+// in the given slice. Unknown names are silently ignored. If names is nil,
+// all tools are copied into the new registry. The returned registry is
+// independent — registering or unregistering tools in it does not affect
+// the original.
+func (r *Registry) Filter(names []string) *Registry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	filtered := NewRegistry()
+	if names == nil {
+		for _, tool := range r.tools {
+			_ = filtered.Register(tool)
+		}
+		r.copyAliasesTo(filtered, nil)
+		return filtered
+	}
+
+	nameSet := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		nameSet[n] = struct{}{}
+	}
+	for name, tool := range r.tools {
+		if _, ok := nameSet[name]; ok {
+			_ = filtered.Register(tool)
+		}
+	}
+	r.copyAliasesTo(filtered, nameSet)
+	return filtered
+}
+
+// copyAliasesTo copies aliases whose canonical targets exist in the destination
+// registry. If allowedTargets is nil, all aliases are copied.
+func (r *Registry) copyAliasesTo(dst *Registry, allowedTargets map[string]struct{}) {
+	for alias, canonical := range r.aliases {
+		if allowedTargets != nil {
+			if _, ok := allowedTargets[canonical]; !ok {
+				continue
+			}
+		}
+		dst.aliases[alias] = canonical
+	}
 }
 
 // Count returns the number of registered tools.

--- a/pkg/agentsdk/registry_test.go
+++ b/pkg/agentsdk/registry_test.go
@@ -80,3 +80,123 @@ func TestRegistryGetNotFound(t *testing.T) {
 	_, ok := r.Get("missing")
 	assert.False(t, ok)
 }
+
+type hintedTool struct {
+	dummyTool
+	hint string
+}
+
+func (h *hintedTool) SearchHint() string { return h.hint }
+
+func TestRegistryAliasResolution(t *testing.T) {
+	r := NewRegistry()
+	require.NoError(t, r.Register(&dummyTool{name: "shell"}))
+	require.NoError(t, r.RegisterAlias("bash", "shell"))
+
+	tool, ok := r.Get("bash")
+	require.True(t, ok)
+	assert.Equal(t, "shell", tool.Name())
+}
+
+func TestRegistryAliasShadowingCanonicalName(t *testing.T) {
+	r := NewRegistry()
+	require.NoError(t, r.Register(&dummyTool{name: "shell"}))
+	err := r.RegisterAlias("shell", "other")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "shadows")
+}
+
+func TestRegistryAliasConflict(t *testing.T) {
+	r := NewRegistry()
+	require.NoError(t, r.Register(&dummyTool{name: "shell"}))
+	require.NoError(t, r.RegisterAlias("bash", "shell"))
+	// Same target again is idempotent.
+	require.NoError(t, r.RegisterAlias("bash", "shell"))
+	// Different target is an error.
+	err := r.RegisterAlias("bash", "file")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "already registered")
+}
+
+func TestRegistryAllExcludesAliases(t *testing.T) {
+	r := NewRegistry()
+	require.NoError(t, r.Register(&dummyTool{name: "shell"}))
+	require.NoError(t, r.RegisterAlias("bash", "shell"))
+
+	defs := r.All()
+	require.Len(t, defs, 1)
+	assert.Equal(t, "shell", defs[0].Name)
+}
+
+func TestRegistryAllSortedByName(t *testing.T) {
+	r := NewRegistry()
+	require.NoError(t, r.Register(&dummyTool{name: "zeta"}))
+	require.NoError(t, r.Register(&dummyTool{name: "alpha"}))
+	require.NoError(t, r.Register(&dummyTool{name: "mid"}))
+
+	defs := r.All()
+	require.Len(t, defs, 3)
+	assert.Equal(t, []string{"alpha", "mid", "zeta"},
+		[]string{defs[0].Name, defs[1].Name, defs[2].Name})
+}
+
+func TestRegistryAllIncludesSearchHint(t *testing.T) {
+	r := NewRegistry()
+	require.NoError(t, r.Register(&hintedTool{dummyTool: dummyTool{name: "web"}, hint: "http fetch url"}))
+	require.NoError(t, r.Register(&dummyTool{name: "plain"}))
+
+	defs := r.All()
+	require.Len(t, defs, 2)
+	byName := map[string]ToolDef{}
+	for _, d := range defs {
+		byName[d.Name] = d
+	}
+	assert.Equal(t, "http fetch url", byName["web"].SearchHint)
+	assert.Empty(t, byName["plain"].SearchHint)
+}
+
+func TestRegistryNames(t *testing.T) {
+	r := NewRegistry()
+	require.NoError(t, r.Register(&dummyTool{name: "a"}))
+	require.NoError(t, r.Register(&dummyTool{name: "b"}))
+	require.NoError(t, r.RegisterAlias("alias-a", "a"))
+
+	names := r.Names()
+	assert.ElementsMatch(t, []string{"a", "b"}, names)
+}
+
+func TestRegistryFilter(t *testing.T) {
+	r := NewRegistry()
+	require.NoError(t, r.Register(&dummyTool{name: "a"}))
+	require.NoError(t, r.Register(&dummyTool{name: "b"}))
+	require.NoError(t, r.Register(&dummyTool{name: "c"}))
+	require.NoError(t, r.RegisterAlias("alias-a", "a"))
+	require.NoError(t, r.RegisterAlias("alias-c", "c"))
+
+	filtered := r.Filter([]string{"a", "b", "unknown"})
+	assert.Equal(t, 2, filtered.Count())
+
+	// Alias whose target survived is copied; alias to a dropped tool is not.
+	tool, ok := filtered.Get("alias-a")
+	require.True(t, ok)
+	assert.Equal(t, "a", tool.Name())
+	_, ok = filtered.Get("alias-c")
+	assert.False(t, ok)
+
+	// Filtered registry is independent of the original.
+	require.NoError(t, filtered.Unregister("a"))
+	_, ok = r.Get("a")
+	assert.True(t, ok)
+}
+
+func TestRegistryFilterNilCopiesAll(t *testing.T) {
+	r := NewRegistry()
+	require.NoError(t, r.Register(&dummyTool{name: "a"}))
+	require.NoError(t, r.Register(&dummyTool{name: "b"}))
+	require.NoError(t, r.RegisterAlias("alias-a", "a"))
+
+	filtered := r.Filter(nil)
+	assert.Equal(t, 2, filtered.Count())
+	_, ok := filtered.Get("alias-a")
+	assert.True(t, ok)
+}


### PR DESCRIPTION
## Summary

First implementation step of the modular core redesign (`docs/MODULAR_CORE_REDESIGN.md`, merged in #296): **delete the forked concrete `Registry`** so external embedders and the internal agent share one implementation.

Two commits, Tidy-First discipline:

**`[BEHAVIORAL]`** — extend `pkg/agentsdk.Registry` with the internal registry's capabilities (TDD, 10 new tests, red→green):
- `RegisterAlias` + alias resolution in `Get` (aliases transparent to `All()`)
- `Names()`, `Filter()` (independent sub-registry, copies aliases whose targets survive)
- `All()` populates `ToolDef.SearchHint` for tools implementing `SearchHinter`

**`[STRUCTURAL]`** — `internal/tools.Registry` becomes `= agentsdk.Registry` (the same alias pattern already used for `Tool`), deleting ~160 lines of duplicate implementation. Product policy stays internal as package functions (Go disallows methods on aliased external types):
- `tools.RegisterDefaultAliases(r)` — rubichan's hallucinated-tool-name alias table
- `tools.SelectForContext(r, msgs)` — keyword-heuristic tool selection (new wiring test)

Call sites updated: `internal/agent/agent.go`, `cmd/rubichan/main.go`, registry tests.

## Behavior notes

- Internal `Registry.All()` is now **sorted by name** (previously nondeterministic map order), matching the SDK's documented ordering — a strict improvement for prompt-cache stability.
- SDK `Registry.Get()` gains alias fallback; with no aliases registered (all existing SDK users) behavior is identical.

## Testing

- `pkg/agentsdk`: 92.6% coverage, all tests green
- Full `go test ./...`: green except pre-existing `TestLoadHooksTOMLReadError` in `internal/hooks`, which fails identically on untouched `main` (environmental: chmod-`0o000` files remain readable when tests run as root; the test then nil-derefs `err.Error()`). Unrelated to this change — verified via a clean `origin/main` worktree.
- `gofmt` clean; `go vet` clean on changed packages. (`golangci-lint` binary in this environment predates go 1.26 and cannot run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tool aliases, allowing tools to be accessed through alternative names.
  * Tool listings can now include helpful search hints.
  * Tool names and listings are presented consistently and in alphabetical order.

* **Bug Fixes**
  * Improved context-aware tool selection so only appropriate tools are made available.
  * Preserved valid aliases when tools are filtered or selected for a specific context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->