### PR TITLE
Phase 1 (step 2): shared ApprovalFlow for both agent loops

### DIFF
--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1892,7 +1892,7 @@ func runInteractive() error {
 		if plainHost != nil {
 			approvalFunc = plainHost.MakeApprovalFunc()
 		} else {
-			// UIRequestHandler takes priority in agent.requestToolApproval.
+			// UIRequestHandler takes priority in the shared agentsdk.ApprovalFlow.
 			// Keep approvalFunc wired as a fallback for non-UI handler paths.
 			approvalFunc = model.MakeApprovalFunc()
 			opts = append(opts, agent.WithUIRequestHandler(model.MakeUIRequestHandler()))

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -423,8 +423,6 @@ type Agent struct {
 	windowManager       *ContextWindowManager
 }
 
-const maxUIRequestInputBytes = 2048
-
 // New creates a new Agent with the given provider, tool registry, approval
 // function, and configuration. Optional AgentOption values can be provided
 // to attach a skill runtime.
@@ -2569,81 +2567,21 @@ func (a *Agent) executeSingleToolWithApproval(ctx context.Context, ch chan<- Tur
 	if approvalResult == AutoDenied {
 		return a.approvalToolErrorResult(tc, "Tool call denied by user (deny-always).", nil)
 	}
-	if a.uiRequestHandler == nil && a.approve == nil {
-		return a.approvalToolErrorResult(tc, "approval function not configured", nil)
-	}
 
-	approved, denyAlways, approvalErr := a.requestToolApproval(ctx, ch, tc)
-	if approvalErr != nil {
-		return a.approvalToolErrorResult(tc, "approval error", approvalErr)
+	// Ask the user via the shared approval flow. The checker is deliberately
+	// omitted: approvalResult was already computed by the caller (planToolCalls
+	// partitions on it), and re-consulting the checker here would double-run
+	// side-effecting checkers like SecurityAwareApprovalChecker's scan.
+	flow := &agentsdk.ApprovalFlow{
+		Approve:   a.approve,
+		UIHandler: a.uiRequestHandler,
+		Emit:      func(ev TurnEvent) { a.emit(ctx, ch, ev) },
 	}
-	if !approved {
-		if denyAlways {
-			return a.approvalToolErrorResult(tc, "Tool call denied by user (deny-always).", nil)
-		}
-		return a.approvalToolErrorResult(tc, "tool call denied by user", nil)
+	out := flow.Decide(ctx, tc)
+	if !out.Approved {
+		return a.approvalToolErrorResult(tc, out.Message, out.Err)
 	}
-
 	return a.executeSingleTool(ctx, ch, tc)
-}
-
-func (a *Agent) requestToolApproval(ctx context.Context, ch chan<- TurnEvent, tc provider.ToolUseBlock) (approved bool, denyAlways bool, err error) {
-	if a.uiRequestHandler != nil {
-		req := UIRequest{
-			ID:      tc.ID,
-			Kind:    UIKindApproval,
-			Title:   fmt.Sprintf("Approve %s tool call", tc.Name),
-			Message: "Review and choose how to proceed.",
-			Actions: []UIAction{
-				{ID: "allow", Label: "Allow", Default: true},
-				{ID: "deny", Label: "Deny", Style: "danger"},
-				{ID: "allow_always", Label: "Always Allow"},
-				{ID: "deny_always", Label: "Always Deny", Style: "danger"},
-			},
-			Metadata: map[string]string{
-				"tool":  tc.Name,
-				"input": truncateUIInput(tc.Input),
-			},
-		}
-		a.emit(ctx, ch, TurnEvent{Type: "ui_request", UIRequest: &req})
-		resp, reqErr := a.uiRequestHandler.Request(ctx, req)
-		if reqErr != nil {
-			return false, false, reqErr
-		}
-		if resp.RequestID != req.ID {
-			return false, false, fmt.Errorf("unexpected UI response id %q for request %q", resp.RequestID, req.ID)
-		}
-		a.emit(ctx, ch, TurnEvent{Type: "ui_response", UIResponse: &resp})
-		switch strings.ToLower(resp.ActionID) {
-		case "allow", "allow_always", "yes":
-			// "allow_always" cache persistence is handled by the UI adapter.
-			return true, false, nil
-		case "deny_always":
-			return false, true, nil
-		case "deny", "no":
-			return false, false, nil
-		default:
-			return false, false, fmt.Errorf("unsupported UI approval action %q", resp.ActionID)
-		}
-	}
-
-	if a.approve == nil {
-		return false, false, fmt.Errorf("approval function not configured")
-	}
-
-	approved, approvalErr := a.approve(ctx, tc.Name, tc.Input)
-	if approvalErr != nil {
-		return false, false, approvalErr
-	}
-	return approved, false, nil
-}
-
-func truncateUIInput(input json.RawMessage) string {
-	s := string(input)
-	if len(s) <= maxUIRequestInputBytes {
-		return s
-	}
-	return s[:maxUIRequestInputBytes] + "...(truncated)"
 }
 
 // executeSingleTool delegates tool execution to the pipeline.

--- a/internal/agent/coverage_test.go
+++ b/internal/agent/coverage_test.go
@@ -153,24 +153,8 @@ func TestAgentCompactorForceCompact(t *testing.T) {
 	assert.Greater(t, result.BeforeMsgCount, 0)
 }
 
-// --- truncateUIInput ---
-
-func TestTruncateUIInputShort(t *testing.T) {
-	input := json.RawMessage(`{"path": "hello.go"}`)
-	result := truncateUIInput(input)
-	assert.Equal(t, string(input), result)
-}
-
-func TestTruncateUIInputLong(t *testing.T) {
-	// Create input longer than maxUIRequestInputBytes (2048)
-	longContent := strings.Repeat("x", 3000)
-	input := json.RawMessage(`{"data": "` + longContent + `"}`)
-	result := truncateUIInput(input)
-
-	assert.True(t, len(result) < len(string(input)), "result should be truncated")
-	assert.True(t, strings.HasSuffix(result, "...(truncated)"))
-	assert.Equal(t, maxUIRequestInputBytes+len("...(truncated)"), len(result))
-}
+// truncateUIInput coverage moved to pkg/agentsdk/approval_flow_test.go
+// alongside the shared ApprovalFlow.
 
 // --- hasTextContent ---
 
@@ -929,19 +913,19 @@ func TestResultStoreRetrieveEmptyBlob(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
-// --- requestToolApproval: no approval function configured ---
+// --- executeSingleToolWithApproval: no approval function configured ---
 
-func TestRequestToolApprovalNilApprovalFunc(t *testing.T) {
+func TestExecuteSingleToolWithApprovalNilApprovalFunc(t *testing.T) {
 	a := &Agent{logger: agentsdk.DefaultLogger()}
 	// Both uiRequestHandler and approve are nil
 	ch := make(chan TurnEvent, 100)
 
-	_, _, err := a.requestToolApproval(context.Background(), ch, provider.ToolUseBlock{
+	res := a.executeSingleToolWithApproval(context.Background(), ch, provider.ToolUseBlock{
 		ID:   "tool-1",
 		Name: "file",
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "approval function not configured")
+	}, ApprovalRequired)
+	assert.True(t, res.isError)
+	assert.Contains(t, res.content, "approval function not configured")
 }
 
 // --- ForkSession no store ---

--- a/pkg/agentsdk/agent.go
+++ b/pkg/agentsdk/agent.go
@@ -2,7 +2,6 @@ package agentsdk
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -66,8 +65,6 @@ type Agent struct {
 	logger           Logger
 	turnMu           sync.Mutex
 }
-
-const maxUIRequestInputBytes = 2048
 
 // NewAgent creates a new Agent with the given LLM provider and options.
 // Panics if provider is nil.
@@ -411,14 +408,6 @@ func (a *Agent) requestToolApproval(ctx context.Context, ch chan<- TurnEvent, tc
 		return false, fmt.Errorf("approval function not configured")
 	}
 	return a.approve(ctx, tc.Name, tc.Input)
-}
-
-func truncateUIInput(input json.RawMessage) string {
-	s := string(input)
-	if len(s) <= maxUIRequestInputBytes {
-		return s
-	}
-	return s[:maxUIRequestInputBytes] + "...(truncated)"
 }
 
 func (a *Agent) toolError(tc ToolUseBlock, msg string) toolResult {

--- a/pkg/agentsdk/agent.go
+++ b/pkg/agentsdk/agent.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 )
 
@@ -89,7 +88,6 @@ func NewAgent(provider LLMProvider, opts ...Option) *Agent {
 
 // ErrEmptyMessage is returned by Turn when the user message is empty.
 var ErrEmptyMessage = errors.New("agentsdk: empty user message")
-var errUIDenyAlways = errors.New("agentsdk: ui deny-always")
 
 // Turn initiates a new agent turn with the given user message. It returns a
 // channel of TurnEvent that streams events as the agent processes the turn.
@@ -285,40 +283,21 @@ type toolResult struct {
 }
 
 func (a *Agent) executeSingleTool(ctx context.Context, ch chan<- TurnEvent, tc ToolUseBlock) toolResult {
-	// Check approval if checker is configured.
-	if a.approvalChecker != nil {
-		result := a.approvalChecker.CheckApproval(tc.Name, tc.Input)
-		if result == AutoDenied {
-			return a.toolError(tc, "Tool call denied by user (deny-always).")
+	// Run the shared approval flow when any approval mechanism is
+	// configured. With nothing configured the SDK executes directly —
+	// approval is opt-in for embedders.
+	if a.approvalChecker != nil || a.approve != nil || a.uiRequestHandler != nil {
+		flow := &ApprovalFlow{
+			Checker:   a.approvalChecker,
+			Approve:   a.approve,
+			UIHandler: a.uiRequestHandler,
+			Emit:      func(ev TurnEvent) { ch <- ev },
 		}
-		if result == ApprovalRequired {
-			if a.uiRequestHandler == nil && a.approve == nil {
-				return a.toolError(tc, "approval function not configured")
+		if out := flow.Decide(ctx, tc); !out.Approved {
+			if out.Err != nil {
+				a.logger.Error("approval failure for tool %s: %v", tc.Name, out.Err)
 			}
-			approved, err := a.requestToolApproval(ctx, ch, tc)
-			if err != nil {
-				if errors.Is(err, errUIDenyAlways) {
-					return a.toolError(tc, "Tool call denied by user (deny-always).")
-				}
-				a.logger.Error("approval failure for tool %s: %v", tc.Name, err)
-				return a.toolError(tc, "approval error")
-			}
-			if !approved {
-				return a.toolError(tc, "tool call denied by user")
-			}
-		}
-	} else if a.approve != nil || a.uiRequestHandler != nil {
-		// No checker — always ask for approval.
-		approved, err := a.requestToolApproval(ctx, ch, tc)
-		if err != nil {
-			if errors.Is(err, errUIDenyAlways) {
-				return a.toolError(tc, "Tool call denied by user (deny-always).")
-			}
-			a.logger.Error("approval failure for tool %s: %v", tc.Name, err)
-			return a.toolError(tc, "approval error")
-		}
-		if !approved {
-			return a.toolError(tc, "tool call denied by user")
+			return a.toolError(tc, out.Message)
 		}
 	}
 
@@ -362,52 +341,6 @@ func (a *Agent) executeSingleTool(ctx context.Context, ch chan<- TurnEvent, tc T
 		isError: res.IsError,
 		event:   makeResultEvent(tc.ID, tc.Name, res),
 	}
-}
-
-func (a *Agent) requestToolApproval(ctx context.Context, ch chan<- TurnEvent, tc ToolUseBlock) (bool, error) {
-	if a.uiRequestHandler != nil {
-		req := UIRequest{
-			ID:      tc.ID,
-			Kind:    UIKindApproval,
-			Title:   fmt.Sprintf("Approve %s tool call", tc.Name),
-			Message: "Review and choose how to proceed.",
-			Actions: []UIAction{
-				{ID: "allow", Label: "Allow", Default: true},
-				{ID: "deny", Label: "Deny", Style: "danger"},
-				{ID: "allow_always", Label: "Always Allow"},
-				{ID: "deny_always", Label: "Always Deny", Style: "danger"},
-			},
-			Metadata: map[string]string{
-				"tool":  tc.Name,
-				"input": truncateUIInput(tc.Input),
-			},
-		}
-		ch <- TurnEvent{Type: "ui_request", UIRequest: &req}
-		resp, err := a.uiRequestHandler.Request(ctx, req)
-		if err != nil {
-			return false, err
-		}
-		if resp.RequestID != req.ID {
-			return false, fmt.Errorf("unexpected UI response id %q for request %q", resp.RequestID, req.ID)
-		}
-		ch <- TurnEvent{Type: "ui_response", UIResponse: &resp}
-
-		switch strings.ToLower(resp.ActionID) {
-		case "allow", "allow_always", "yes":
-			return true, nil
-		case "deny_always":
-			return false, errUIDenyAlways
-		case "deny", "no":
-			return false, nil
-		default:
-			return false, fmt.Errorf("unsupported UI approval action %q", resp.ActionID)
-		}
-	}
-
-	if a.approve == nil {
-		return false, fmt.Errorf("approval function not configured")
-	}
-	return a.approve(ctx, tc.Name, tc.Input)
 }
 
 func (a *Agent) toolError(tc ToolUseBlock, msg string) toolResult {

--- a/pkg/agentsdk/approval_flow.go
+++ b/pkg/agentsdk/approval_flow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 // Shared user-facing messages for approval outcomes. Both agent loops embed
@@ -126,11 +127,17 @@ func (f *ApprovalFlow) emit(ev TurnEvent) {
 
 const maxUIRequestInputBytes = 2048
 
-// truncateUIInput bounds tool input shown in approval UI metadata.
+// truncateUIInput bounds tool input shown in approval UI metadata. The
+// length check happens on the raw bytes so oversize inputs are sliced
+// before the string conversion, and the cut backs up to a rune boundary
+// so truncation never produces invalid UTF-8 in the preview.
 func truncateUIInput(input json.RawMessage) string {
-	s := string(input)
-	if len(s) <= maxUIRequestInputBytes {
-		return s
+	if len(input) <= maxUIRequestInputBytes {
+		return string(input)
 	}
-	return s[:maxUIRequestInputBytes] + "...(truncated)"
+	cut := maxUIRequestInputBytes
+	for cut > 0 && !utf8.RuneStart(input[cut]) {
+		cut--
+	}
+	return string(input[:cut]) + "...(truncated)"
 }

--- a/pkg/agentsdk/approval_flow.go
+++ b/pkg/agentsdk/approval_flow.go
@@ -1,0 +1,136 @@
+package agentsdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Shared user-facing messages for approval outcomes. Both agent loops embed
+// these verbatim in tool results, so they live in one place.
+const (
+	approvalMsgDenyAlways   = "Tool call denied by user (deny-always)."
+	approvalMsgDenied       = "tool call denied by user"
+	approvalMsgError        = "approval error"
+	approvalMsgUnconfigured = "approval function not configured"
+)
+
+// ApprovalOutcome is the result of running the approval flow for one tool
+// call. When Approved is false, Message carries the user-facing tool-result
+// text and Err (if non-nil) carries the underlying failure for logging.
+type ApprovalOutcome struct {
+	Approved   bool
+	DenyAlways bool
+	Message    string
+	Err        error
+}
+
+// ApprovalFlow is the tool-approval decision engine shared by the SDK and
+// internal agent loops. It consults the Checker first (nil is treated as
+// approval-required), then interacts with the user through UIHandler or
+// Approve — UIHandler takes precedence when both are set.
+//
+// Emit, when non-nil, receives the ui_request / ui_response TurnEvents
+// produced during a UI interaction; each loop wires its own emission.
+type ApprovalFlow struct {
+	Checker   ApprovalChecker
+	Approve   ApprovalFunc
+	UIHandler UIRequestHandler
+	Emit      func(TurnEvent)
+}
+
+// Decide runs the approval flow for the given tool call.
+func (f *ApprovalFlow) Decide(ctx context.Context, tc ToolUseBlock) ApprovalOutcome {
+	result := ApprovalRequired
+	if f.Checker != nil {
+		result = f.Checker.CheckApproval(tc.Name, tc.Input)
+	}
+
+	switch result {
+	case AutoApproved, TrustRuleApproved:
+		return ApprovalOutcome{Approved: true}
+	case AutoDenied:
+		return ApprovalOutcome{DenyAlways: true, Message: approvalMsgDenyAlways}
+	}
+
+	if f.UIHandler == nil && f.Approve == nil {
+		return ApprovalOutcome{Message: approvalMsgUnconfigured}
+	}
+
+	approved, denyAlways, err := f.requestApproval(ctx, tc)
+	switch {
+	case err != nil:
+		return ApprovalOutcome{Message: approvalMsgError, Err: err}
+	case approved:
+		return ApprovalOutcome{Approved: true}
+	case denyAlways:
+		return ApprovalOutcome{DenyAlways: true, Message: approvalMsgDenyAlways}
+	default:
+		return ApprovalOutcome{Message: approvalMsgDenied}
+	}
+}
+
+// requestApproval asks the user through the UI handler when available,
+// otherwise through the plain approval function.
+func (f *ApprovalFlow) requestApproval(ctx context.Context, tc ToolUseBlock) (approved, denyAlways bool, err error) {
+	if f.UIHandler == nil {
+		approved, err = f.Approve(ctx, tc.Name, tc.Input)
+		return approved, false, err
+	}
+
+	req := UIRequest{
+		ID:      tc.ID,
+		Kind:    UIKindApproval,
+		Title:   fmt.Sprintf("Approve %s tool call", tc.Name),
+		Message: "Review and choose how to proceed.",
+		Actions: []UIAction{
+			{ID: "allow", Label: "Allow", Default: true},
+			{ID: "deny", Label: "Deny", Style: "danger"},
+			{ID: "allow_always", Label: "Always Allow"},
+			{ID: "deny_always", Label: "Always Deny", Style: "danger"},
+		},
+		Metadata: map[string]string{
+			"tool":  tc.Name,
+			"input": truncateUIInput(tc.Input),
+		},
+	}
+	f.emit(TurnEvent{Type: "ui_request", UIRequest: &req})
+	resp, err := f.UIHandler.Request(ctx, req)
+	if err != nil {
+		return false, false, err
+	}
+	if resp.RequestID != req.ID {
+		return false, false, fmt.Errorf("unexpected UI response id %q for request %q", resp.RequestID, req.ID)
+	}
+	f.emit(TurnEvent{Type: "ui_response", UIResponse: &resp})
+
+	switch strings.ToLower(resp.ActionID) {
+	case "allow", "allow_always", "yes":
+		// "allow_always" cache persistence is handled by the UI adapter.
+		return true, false, nil
+	case "deny_always":
+		return false, true, nil
+	case "deny", "no":
+		return false, false, nil
+	default:
+		return false, false, fmt.Errorf("unsupported UI approval action %q", resp.ActionID)
+	}
+}
+
+func (f *ApprovalFlow) emit(ev TurnEvent) {
+	if f.Emit != nil {
+		f.Emit(ev)
+	}
+}
+
+const maxUIRequestInputBytes = 2048
+
+// truncateUIInput bounds tool input shown in approval UI metadata.
+func truncateUIInput(input json.RawMessage) string {
+	s := string(input)
+	if len(s) <= maxUIRequestInputBytes {
+		return s
+	}
+	return s[:maxUIRequestInputBytes] + "...(truncated)"
+}

--- a/pkg/agentsdk/approval_flow_test.go
+++ b/pkg/agentsdk/approval_flow_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -223,4 +224,17 @@ func TestApprovalFlowTruncatesLargeUIInput(t *testing.T) {
 	input := captured.Metadata["input"]
 	assert.True(t, strings.HasSuffix(input, "...(truncated)"))
 	assert.Len(t, input, maxUIRequestInputBytes+len("...(truncated)"))
+}
+
+func TestTruncateUIInputNeverSplitsRunes(t *testing.T) {
+	// Place a 3-byte rune ("€") straddling the truncation boundary: naive
+	// byte slicing at maxUIRequestInputBytes would cut it mid-sequence and
+	// produce invalid UTF-8 in the preview.
+	prefix := strings.Repeat("a", maxUIRequestInputBytes-1)
+	input := json.RawMessage(prefix + "€xxxxx")
+
+	result := truncateUIInput(input)
+	assert.True(t, utf8.ValidString(result), "truncated preview must be valid UTF-8")
+	assert.True(t, strings.HasSuffix(result, "...(truncated)"))
+	assert.Equal(t, prefix+"...(truncated)", result, "partial rune must be dropped entirely")
 }

--- a/pkg/agentsdk/approval_flow_test.go
+++ b/pkg/agentsdk/approval_flow_test.go
@@ -1,0 +1,226 @@
+package agentsdk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type checkerFunc func(tool string, input json.RawMessage) ApprovalResult
+
+func (f checkerFunc) CheckApproval(tool string, input json.RawMessage) ApprovalResult {
+	return f(tool, input)
+}
+
+func approvalTC() ToolUseBlock {
+	return ToolUseBlock{ID: "tu_1", Name: "shell", Input: json.RawMessage(`{"command":"ls"}`)}
+}
+
+func TestApprovalFlowAutoApproved(t *testing.T) {
+	for _, result := range []ApprovalResult{AutoApproved, TrustRuleApproved} {
+		flow := &ApprovalFlow{
+			Checker: checkerFunc(func(string, json.RawMessage) ApprovalResult { return result }),
+			Approve: func(context.Context, string, json.RawMessage) (bool, error) {
+				t.Fatal("approver must not be consulted for auto-approved tools")
+				return false, nil
+			},
+		}
+		out := flow.Decide(context.Background(), approvalTC())
+		assert.True(t, out.Approved)
+		assert.Empty(t, out.Message)
+		assert.NoError(t, out.Err)
+	}
+}
+
+func TestApprovalFlowAutoDenied(t *testing.T) {
+	flow := &ApprovalFlow{
+		Checker: checkerFunc(func(string, json.RawMessage) ApprovalResult { return AutoDenied }),
+		Approve: func(context.Context, string, json.RawMessage) (bool, error) {
+			t.Fatal("approver must not be consulted for auto-denied tools")
+			return false, nil
+		},
+	}
+	out := flow.Decide(context.Background(), approvalTC())
+	assert.False(t, out.Approved)
+	assert.True(t, out.DenyAlways)
+	assert.Equal(t, "Tool call denied by user (deny-always).", out.Message)
+	assert.NoError(t, out.Err)
+}
+
+func TestApprovalFlowRequiredNoApproverConfigured(t *testing.T) {
+	flow := &ApprovalFlow{
+		Checker: checkerFunc(func(string, json.RawMessage) ApprovalResult { return ApprovalRequired }),
+	}
+	out := flow.Decide(context.Background(), approvalTC())
+	assert.False(t, out.Approved)
+	assert.Equal(t, "approval function not configured", out.Message)
+	assert.NoError(t, out.Err)
+}
+
+func TestApprovalFlowNilCheckerAsksApprover(t *testing.T) {
+	asked := false
+	flow := &ApprovalFlow{
+		Approve: func(_ context.Context, tool string, _ json.RawMessage) (bool, error) {
+			asked = true
+			assert.Equal(t, "shell", tool)
+			return true, nil
+		},
+	}
+	out := flow.Decide(context.Background(), approvalTC())
+	assert.True(t, asked, "nil checker must be treated as approval-required")
+	assert.True(t, out.Approved)
+}
+
+func TestApprovalFlowApproveFuncDenies(t *testing.T) {
+	flow := &ApprovalFlow{
+		Approve: func(context.Context, string, json.RawMessage) (bool, error) { return false, nil },
+	}
+	out := flow.Decide(context.Background(), approvalTC())
+	assert.False(t, out.Approved)
+	assert.False(t, out.DenyAlways)
+	assert.Equal(t, "tool call denied by user", out.Message)
+	assert.NoError(t, out.Err)
+}
+
+func TestApprovalFlowApproveFuncError(t *testing.T) {
+	boom := errors.New("boom")
+	flow := &ApprovalFlow{
+		Approve: func(context.Context, string, json.RawMessage) (bool, error) { return false, boom },
+	}
+	out := flow.Decide(context.Background(), approvalTC())
+	assert.False(t, out.Approved)
+	assert.Equal(t, "approval error", out.Message)
+	assert.ErrorIs(t, out.Err, boom)
+}
+
+func uiHandlerReturning(action string) UIRequestHandler {
+	return UIRequestFunc(func(_ context.Context, req UIRequest) (UIResponse, error) {
+		return UIResponse{RequestID: req.ID, ActionID: action}, nil
+	})
+}
+
+func TestApprovalFlowUIActions(t *testing.T) {
+	cases := []struct {
+		action     string
+		approved   bool
+		denyAlways bool
+		message    string
+		wantErr    bool
+	}{
+		{"allow", true, false, "", false},
+		{"allow_always", true, false, "", false},
+		{"yes", true, false, "", false},
+		{"ALLOW", true, false, "", false}, // case-insensitive
+		{"deny", false, false, "tool call denied by user", false},
+		{"no", false, false, "tool call denied by user", false},
+		{"deny_always", false, true, "Tool call denied by user (deny-always).", false},
+		{"bogus", false, false, "approval error", true},
+	}
+	for _, c := range cases {
+		t.Run(c.action, func(t *testing.T) {
+			flow := &ApprovalFlow{UIHandler: uiHandlerReturning(c.action)}
+			out := flow.Decide(context.Background(), approvalTC())
+			assert.Equal(t, c.approved, out.Approved)
+			assert.Equal(t, c.denyAlways, out.DenyAlways)
+			assert.Equal(t, c.message, out.Message)
+			if c.wantErr {
+				assert.Error(t, out.Err)
+			} else {
+				assert.NoError(t, out.Err)
+			}
+		})
+	}
+}
+
+func TestApprovalFlowUIRequestShapeAndEvents(t *testing.T) {
+	var captured UIRequest
+	handler := UIRequestFunc(func(_ context.Context, req UIRequest) (UIResponse, error) {
+		captured = req
+		return UIResponse{RequestID: req.ID, ActionID: "allow"}, nil
+	})
+	var events []TurnEvent
+	flow := &ApprovalFlow{
+		UIHandler: handler,
+		Emit:      func(ev TurnEvent) { events = append(events, ev) },
+	}
+	out := flow.Decide(context.Background(), approvalTC())
+	require.True(t, out.Approved)
+
+	// Canonical request shape shared by both loops.
+	assert.Equal(t, "tu_1", captured.ID)
+	assert.Equal(t, UIKindApproval, captured.Kind)
+	assert.Equal(t, "Approve shell tool call", captured.Title)
+	require.Len(t, captured.Actions, 4)
+	assert.Equal(t, "allow", captured.Actions[0].ID)
+	assert.True(t, captured.Actions[0].Default)
+	assert.Equal(t, "shell", captured.Metadata["tool"])
+	assert.Equal(t, `{"command":"ls"}`, captured.Metadata["input"])
+
+	// ui_request then ui_response events.
+	require.Len(t, events, 2)
+	assert.Equal(t, "ui_request", events[0].Type)
+	assert.Equal(t, "ui_response", events[1].Type)
+}
+
+func TestApprovalFlowUIResponseIDMismatch(t *testing.T) {
+	handler := UIRequestFunc(func(_ context.Context, _ UIRequest) (UIResponse, error) {
+		return UIResponse{RequestID: "wrong", ActionID: "allow"}, nil
+	})
+	flow := &ApprovalFlow{UIHandler: handler}
+	out := flow.Decide(context.Background(), approvalTC())
+	assert.False(t, out.Approved)
+	assert.Equal(t, "approval error", out.Message)
+	assert.Error(t, out.Err)
+}
+
+func TestApprovalFlowUIHandlerError(t *testing.T) {
+	boom := errors.New("ui down")
+	handler := UIRequestFunc(func(_ context.Context, _ UIRequest) (UIResponse, error) {
+		return UIResponse{}, boom
+	})
+	flow := &ApprovalFlow{UIHandler: handler}
+	out := flow.Decide(context.Background(), approvalTC())
+	assert.False(t, out.Approved)
+	assert.Equal(t, "approval error", out.Message)
+	assert.ErrorIs(t, out.Err, boom)
+}
+
+func TestApprovalFlowUIHandlerPrecedesApproveFunc(t *testing.T) {
+	flow := &ApprovalFlow{
+		UIHandler: uiHandlerReturning("deny"),
+		Approve: func(context.Context, string, json.RawMessage) (bool, error) {
+			t.Fatal("approve func must not be called when a UI handler is set")
+			return true, nil
+		},
+	}
+	out := flow.Decide(context.Background(), approvalTC())
+	assert.False(t, out.Approved)
+}
+
+func TestApprovalFlowNilEmitSafe(t *testing.T) {
+	flow := &ApprovalFlow{UIHandler: uiHandlerReturning("allow")}
+	out := flow.Decide(context.Background(), approvalTC()) // Emit is nil
+	assert.True(t, out.Approved)
+}
+
+func TestApprovalFlowTruncatesLargeUIInput(t *testing.T) {
+	big := fmt.Sprintf(`{"data":%q}`, strings.Repeat("x", 5000))
+	tc := ToolUseBlock{ID: "tu_big", Name: "shell", Input: json.RawMessage(big)}
+	var captured UIRequest
+	handler := UIRequestFunc(func(_ context.Context, req UIRequest) (UIResponse, error) {
+		captured = req
+		return UIResponse{RequestID: req.ID, ActionID: "allow"}, nil
+	})
+	flow := &ApprovalFlow{UIHandler: handler}
+	flow.Decide(context.Background(), tc)
+
+	input := captured.Metadata["input"]
+	assert.True(t, strings.HasSuffix(input, "...(truncated)"))
+	assert.Len(t, input, maxUIRequestInputBytes+len("...(truncated)"))
+}


### PR DESCRIPTION
## Summary

Second step of Phase 1 of the modular core redesign (`docs/MODULAR_CORE_REDESIGN.md`; follows #298): converge the **tool-approval flow** — the second-largest block of duplication between the two agent loops — into a shared `agentsdk.ApprovalFlow`.

Both loops previously carried near-identical private code for: checker consultation, canonical approval `UIRequest` construction (title/actions/metadata), UI action-ID parsing, deny-always signaling, and input truncation (`truncateUIInput` + `maxUIRequestInputBytes` were duplicated verbatim).

Three commits, Tidy-First discipline:

**`[BEHAVIORAL]`** — add `agentsdk.ApprovalFlow` (TDD, 13 tests) returning a structured `ApprovalOutcome{Approved, DenyAlways, Message, Err}`. Nil checker ⇒ approval-required; `UIHandler` takes precedence over `Approve`; `ui_request`/`ui_response` events surface via an `Emit` callback so each loop wires its own emission style.

**`[STRUCTURAL]`** — SDK `executeSingleTool` delegates to the flow; the private `requestToolApproval` and the `errUIDenyAlways` sentinel are deleted. The SDK's permissive default (execute directly when *no* approval mechanism is configured) stays as an explicit one-line caller check — the single intentional behavioral divergence between the loops, now visible instead of buried.

**`[STRUCTURAL]`** — internal `executeSingleToolWithApproval` keeps its `AutoApproved`/`TrustRuleApproved`/`AutoDenied` fast paths (the result is **pre-computed** by `planToolCalls`, and re-consulting the checker would double-run side-effecting checkers like `SecurityAwareApprovalChecker`'s security scan) and delegates the ask stage to a checker-less flow. Internal `requestToolApproval`/`truncateUIInput` duplicates deleted; their coverage moved to the SDK flow tests.

Net: −189 duplicated lines across the two loops; one shared decision engine with identical user-facing messages.

## Testing

- `pkg/agentsdk`: 13 new `ApprovalFlow` tests (decision table, UI action parsing incl. case-insensitivity, request shape, ID-mismatch/handler-error paths, truncation); full package green
- `internal/agent`: full suite green **unmodified** (one coverage test re-targeted from the deleted private helper to `executeSingleToolWithApproval`)
- Full `go test ./...`: green except pre-existing environmental failures (`TestOpenSessionStore_Works`, `TestSessionListCmd_Execute` — sqlite session-store path in this container; both reproduce identically on untouched `main`)
- `gofmt` clean, `go vet` clean

## Remaining Phase 1 steps

Tool execution convergence (streaming-tool progress, result shaping), then the outer loop skeleton — after which the SDK's parallel loop is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified tool-approval flow supporting automatic decisions, approval callbacks, and interactive UI approval.
  * Added clearer approval outcomes for approved, denied, and permanently denied tool requests.
  * Interactive approval now emits request and response events and validates response matching.

* **Bug Fixes**
  * Improved handling of approval errors, unsupported actions, missing configuration, and invalid responses.
  * Large tool inputs shown during approval are safely truncated without breaking characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->