### PR TITLE
Phase 1 (step 1): shared StreamAccumulator for both agent loops

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1717,13 +1717,9 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		}
 
 	processStream:
-		// Accumulate assistant content blocks and track tool calls
-		var blocks []provider.ContentBlock
-		var pendingTools []provider.ToolUseBlock
-		var currentTextBuf string
+		// Accumulate assistant content blocks and track tool calls via the
+		// shared StreamAccumulator (pkg/agentsdk).
 		ls.resetPerTurn()
-		var currentTool *provider.ToolUseBlock
-		var toolInputBuf string
 		var thinkingBuf string
 		var stopReason string
 
@@ -1734,83 +1730,58 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			return a.executeSingleTool(sctx, ch, tc)
 		})
 
-		finalizeTool := func() {
-			if currentTool != nil {
-				if toolInputBuf != "" {
-					currentTool.Input = json.RawMessage(toolInputBuf)
-				}
-				pendingTools = append(pendingTools, *currentTool)
-				blocks = append(blocks, provider.ContentBlock{
-					Type:  "tool_use",
-					ID:    currentTool.ID,
-					Name:  currentTool.Name,
-					Input: currentTool.Input,
-				})
-
-				// Streaming dispatch: if the tool is concurrency-safe
-				// and auto-approved, start executing it now so it runs
-				// in parallel with the remaining model stream. The
-				// marker check comes first so non-eligible tools skip
-				// the approval scan entirely — approval can be expensive
-				// when a security scanner is wired in.
-				isUnsafe := true
-				isWrite := false
-				if tool, ok := a.tools.Get(currentTool.Name); ok {
-					dispatched := false
-					if ic, icok := tool.(agentsdk.InputConcurrencySafeTool); icok {
-						isWrite = isWriteOperationForInput(ic, currentTool.Input)
-						if ic.IsConcurrencySafeForInput(currentTool.Input) {
-							approval := a.approvalResultForTool(*currentTool)
-							if approval == AutoApproved || approval == TrustRuleApproved {
-								dispatched = execStream.Dispatch(ctx, *currentTool)
-							}
-							isUnsafe = false
-						}
-					} else if cs, csok := tool.(agentsdk.ConcurrencySafeTool); csok && cs.IsConcurrencySafe() {
-						isWrite = isWriteOperation(tool, currentTool.Input)
-						approval := a.approvalResultForTool(*currentTool)
-						if approval == AutoApproved || approval == TrustRuleApproved {
-							dispatched = execStream.Dispatch(ctx, *currentTool)
-						}
-						isUnsafe = false
-					} else {
-						// Not concurrency-safe — still check write status for barrier.
-						isWrite = isWriteOperation(tool, currentTool.Input)
-					}
-					if dispatched {
-						currentTool = nil
-					}
-					// A write tool acts as an ordering barrier even when dispatched:
-					// subsequent safe tools must wait for it to complete.
-					if isWrite {
-						execStream.SetBarrier()
-					}
-				}
-
-				if currentTool != nil && isUnsafe {
-					execStream.SetBarrier()
-				}
-
-				currentTool = nil
-				toolInputBuf = ""
+		acc := agentsdk.NewStreamAccumulator()
+		// Commit text only if it is not purely whitespace. This prevents
+		// whitespace-only responses from polluting the conversation. Note:
+		// LLMCompleter.Complete() also validates empty responses at its layer,
+		// failing fast with an error. The agent handles empty responses
+		// gracefully (adding a placeholder message below), allowing the turn
+		// to continue. This design enables callers of Complete() to fail fast
+		// (e.g., wiki diagram generation), while agent turns can recover with
+		// a placeholder message to keep conversation valid.
+		acc.KeepText = func(s string) bool { return !text.IsEmptyResponse(s) }
+		// Streaming dispatch: if the finalized tool is concurrency-safe
+		// and auto-approved, start executing it now so it runs in parallel
+		// with the remaining model stream. The marker check comes first so
+		// non-eligible tools skip the approval scan entirely — approval can
+		// be expensive when a security scanner is wired in.
+		acc.OnToolFinalized = func(tc provider.ToolUseBlock) {
+			tool, ok := a.tools.Get(tc.Name)
+			if !ok {
+				// Unknown tool — conservative ordering barrier.
+				execStream.SetBarrier()
+				return
 			}
-		}
-
-		// finalizeText commits accumulated text to the blocks list, but only if
-		// the text is not purely whitespace. This prevents whitespace-only responses
-		// from polluting the conversation. Note: LLMCompleter.Complete() also validates
-		// empty responses at its layer, failing fast with an error. The agent handles
-		// empty responses gracefully (falling through to line 1287 where a placeholder
-		// message is added), allowing the turn to continue. This design enables callers
-		// of Complete() to fail fast (e.g., wiki diagram generation), while agent turns
-		// can recover with a placeholder message to keep conversation valid.
-		finalizeText := func() {
-			if !text.IsEmptyResponse(currentTextBuf) {
-				blocks = append(blocks, provider.ContentBlock{
-					Type: "text",
-					Text: currentTextBuf,
-				})
-				currentTextBuf = ""
+			isUnsafe := true
+			isWrite := false
+			dispatched := false
+			if ic, icok := tool.(agentsdk.InputConcurrencySafeTool); icok {
+				isWrite = isWriteOperationForInput(ic, tc.Input)
+				if ic.IsConcurrencySafeForInput(tc.Input) {
+					approval := a.approvalResultForTool(tc)
+					if approval == AutoApproved || approval == TrustRuleApproved {
+						dispatched = execStream.Dispatch(ctx, tc)
+					}
+					isUnsafe = false
+				}
+			} else if cs, csok := tool.(agentsdk.ConcurrencySafeTool); csok && cs.IsConcurrencySafe() {
+				isWrite = isWriteOperation(tool, tc.Input)
+				approval := a.approvalResultForTool(tc)
+				if approval == AutoApproved || approval == TrustRuleApproved {
+					dispatched = execStream.Dispatch(ctx, tc)
+				}
+				isUnsafe = false
+			} else {
+				// Not concurrency-safe — still check write status for barrier.
+				isWrite = isWriteOperation(tool, tc.Input)
+			}
+			// A write tool acts as an ordering barrier even when dispatched:
+			// subsequent safe tools must wait for it to complete.
+			if isWrite {
+				execStream.SetBarrier()
+			}
+			if !dispatched && isUnsafe {
+				execStream.SetBarrier()
 			}
 		}
 
@@ -1832,43 +1803,32 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 				a.emit(ctx, ch, TurnEvent{Type: "thinking_delta", Text: event.Text})
 
 			case "text_delta":
-				if currentTool != nil {
-					// Accumulating tool input JSON fragments
-					toolInputBuf += event.Text
-				} else {
-					// Regular text content
-					currentTextBuf += event.Text
+				// During tool accumulation, text deltas carry input JSON
+				// fragments; only regular text is emitted to the consumer.
+				if !acc.AddText(event.Text) {
 					a.emit(ctx, ch, TurnEvent{Type: "text_delta", Text: event.Text})
 				}
 
 			case "tool_use":
 				if event.ToolUse == nil {
-					// Finalize any in-progress tool to prevent input corruption.
-					finalizeText()
-					finalizeTool()
+					// Finalize any in-progress text/tool to prevent input corruption.
+					acc.Finish()
 					a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider sent tool_use event with nil ToolUse")})
 					continue
 				}
-				// Finalize any pending text block
-				finalizeText()
-				// Finalize any previous tool
-				finalizeTool()
-				// Start new tool accumulation. Input may be empty here
-				// if the provider will deliver it as subsequent
-				// text_delta events (legacy path) — otherwise the next
-				// content_block_stop or tool_use event triggers finalize.
-				currentTool = &provider.ToolUseBlock{
-					ID:    event.ToolUse.ID,
-					Name:  event.ToolUse.Name,
-					Input: append(json.RawMessage(nil), event.ToolUse.Input...),
-				}
+				// Finalizes any pending text and previous tool, then starts
+				// new tool accumulation. Input may be empty here if the
+				// provider will deliver it as subsequent text_delta events
+				// (legacy path) — otherwise the next content_block_stop or
+				// tool_use event triggers finalize.
+				acc.StartTool(*event.ToolUse)
 
 			case agentsdk.EventContentBlockStop:
 				// Finalize on block-end so single-tool responses
 				// dispatch mid-stream. Providers that don't emit this
 				// fall back to the "finalize on next tool_use or stream
 				// end" timing, which is the legacy multi-tool path.
-				finalizeTool()
+				acc.FinalizeTool()
 
 			case "error":
 				ls.streamErr = true
@@ -1888,9 +1848,9 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// pending tool calls; otherwise the truncated-tool detection below
 		// handles it.
 		if stopReason == agentsdk.StopReasonMaxTokens {
-			hasPendingTools := len(pendingTools) > 0 || currentTool != nil
+			hasPendingTools := len(acc.PendingTools()) > 0 || acc.HasPartialTool()
 			if hasPendingTools {
-				a.logger.Warn("response hit output token limit with %d pending tool calls; tool arguments may be truncated", len(pendingTools))
+				a.logger.Warn("response hit output token limit with %d pending tool calls; tool arguments may be truncated", len(acc.PendingTools()))
 			} else if ls.maxOutputTokens < escalatedMaxOutputTokens {
 				a.logger.Warn("output token limit hit; escalating max_tokens from %d to %d", ls.maxOutputTokens, escalatedMaxOutputTokens)
 				a.escalateMaxTokens(ls)
@@ -1900,8 +1860,8 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 				continue
 			} else if ls.maxTokensRecoveryAttempts < maxOutputTokensRecoveryLimit {
 				ls.maxTokensRecoveryAttempts++
-				a.conversation.AddAssistant(blocks)
-				a.persistMessage("assistant", blocks)
+				a.conversation.AddAssistant(acc.Blocks())
+				a.persistMessage("assistant", acc.Blocks())
 				a.conversation.AddUser(fmt.Sprintf(
 					"[max_output_tokens recovery %d/%d] Continue your response from where you left off.",
 					ls.maxTokensRecoveryAttempts, maxOutputTokensRecoveryLimit))
@@ -1916,19 +1876,18 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		}
 
 		// Capture accumulated text before finalizing, for text-based tool extraction.
-		accumulatedText := currentTextBuf
+		accumulatedText := acc.CurrentText()
 
 		// Detect truncated tool calls: if the stream ended with a partially
 		// accumulated tool whose input JSON is invalid, discard it and warn.
-		if currentTool != nil && toolInputBuf != "" && !json.Valid([]byte(toolInputBuf)) {
+		if acc.DropInvalidPartialTool() {
 			a.emit(ctx, ch, TurnEvent{Type: "text_delta", Text: "\n⚠️ Tool call truncated by output limit.\n"})
-			currentTool = nil
-			toolInputBuf = ""
 		}
 
-		// Finalize any remaining text or tool
-		finalizeText()
-		finalizeTool()
+		// Finalize any remaining text or tool.
+		acc.Finish()
+		blocks := acc.Blocks()
+		pendingTools := acc.PendingTools()
 
 		// Prepend thinking block if the model produced extended thinking output.
 		if thinkingBuf != "" {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1860,8 +1860,14 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 				continue
 			} else if ls.maxTokensRecoveryAttempts < maxOutputTokensRecoveryLimit {
 				ls.maxTokensRecoveryAttempts++
-				a.conversation.AddAssistant(acc.Blocks())
-				a.persistMessage("assistant", acc.Blocks())
+				// Finalize buffered text so the truncated partial response is
+				// retained in history — the continuation prompt is meaningless
+				// if the model can't see what it already wrote. No partial tool
+				// can exist here: this branch requires hasPendingTools == false.
+				acc.Finish()
+				partialBlocks := acc.Blocks()
+				a.conversation.AddAssistant(partialBlocks)
+				a.persistMessage("assistant", partialBlocks)
 				a.conversation.AddUser(fmt.Sprintf(
 					"[max_output_tokens recovery %d/%d] Continue your response from where you left off.",
 					ls.maxTokensRecoveryAttempts, maxOutputTokensRecoveryLimit))

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -4077,3 +4077,38 @@ func TestTurnUnblocksWhenConsumerCancelsCtx(t *testing.T) {
 		t.Fatal("second Turn blocked on turnMu — first goroutine never released the lock (deadlock on blocked ch send)")
 	}
 }
+
+func TestRunLoop_MaxTokensRecovery_PersistsTruncatedText(t *testing.T) {
+	// Each recovery attempt must finalize and persist the truncated partial
+	// response before asking the model to continue — otherwise the model is
+	// told to "continue from where you left off" with no record of what it
+	// already wrote.
+	prov := &maxTokensProvider{maxCalls: 4}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	agent := New(prov, reg, autoApprove, cfg)
+
+	ch, err := agent.Turn(context.Background(), "hello")
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	var assistantTexts []string
+	for _, msg := range agent.conversation.Messages() {
+		if msg.Role != "assistant" {
+			continue
+		}
+		for _, b := range msg.Content {
+			if b.Type == "text" {
+				assistantTexts = append(assistantTexts, b.Text)
+			}
+		}
+	}
+	joined := strings.Join(assistantTexts, "\n")
+	// Calls 2 and 3 hit the recovery branch (call 1 hits escalation, which
+	// intentionally discards and regenerates); their partial text must be in
+	// conversation history for the continuation to make sense.
+	assert.Contains(t, joined, "response_2", "recovery attempt 1 must persist truncated text")
+	assert.Contains(t, joined, "response_3", "recovery attempt 2 must persist truncated text")
+	assert.Contains(t, joined, "response_4", "final completed response persisted")
+}

--- a/pkg/agentsdk/agent.go
+++ b/pkg/agentsdk/agent.go
@@ -235,7 +235,7 @@ func (a *Agent) consumeStream(
 			acc.StartTool(*event.ToolUse)
 		case EventError:
 			a.logger.Error("stream error: %v", event.Error)
-			ch <- TurnEvent{Type: "error", Error: event.Error}
+			ch <- TurnEvent{Type: "error", Error: fmt.Errorf("provider stream event: %w", event.Error)}
 			// Discard all accumulated state to avoid processing
 			// data from a corrupt/partial stream.
 			acc.Reset()

--- a/pkg/agentsdk/agent.go
+++ b/pkg/agentsdk/agent.go
@@ -198,45 +198,14 @@ type streamResult struct {
 }
 
 // consumeStream reads the provider stream, accumulating content blocks and
-// tool calls.
+// tool calls via StreamAccumulator.
 func (a *Agent) consumeStream(
 	ctx context.Context,
 	ch chan<- TurnEvent,
 	stream <-chan StreamEvent,
 	totalInput, totalOutput *int,
 ) streamResult {
-	var blocks []ContentBlock
-	var pendingTools []ToolUseBlock
-	var currentTextBuf string
-	var currentTool *ToolUseBlock
-	var toolInputBuf string
-
-	finalizeTool := func() {
-		if currentTool != nil {
-			if toolInputBuf != "" {
-				currentTool.Input = json.RawMessage(toolInputBuf)
-			}
-			pendingTools = append(pendingTools, *currentTool)
-			blocks = append(blocks, ContentBlock{
-				Type:  "tool_use",
-				ID:    currentTool.ID,
-				Name:  currentTool.Name,
-				Input: currentTool.Input,
-			})
-			currentTool = nil
-			toolInputBuf = ""
-		}
-	}
-
-	finalizeText := func() {
-		if currentTextBuf != "" {
-			blocks = append(blocks, ContentBlock{
-				Type: "text",
-				Text: currentTextBuf,
-			})
-			currentTextBuf = ""
-		}
-	}
+	acc := NewStreamAccumulator()
 
 	var hadError bool
 	for event := range stream {
@@ -249,42 +218,27 @@ func (a *Agent) consumeStream(
 		case EventTextDelta:
 			// During tool accumulation, text deltas carry JSON input
 			// for the tool call, not user-visible text.
-			if currentTool != nil {
-				toolInputBuf += event.Text
-			} else {
-				currentTextBuf += event.Text
+			if !acc.AddText(event.Text) {
 				ch <- TurnEvent{Type: EventTextDelta, Text: event.Text}
 			}
 		case EventInputJsonDelta:
-			if currentTool != nil {
-				toolInputBuf += event.Text
+			if acc.AddToolInput(event.Text) {
 				ch <- TurnEvent{Type: EventInputJsonDelta, Text: event.Text}
 			}
 		case EventToolUse:
 			if event.ToolUse == nil {
-				finalizeText()
-				finalizeTool()
+				acc.Finish()
 				ch <- TurnEvent{Type: "error", Error: fmt.Errorf("provider sent tool_use event with nil ToolUse")}
 				hadError = true
 				continue
 			}
-			finalizeText()
-			finalizeTool()
-			currentTool = &ToolUseBlock{
-				ID:    event.ToolUse.ID,
-				Name:  event.ToolUse.Name,
-				Input: append(json.RawMessage(nil), event.ToolUse.Input...),
-			}
+			acc.StartTool(*event.ToolUse)
 		case EventError:
 			a.logger.Error("stream error: %v", event.Error)
 			ch <- TurnEvent{Type: "error", Error: event.Error}
 			// Discard all accumulated state to avoid processing
 			// data from a corrupt/partial stream.
-			currentTool = nil
-			toolInputBuf = ""
-			currentTextBuf = ""
-			blocks = nil
-			pendingTools = nil
+			acc.Reset()
 			hadError = true
 		case EventStop:
 			// handled after loop
@@ -292,13 +246,12 @@ func (a *Agent) consumeStream(
 	}
 
 	if !hadError {
-		finalizeText()
-		finalizeTool()
+		acc.Finish()
 	}
 
 	return streamResult{
-		blocks:       blocks,
-		pendingTools: pendingTools,
+		blocks:       acc.Blocks(),
+		pendingTools: acc.PendingTools(),
 		cancelled:    ctx.Err() != nil,
 		hadError:     hadError,
 	}

--- a/pkg/agentsdk/stream_accumulator.go
+++ b/pkg/agentsdk/stream_accumulator.go
@@ -7,7 +7,7 @@ import "encoding/json"
 // loop and the internal agent loop share this accumulation logic; loop-
 // specific behavior plugs in via KeepText and OnToolFinalized.
 //
-// The zero value is not usable; construct with NewStreamAccumulator.
+// The zero value is ready to use.
 // It is not safe for concurrent use — a stream is consumed by one goroutine.
 type StreamAccumulator struct {
 	blocks       []ContentBlock
@@ -17,7 +17,7 @@ type StreamAccumulator struct {
 	toolInputBuf string
 
 	// KeepText decides whether accumulated text is committed as a content
-	// block when finalized. Defaults to keeping any non-empty string.
+	// block when finalized. Nil means keep any non-empty string.
 	KeepText func(string) bool
 
 	// OnToolFinalized fires after a tool_use block is committed to Blocks
@@ -27,9 +27,7 @@ type StreamAccumulator struct {
 
 // NewStreamAccumulator creates an empty accumulator.
 func NewStreamAccumulator() *StreamAccumulator {
-	return &StreamAccumulator{
-		KeepText: func(s string) bool { return s != "" },
-	}
+	return &StreamAccumulator{}
 }
 
 // AddText routes a text delta. During tool accumulation, text deltas carry
@@ -97,7 +95,11 @@ func (s *StreamAccumulator) FinalizeTool() {
 // streams after an intervening tool call, matching the loops' historical
 // behavior of clearing the buffer only on commit.
 func (s *StreamAccumulator) finalizeText() {
-	if s.KeepText(s.textBuf) {
+	keep := s.textBuf != ""
+	if s.KeepText != nil {
+		keep = s.KeepText(s.textBuf)
+	}
+	if keep {
 		s.blocks = append(s.blocks, ContentBlock{Type: "text", Text: s.textBuf})
 		s.textBuf = ""
 	}

--- a/pkg/agentsdk/stream_accumulator.go
+++ b/pkg/agentsdk/stream_accumulator.go
@@ -1,0 +1,157 @@
+package agentsdk
+
+import "encoding/json"
+
+// StreamAccumulator is the state machine that assembles a provider stream
+// into assistant content blocks and pending tool calls. Both the SDK agent
+// loop and the internal agent loop share this accumulation logic; loop-
+// specific behavior plugs in via KeepText and OnToolFinalized.
+//
+// The zero value is not usable; construct with NewStreamAccumulator.
+// It is not safe for concurrent use — a stream is consumed by one goroutine.
+type StreamAccumulator struct {
+	blocks       []ContentBlock
+	pendingTools []ToolUseBlock
+	textBuf      string
+	currentTool  *ToolUseBlock
+	toolInputBuf string
+
+	// KeepText decides whether accumulated text is committed as a content
+	// block when finalized. Defaults to keeping any non-empty string.
+	KeepText func(string) bool
+
+	// OnToolFinalized fires after a tool_use block is committed to Blocks
+	// and PendingTools — the seam for mid-stream tool dispatch. May be nil.
+	OnToolFinalized func(tc ToolUseBlock)
+}
+
+// NewStreamAccumulator creates an empty accumulator.
+func NewStreamAccumulator() *StreamAccumulator {
+	return &StreamAccumulator{
+		KeepText: func(s string) bool { return s != "" },
+	}
+}
+
+// AddText routes a text delta. During tool accumulation, text deltas carry
+// the tool's input JSON rather than user-visible text; the return value
+// reports which happened (true = consumed as tool input).
+func (s *StreamAccumulator) AddText(text string) bool {
+	if s.currentTool != nil {
+		s.toolInputBuf += text
+		return true
+	}
+	s.textBuf += text
+	return false
+}
+
+// AddToolInput appends an input_json_delta fragment to the in-progress
+// tool. Returns false (no-op) when no tool is being accumulated.
+func (s *StreamAccumulator) AddToolInput(text string) bool {
+	if s.currentTool == nil {
+		return false
+	}
+	s.toolInputBuf += text
+	return true
+}
+
+// StartTool finalizes any pending text and any in-progress tool, then
+// begins accumulating a new tool call. The input slice is copied.
+func (s *StreamAccumulator) StartTool(tu ToolUseBlock) {
+	s.finalizeText()
+	s.FinalizeTool()
+	s.currentTool = &ToolUseBlock{
+		ID:    tu.ID,
+		Name:  tu.Name,
+		Input: append(json.RawMessage(nil), tu.Input...),
+	}
+	s.toolInputBuf = ""
+}
+
+// FinalizeTool commits the in-progress tool call, if any, to Blocks and
+// PendingTools (content_block_stop timing). Buffered input JSON overrides
+// the tool's initial Input only when non-empty. Fires OnToolFinalized.
+func (s *StreamAccumulator) FinalizeTool() {
+	if s.currentTool == nil {
+		return
+	}
+	if s.toolInputBuf != "" {
+		s.currentTool.Input = json.RawMessage(s.toolInputBuf)
+	}
+	tc := *s.currentTool
+	s.pendingTools = append(s.pendingTools, tc)
+	s.blocks = append(s.blocks, ContentBlock{
+		Type:  "tool_use",
+		ID:    tc.ID,
+		Name:  tc.Name,
+		Input: tc.Input,
+	})
+	s.currentTool = nil
+	s.toolInputBuf = ""
+	if s.OnToolFinalized != nil {
+		s.OnToolFinalized(tc)
+	}
+}
+
+// finalizeText commits accumulated text as a content block when KeepText
+// accepts it. Rejected text stays buffered — it prefixes any text that
+// streams after an intervening tool call, matching the loops' historical
+// behavior of clearing the buffer only on commit.
+func (s *StreamAccumulator) finalizeText() {
+	if s.KeepText(s.textBuf) {
+		s.blocks = append(s.blocks, ContentBlock{Type: "text", Text: s.textBuf})
+		s.textBuf = ""
+	}
+}
+
+// Finish finalizes any remaining text and in-progress tool at stream end.
+func (s *StreamAccumulator) Finish() {
+	s.finalizeText()
+	s.FinalizeTool()
+}
+
+// HasPartialTool reports whether a tool call is still being accumulated.
+func (s *StreamAccumulator) HasPartialTool() bool {
+	return s.currentTool != nil
+}
+
+// DropInvalidPartialTool discards the in-progress tool call when its
+// buffered input is invalid JSON — the signature of a stream truncated
+// mid-tool-call. Returns true if a tool was discarded. Tools whose input
+// arrived whole (empty buffer) are never dropped.
+func (s *StreamAccumulator) DropInvalidPartialTool() bool {
+	if s.currentTool == nil || s.toolInputBuf == "" {
+		return false
+	}
+	if json.Valid([]byte(s.toolInputBuf)) {
+		return false
+	}
+	s.currentTool = nil
+	s.toolInputBuf = ""
+	return true
+}
+
+// CurrentText returns the uncommitted text buffer. Callers that extract
+// tool calls from text (non-native models) read this before Finish.
+func (s *StreamAccumulator) CurrentText() string {
+	return s.textBuf
+}
+
+// Reset discards all accumulated state, e.g. after a stream error, so a
+// corrupt partial stream cannot pollute the conversation.
+func (s *StreamAccumulator) Reset() {
+	s.blocks = nil
+	s.pendingTools = nil
+	s.textBuf = ""
+	s.currentTool = nil
+	s.toolInputBuf = ""
+}
+
+// Blocks returns the accumulated content blocks.
+func (s *StreamAccumulator) Blocks() []ContentBlock {
+	return s.blocks
+}
+
+// PendingTools returns the finalized tool calls in stream order.
+func (s *StreamAccumulator) PendingTools() []ToolUseBlock {
+	return s.pendingTools
+}

--- a/pkg/agentsdk/stream_accumulator_test.go
+++ b/pkg/agentsdk/stream_accumulator_test.go
@@ -1,0 +1,242 @@
+package agentsdk
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccumulatorTextCommitsOnFinish(t *testing.T) {
+	acc := NewStreamAccumulator()
+	isTool := acc.AddText("hello ")
+	assert.False(t, isTool)
+	acc.AddText("world")
+	acc.Finish()
+
+	blocks := acc.Blocks()
+	require.Len(t, blocks, 1)
+	assert.Equal(t, "text", blocks[0].Type)
+	assert.Equal(t, "hello world", blocks[0].Text)
+	assert.Empty(t, acc.PendingTools())
+}
+
+func TestAccumulatorToolInputViaTextDeltas(t *testing.T) {
+	acc := NewStreamAccumulator()
+	acc.AddText("thinking out loud... ")
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "shell"})
+
+	// Text deltas during tool accumulation carry input JSON.
+	isTool := acc.AddText(`{"command":`)
+	assert.True(t, isTool)
+	acc.AddText(`"ls"}`)
+	acc.Finish()
+
+	tools := acc.PendingTools()
+	require.Len(t, tools, 1)
+	assert.Equal(t, "t1", tools[0].ID)
+	assert.JSONEq(t, `{"command":"ls"}`, string(tools[0].Input))
+
+	// Blocks: text first, then tool_use.
+	blocks := acc.Blocks()
+	require.Len(t, blocks, 2)
+	assert.Equal(t, "text", blocks[0].Type)
+	assert.Equal(t, "tool_use", blocks[1].Type)
+	assert.Equal(t, "shell", blocks[1].Name)
+}
+
+func TestAccumulatorToolInputPrePopulated(t *testing.T) {
+	acc := NewStreamAccumulator()
+	input := json.RawMessage(`{"path":"main.go"}`)
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "file", Input: input})
+	acc.Finish()
+
+	tools := acc.PendingTools()
+	require.Len(t, tools, 1)
+	assert.JSONEq(t, `{"path":"main.go"}`, string(tools[0].Input))
+}
+
+func TestAccumulatorStartToolCopiesInput(t *testing.T) {
+	acc := NewStreamAccumulator()
+	input := json.RawMessage(`{"a":1}`)
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "x", Input: input})
+	input[1] = 'z' // mutate the caller's slice after StartTool
+	acc.Finish()
+
+	tools := acc.PendingTools()
+	require.Len(t, tools, 1)
+	assert.JSONEq(t, `{"a":1}`, string(tools[0].Input))
+}
+
+func TestAccumulatorMultipleToolsFinalizeOnNextStart(t *testing.T) {
+	acc := NewStreamAccumulator()
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "a", Input: json.RawMessage(`{}`)})
+	acc.StartTool(ToolUseBlock{ID: "t2", Name: "b", Input: json.RawMessage(`{}`)})
+	acc.Finish()
+
+	tools := acc.PendingTools()
+	require.Len(t, tools, 2)
+	assert.Equal(t, "t1", tools[0].ID)
+	assert.Equal(t, "t2", tools[1].ID)
+}
+
+func TestAccumulatorAddToolInput(t *testing.T) {
+	acc := NewStreamAccumulator()
+	// Outside a tool, AddToolInput is a no-op.
+	assert.False(t, acc.AddToolInput(`{"x":1}`))
+
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "a"})
+	assert.True(t, acc.AddToolInput(`{"x":`))
+	assert.True(t, acc.AddToolInput(`1}`))
+	acc.Finish()
+
+	tools := acc.PendingTools()
+	require.Len(t, tools, 1)
+	assert.JSONEq(t, `{"x":1}`, string(tools[0].Input))
+}
+
+func TestAccumulatorKeepTextPredicate(t *testing.T) {
+	acc := NewStreamAccumulator()
+	acc.KeepText = func(s string) bool { return strings.TrimSpace(s) != "" }
+	acc.AddText("   \n\t  ")
+	acc.Finish()
+	assert.Empty(t, acc.Blocks(), "whitespace-only text dropped by predicate")
+
+	acc2 := NewStreamAccumulator()
+	// Default: any non-empty string is kept, including whitespace.
+	acc2.AddText("   ")
+	acc2.Finish()
+	require.Len(t, acc2.Blocks(), 1)
+}
+
+func TestAccumulatorRejectedTextStaysBuffered(t *testing.T) {
+	// Historical loop behavior: text the predicate rejects is not cleared —
+	// it prefixes text that streams after an intervening tool call.
+	acc := NewStreamAccumulator()
+	acc.KeepText = func(s string) bool { return strings.TrimSpace(s) != "" }
+
+	acc.AddText("  \n")
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "a", Input: json.RawMessage(`{}`)})
+	acc.FinalizeTool()
+	acc.AddText("real text")
+	acc.Finish()
+
+	blocks := acc.Blocks()
+	require.Len(t, blocks, 2)
+	assert.Equal(t, "tool_use", blocks[0].Type)
+	assert.Equal(t, "text", blocks[1].Type)
+	assert.Equal(t, "  \nreal text", blocks[1].Text)
+}
+
+func TestAccumulatorFinalizeToolMidStream(t *testing.T) {
+	acc := NewStreamAccumulator()
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "a", Input: json.RawMessage(`{}`)})
+	acc.FinalizeTool() // content_block_stop
+
+	// Tool is committed before the stream ends.
+	require.Len(t, acc.PendingTools(), 1)
+	assert.False(t, acc.HasPartialTool())
+
+	// Subsequent text is normal text, not tool input.
+	isTool := acc.AddText("after")
+	assert.False(t, isTool)
+}
+
+func TestAccumulatorOnToolFinalizedHook(t *testing.T) {
+	acc := NewStreamAccumulator()
+	var hookTool ToolUseBlock
+	var pendingAtHook int
+	acc.OnToolFinalized = func(tc ToolUseBlock) {
+		hookTool = tc
+		// Invariant: the tool is already in PendingTools when the hook fires.
+		pendingAtHook = len(acc.PendingTools())
+	}
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "shell"})
+	acc.AddText(`{"command":"ls"}`)
+	acc.Finish()
+
+	assert.Equal(t, "t1", hookTool.ID)
+	assert.JSONEq(t, `{"command":"ls"}`, string(hookTool.Input))
+	assert.Equal(t, 1, pendingAtHook)
+}
+
+func TestAccumulatorDropInvalidPartialTool(t *testing.T) {
+	acc := NewStreamAccumulator()
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "shell"})
+	acc.AddText(`{"command": "truncat`) // stream cut mid-JSON
+
+	assert.True(t, acc.HasPartialTool())
+	dropped := acc.DropInvalidPartialTool()
+	assert.True(t, dropped)
+	acc.Finish()
+
+	assert.Empty(t, acc.PendingTools())
+	assert.Empty(t, acc.Blocks())
+}
+
+func TestAccumulatorDropInvalidPartialToolKeepsValid(t *testing.T) {
+	acc := NewStreamAccumulator()
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "shell"})
+	acc.AddText(`{"command":"ls"}`)
+
+	dropped := acc.DropInvalidPartialTool()
+	assert.False(t, dropped, "valid JSON input must not be dropped")
+	acc.Finish()
+	assert.Len(t, acc.PendingTools(), 1)
+}
+
+func TestAccumulatorDropInvalidPartialToolNoInput(t *testing.T) {
+	acc := NewStreamAccumulator()
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "shell", Input: json.RawMessage(`{}`)})
+
+	// No streamed input buffer — nothing to validate, tool kept.
+	dropped := acc.DropInvalidPartialTool()
+	assert.False(t, dropped)
+	acc.Finish()
+	assert.Len(t, acc.PendingTools(), 1)
+}
+
+func TestAccumulatorCurrentText(t *testing.T) {
+	acc := NewStreamAccumulator()
+	acc.AddText("partial answer")
+	assert.Equal(t, "partial answer", acc.CurrentText())
+	acc.Finish()
+	assert.Equal(t, "", acc.CurrentText(), "buffer cleared after finish")
+}
+
+func TestAccumulatorReset(t *testing.T) {
+	acc := NewStreamAccumulator()
+	acc.AddText("some text")
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "shell"})
+	acc.AddText(`{"comm`)
+	acc.Reset()
+
+	acc.Finish()
+	assert.Empty(t, acc.Blocks())
+	assert.Empty(t, acc.PendingTools())
+	assert.False(t, acc.HasPartialTool())
+	assert.Equal(t, "", acc.CurrentText())
+}
+
+func TestAccumulatorHasPartialTool(t *testing.T) {
+	acc := NewStreamAccumulator()
+	assert.False(t, acc.HasPartialTool())
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "shell"})
+	assert.True(t, acc.HasPartialTool())
+	acc.Finish()
+	assert.False(t, acc.HasPartialTool())
+}
+
+func TestAccumulatorEmptyToolInputBufLeavesInputUntouched(t *testing.T) {
+	// When no input deltas arrive, the Input provided at StartTool survives
+	// (matches both loops: toolInputBuf overrides only when non-empty).
+	acc := NewStreamAccumulator()
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "a", Input: json.RawMessage(`{"k":"v"}`)})
+	acc.Finish()
+
+	tools := acc.PendingTools()
+	require.Len(t, tools, 1)
+	assert.JSONEq(t, `{"k":"v"}`, string(tools[0].Input))
+}

--- a/pkg/agentsdk/stream_accumulator_test.go
+++ b/pkg/agentsdk/stream_accumulator_test.go
@@ -240,3 +240,18 @@ func TestAccumulatorEmptyToolInputBufLeavesInputUntouched(t *testing.T) {
 	require.Len(t, tools, 1)
 	assert.JSONEq(t, `{"k":"v"}`, string(tools[0].Input))
 }
+
+func TestAccumulatorZeroValueUsable(t *testing.T) {
+	// The zero value must not panic: nil KeepText falls back to the
+	// default keep-any-non-empty policy.
+	var acc StreamAccumulator
+	acc.AddText("hello")
+	acc.StartTool(ToolUseBlock{ID: "t1", Name: "a", Input: json.RawMessage(`{}`)})
+	acc.Finish()
+
+	blocks := acc.Blocks()
+	require.Len(t, blocks, 2)
+	assert.Equal(t, "text", blocks[0].Type)
+	assert.Equal(t, "hello", blocks[0].Text)
+	assert.Len(t, acc.PendingTools(), 1)
+}


### PR DESCRIPTION
## Summary

First step of Phase 1 of the modular core redesign (`docs/MODULAR_CORE_REDESIGN.md`; follows #297): begin unifying the two divergent agent loops by extracting their **stream-accumulation state machine** — the largest block of near-line-for-line duplication — into a shared `pkg/agentsdk.StreamAccumulator`, now used by both loops.

Three commits, Tidy-First discipline:

**`[BEHAVIORAL]`** — add `StreamAccumulator` to `pkg/agentsdk` (TDD, 16 tests): text/tool buffering, finalize-on-boundary (`StartTool` / `FinalizeTool` / `Finish`), truncated-tool detection (`DropInvalidPartialTool`), stream-error `Reset`. Loop-specific behavior enters via two seams:
- `KeepText` — text-commit policy (rejected text stays buffered, preserving the loops' historical clear-on-commit behavior)
- `OnToolFinalized` — mid-stream dispatch hook, fired **after** the tool is visible in `PendingTools` (the invariant `surfaceStreamedResults` depends on)

**`[STRUCTURAL]`** — SDK `consumeStream` delegates to the accumulator. SDK tests pass unmodified.

**`[STRUCTURAL]`** — internal `runLoop`'s stream section delegates to the accumulator (−41 lines). Preserved exactly:
- whitespace-only text policy via `KeepText` (`text.IsEmptyResponse`)
- concurrency-safe streaming dispatch + write/unsafe ordering barriers via `OnToolFinalized`
- thinking-block handling stays loop-local, so max_tokens recovery still persists blocks **without** a thinking prefix (subtle ordering the accumulator deliberately does not own)
- truncated-tool warning, `streamErr` discard semantics, stop-reason capture

## Why this step first

The two loops (`pkg/agentsdk/agent.go`, 506 lines vs `internal/agent/agent.go`, 2,910 lines) share this state machine verbatim; it's the highest-duplication, lowest-entanglement piece. Subsequent steps will converge approval flow and tool execution, shrinking the fork until one loop remains.

## Testing

- `pkg/agentsdk`: all tests green (16 new)
- `internal/agent`: full suite green **unmodified** — including the 1,426-line streaming-dispatch/barrier tests, the strongest behavior-preservation evidence
- Full `go test ./...`: green except two pre-existing environmental failures reproduced identically on untouched `main` (`TestLoadHooksTOMLReadError` — root can read chmod-000 files; `TestOpenSessionStore_Works` — sqlite store path in this container)
- `gofmt` clean, `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when processing streamed text and tool calls.
  - Preserved correct ordering for tool operations, including write actions.
  - Improved handling of incomplete or invalid tool calls when streams end unexpectedly.
  - Prevented whitespace-only streaming content from being surfaced unnecessarily.

- **Tests**
  - Added comprehensive coverage for streamed text, tool inputs, ordering, interruptions, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->