### PR TITLE
Phase 2 (step 1): shared tool-execution Middleware/Pipeline seam

### DIFF
--- a/internal/toolexec/pipeline.go
+++ b/internal/toolexec/pipeline.go
@@ -1,89 +1,44 @@
 package toolexec
 
 import (
-	"context"
-	"encoding/json"
-
-	"github.com/julianshen/rubichan/internal/tools"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
+// The tool-execution pipeline types are defined in pkg/agentsdk so external
+// embedders and the internal agent share one Middleware seam
+// (docs/MODULAR_CORE_REDESIGN.md §4.1, Phase 2 step 1). Aliased here so
+// existing code using toolexec.ToolCall etc. compiles unchanged.
+
 // ToolCall is the input to the pipeline.
-type ToolCall struct {
-	ID    string
-	Name  string
-	Input json.RawMessage
-}
+type ToolCall = agentsdk.ToolCall
 
 // Result is the output of the pipeline.
-type Result struct {
-	Content        string
-	DisplayContent string
-	IsError        bool
-}
+type Result = agentsdk.Result
 
 // HandlerFunc executes a tool call and returns a result.
-type HandlerFunc func(ctx context.Context, tc ToolCall) Result
+type HandlerFunc = agentsdk.HandlerFunc
 
 // Middleware wraps a HandlerFunc, adding behavior before/after.
-type Middleware func(next HandlerFunc) HandlerFunc
+type Middleware = agentsdk.Middleware
 
 // Pipeline composes middlewares around a base executor.
-type Pipeline struct {
-	middlewares []Middleware
-	base        HandlerFunc
-}
+type Pipeline = agentsdk.Pipeline
 
 // NewPipeline creates a Pipeline that composes the given middlewares around
 // the base handler. The first middleware in the list is the outermost wrapper.
 func NewPipeline(base HandlerFunc, middlewares ...Middleware) *Pipeline {
-	return &Pipeline{
-		base:        base,
-		middlewares: middlewares,
-	}
-}
-
-// Execute runs the pipeline: middlewares wrap the base handler in order
-// (first middleware is outermost), then the composed handler is called
-// with the given context and tool call.
-func (p *Pipeline) Execute(ctx context.Context, tc ToolCall) Result {
-	handler := p.base
-	// Apply in reverse so that the first middleware is outermost.
-	for i := len(p.middlewares) - 1; i >= 0; i-- {
-		handler = p.middlewares[i](handler)
-	}
-	return handler(ctx, tc)
+	return agentsdk.NewPipeline(base, middlewares...)
 }
 
 // StreamEventType distinguishes progress events from the final result.
-type StreamEventType int
+type StreamEventType = agentsdk.PipelineEventType
 
 const (
 	// StreamProgress carries a ToolEvent during execution.
-	StreamProgress StreamEventType = iota
+	StreamProgress = agentsdk.PipelineProgress
 	// StreamFinal carries the completed Result.
-	StreamFinal
+	StreamFinal = agentsdk.PipelineFinal
 )
 
 // StreamEvent is either a progress event or a final result from the pipeline.
-type StreamEvent struct {
-	Type   StreamEventType
-	Event  *tools.ToolEvent // set when Type == StreamProgress
-	Result *Result          // set when Type == StreamFinal
-}
-
-// ExecuteStream runs the pipeline in a goroutine and returns a channel
-// of StreamEvents. Progress events arrive first, followed by a single
-// StreamFinal event. The channel is closed after the final event.
-func (p *Pipeline) ExecuteStream(ctx context.Context, tc ToolCall) <-chan StreamEvent {
-	ch := make(chan StreamEvent, 32)
-	go func() {
-		defer close(ch)
-		emit := func(ev tools.ToolEvent) {
-			ch <- StreamEvent{Type: StreamProgress, Event: &ev}
-		}
-		emitCtx := WithToolEventEmitter(ctx, emit)
-		result := p.Execute(emitCtx, tc)
-		ch <- StreamEvent{Type: StreamFinal, Result: &result}
-	}()
-	return ch
-}
+type StreamEvent = agentsdk.PipelineEvent

--- a/internal/toolexec/stream.go
+++ b/internal/toolexec/stream.go
@@ -4,21 +4,22 @@ import (
 	"context"
 
 	"github.com/julianshen/rubichan/internal/tools"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
-type toolEventEmitterKey struct{}
+// WithToolEventEmitter and ToolEventEmitterFromContext are defined in
+// pkg/agentsdk (docs/MODULAR_CORE_REDESIGN.md §4.1, Phase 2 step 1) so the
+// context-carried emitter is the same mechanism used by
+// agentsdk.Pipeline.ExecuteStream. Thin wrappers here so existing code
+// using toolexec.WithToolEventEmitter etc. compiles unchanged.
 
 // WithToolEventEmitter returns a context that carries a tool event emitter.
 func WithToolEventEmitter(ctx context.Context, emit tools.ToolEventEmitter) context.Context {
-	if emit == nil {
-		return ctx
-	}
-	return context.WithValue(ctx, toolEventEmitterKey{}, emit)
+	return agentsdk.WithToolEventEmitter(ctx, emit)
 }
 
 // ToolEventEmitterFromContext extracts the tool event emitter from the context.
 // Returns nil if no emitter was set.
 func ToolEventEmitterFromContext(ctx context.Context) tools.ToolEventEmitter {
-	emit, _ := ctx.Value(toolEventEmitterKey{}).(tools.ToolEventEmitter)
-	return emit
+	return agentsdk.ToolEventEmitterFromContext(ctx)
 }

--- a/pkg/agentsdk/pipeline.go
+++ b/pkg/agentsdk/pipeline.go
@@ -81,12 +81,22 @@ func (p *Pipeline) ExecuteStream(ctx context.Context, tc ToolCall) <-chan Pipeli
 	ch := make(chan PipelineEvent, 32)
 	go func() {
 		defer close(ch)
+		// Sends select on ctx.Done() so a cancelled turn whose consumer has
+		// stopped reading cannot wedge this goroutine on a full buffer. The
+		// tool itself still runs to completion (Execute is synchronous); only
+		// the delivery of its progress/final events is abandoned on cancel.
 		emit := func(ev ToolEvent) {
-			ch <- PipelineEvent{Type: PipelineProgress, Event: &ev}
+			select {
+			case ch <- PipelineEvent{Type: PipelineProgress, Event: &ev}:
+			case <-ctx.Done():
+			}
 		}
 		emitCtx := WithToolEventEmitter(ctx, emit)
 		result := p.Execute(emitCtx, tc)
-		ch <- PipelineEvent{Type: PipelineFinal, Result: &result}
+		select {
+		case ch <- PipelineEvent{Type: PipelineFinal, Result: &result}:
+		case <-ctx.Done():
+		}
 	}()
 	return ch
 }

--- a/pkg/agentsdk/pipeline.go
+++ b/pkg/agentsdk/pipeline.go
@@ -1,0 +1,111 @@
+package agentsdk
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// ToolCall is the input to the tool-execution pipeline.
+type ToolCall struct {
+	ID    string
+	Name  string
+	Input json.RawMessage
+}
+
+// Result is the output of the tool-execution pipeline.
+type Result struct {
+	Content        string
+	DisplayContent string
+	IsError        bool
+}
+
+// HandlerFunc executes a tool call and returns a result.
+type HandlerFunc func(ctx context.Context, tc ToolCall) Result
+
+// Middleware wraps a HandlerFunc, adding behavior before/after. This is the
+// shared tool-execution middleware seam (docs/MODULAR_CORE_REDESIGN.md §4.1):
+// checkpointing, security gating, output offloading, and similar concerns
+// compose around a base executor without the core knowing they exist.
+type Middleware func(next HandlerFunc) HandlerFunc
+
+// Pipeline composes middlewares around a base executor.
+type Pipeline struct {
+	middlewares []Middleware
+	base        HandlerFunc
+}
+
+// NewPipeline creates a Pipeline that composes the given middlewares around
+// the base handler. The first middleware in the list is the outermost wrapper.
+func NewPipeline(base HandlerFunc, middlewares ...Middleware) *Pipeline {
+	return &Pipeline{
+		base:        base,
+		middlewares: middlewares,
+	}
+}
+
+// Execute runs the pipeline: middlewares wrap the base handler in order
+// (first middleware is outermost), then the composed handler is called
+// with the given context and tool call.
+func (p *Pipeline) Execute(ctx context.Context, tc ToolCall) Result {
+	handler := p.base
+	// Apply in reverse so that the first middleware is outermost.
+	for i := len(p.middlewares) - 1; i >= 0; i-- {
+		handler = p.middlewares[i](handler)
+	}
+	return handler(ctx, tc)
+}
+
+// PipelineEventType distinguishes tool progress events from the final
+// result on a Pipeline's streaming channel. Named to avoid colliding with
+// the unrelated provider-level StreamEvent (types.go).
+type PipelineEventType int
+
+const (
+	// PipelineProgress carries a ToolEvent during execution.
+	PipelineProgress PipelineEventType = iota
+	// PipelineFinal carries the completed Result.
+	PipelineFinal
+)
+
+// PipelineEvent is either a progress event or a final result from the pipeline.
+type PipelineEvent struct {
+	Type   PipelineEventType
+	Event  *ToolEvent // set when Type == PipelineProgress
+	Result *Result    // set when Type == PipelineFinal
+}
+
+// ExecuteStream runs the pipeline in a goroutine and returns a channel of
+// PipelineEvents. Progress events arrive first, followed by a single
+// PipelineFinal event. The channel is closed after the final event.
+func (p *Pipeline) ExecuteStream(ctx context.Context, tc ToolCall) <-chan PipelineEvent {
+	ch := make(chan PipelineEvent, 32)
+	go func() {
+		defer close(ch)
+		emit := func(ev ToolEvent) {
+			ch <- PipelineEvent{Type: PipelineProgress, Event: &ev}
+		}
+		emitCtx := WithToolEventEmitter(ctx, emit)
+		result := p.Execute(emitCtx, tc)
+		ch <- PipelineEvent{Type: PipelineFinal, Result: &result}
+	}()
+	return ch
+}
+
+type toolEventEmitterKey struct{}
+
+// WithToolEventEmitter returns a context that carries a tool event emitter.
+// This is how a Middleware or the base HandlerFunc reaches the emitter that
+// ExecuteStream wired up — HandlerFunc has no other channel for it.
+func WithToolEventEmitter(ctx context.Context, emit ToolEventEmitter) context.Context {
+	if emit == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, toolEventEmitterKey{}, emit)
+}
+
+// ToolEventEmitterFromContext extracts the tool event emitter from the
+// context. Returns nil if no emitter was set.
+func ToolEventEmitterFromContext(ctx context.Context) ToolEventEmitter {
+	emit, _ := ctx.Value(toolEventEmitterKey{}).(ToolEventEmitter)
+	return emit
+}

--- a/pkg/agentsdk/pipeline.go
+++ b/pkg/agentsdk/pipeline.go
@@ -81,22 +81,32 @@ func (p *Pipeline) ExecuteStream(ctx context.Context, tc ToolCall) <-chan Pipeli
 	ch := make(chan PipelineEvent, 32)
 	go func() {
 		defer close(ch)
-		// Sends select on ctx.Done() so a cancelled turn whose consumer has
-		// stopped reading cannot wedge this goroutine on a full buffer. The
-		// tool itself still runs to completion (Execute is synchronous); only
-		// the delivery of its progress/final events is abandoned on cancel.
-		emit := func(ev ToolEvent) {
+		// send tries a non-blocking send first so an event is always
+		// delivered whenever the buffer has room — even under a cancelled
+		// context, where a bare select{ch<-; ctx.Done()} would drop it at
+		// random (Go picks a ready arm nondeterministically). Only when the
+		// send would actually block do we fall back to the cancellation arm,
+		// which keeps a cancelled turn whose consumer stopped reading from
+		// wedging this goroutine on a full buffer. The tool itself still runs
+		// to completion (Execute is synchronous); only event delivery past a
+		// full buffer is abandoned on cancel. Mirrors sendEvent.
+		send := func(ev PipelineEvent) {
 			select {
-			case ch <- PipelineEvent{Type: PipelineProgress, Event: &ev}:
+			case ch <- ev:
+				return
+			default:
+			}
+			select {
+			case ch <- ev:
 			case <-ctx.Done():
 			}
 		}
+		emit := func(ev ToolEvent) {
+			send(PipelineEvent{Type: PipelineProgress, Event: &ev})
+		}
 		emitCtx := WithToolEventEmitter(ctx, emit)
 		result := p.Execute(emitCtx, tc)
-		select {
-		case ch <- PipelineEvent{Type: PipelineFinal, Result: &result}:
-		case <-ctx.Done():
-		}
+		send(PipelineEvent{Type: PipelineFinal, Result: &result})
 	}()
 	return ch
 }

--- a/pkg/agentsdk/pipeline_test.go
+++ b/pkg/agentsdk/pipeline_test.go
@@ -1,0 +1,203 @@
+package agentsdk
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipelineExecutesBaseHandler(t *testing.T) {
+	base := func(ctx context.Context, tc ToolCall) Result {
+		assert.Equal(t, "call-1", tc.ID)
+		assert.Equal(t, "read_file", tc.Name)
+		assert.JSONEq(t, `{"path":"/tmp/test.go"}`, string(tc.Input))
+
+		return Result{
+			Content:        "file contents here",
+			DisplayContent: "Read /tmp/test.go",
+			IsError:        false,
+		}
+	}
+
+	p := NewPipeline(base)
+	result := p.Execute(context.Background(), ToolCall{
+		ID:    "call-1",
+		Name:  "read_file",
+		Input: json.RawMessage(`{"path":"/tmp/test.go"}`),
+	})
+
+	assert.Equal(t, "file contents here", result.Content)
+	assert.Equal(t, "Read /tmp/test.go", result.DisplayContent)
+	assert.False(t, result.IsError)
+}
+
+func TestPipelineMiddlewareOrder(t *testing.T) {
+	var order []string
+
+	base := func(ctx context.Context, tc ToolCall) Result {
+		order = append(order, "base")
+		return Result{Content: "base-result"}
+	}
+
+	first := func(next HandlerFunc) HandlerFunc {
+		return func(ctx context.Context, tc ToolCall) Result {
+			order = append(order, "first:before")
+			result := next(ctx, tc)
+			order = append(order, "first:after")
+			return result
+		}
+	}
+
+	second := func(next HandlerFunc) HandlerFunc {
+		return func(ctx context.Context, tc ToolCall) Result {
+			order = append(order, "second:before")
+			result := next(ctx, tc)
+			order = append(order, "second:after")
+			return result
+		}
+	}
+
+	p := NewPipeline(base, first, second)
+	result := p.Execute(context.Background(), ToolCall{
+		ID:   "call-2",
+		Name: "test_tool",
+	})
+
+	assert.Equal(t, "base-result", result.Content)
+	assert.Equal(t, []string{
+		"first:before",
+		"second:before",
+		"base",
+		"second:after",
+		"first:after",
+	}, order)
+}
+
+func TestPipelineMiddlewareShortCircuit(t *testing.T) {
+	baseCalled := false
+
+	base := func(ctx context.Context, tc ToolCall) Result {
+		baseCalled = true
+		return Result{Content: "should not reach"}
+	}
+
+	blocker := func(next HandlerFunc) HandlerFunc {
+		return func(ctx context.Context, tc ToolCall) Result {
+			// Short-circuit: do not call next
+			return Result{
+				Content: "blocked",
+				IsError: true,
+			}
+		}
+	}
+
+	p := NewPipeline(base, blocker)
+	result := p.Execute(context.Background(), ToolCall{
+		ID:   "call-3",
+		Name: "dangerous_tool",
+	})
+
+	assert.False(t, baseCalled, "base handler should not be called when middleware short-circuits")
+	assert.Equal(t, "blocked", result.Content)
+	assert.True(t, result.IsError)
+}
+
+func TestPipelineExecuteStreamFinalResult(t *testing.T) {
+	base := func(ctx context.Context, tc ToolCall) Result {
+		return Result{Content: "sync result", DisplayContent: "display"}
+	}
+
+	p := NewPipeline(base)
+	ch := p.ExecuteStream(context.Background(), ToolCall{
+		ID: "call-1", Name: "test",
+	})
+
+	var events []PipelineEvent
+	for ev := range ch {
+		events = append(events, ev)
+	}
+
+	require.Len(t, events, 1)
+	assert.Equal(t, PipelineFinal, events[0].Type)
+	require.NotNil(t, events[0].Result)
+	assert.Equal(t, "sync result", events[0].Result.Content)
+	assert.Equal(t, "display", events[0].Result.DisplayContent)
+}
+
+func TestPipelineExecuteStreamWithProgressEvents(t *testing.T) {
+	base := func(ctx context.Context, tc ToolCall) Result {
+		emit := ToolEventEmitterFromContext(ctx)
+		if emit != nil {
+			emit(ToolEvent{Stage: EventBegin, Content: "starting"})
+			emit(ToolEvent{Stage: EventDelta, Content: "line 1\n"})
+			emit(ToolEvent{Stage: EventDelta, Content: "line 2\n"})
+			emit(ToolEvent{Stage: EventEnd, Content: "done"})
+		}
+		return Result{Content: "final"}
+	}
+
+	p := NewPipeline(base)
+	ch := p.ExecuteStream(context.Background(), ToolCall{
+		ID: "call-2", Name: "streaming_test",
+	})
+
+	var events []PipelineEvent
+	for ev := range ch {
+		events = append(events, ev)
+	}
+
+	// 4 progress events + 1 final
+	require.Len(t, events, 5)
+	assert.Equal(t, PipelineProgress, events[0].Type)
+	assert.Equal(t, "starting", events[0].Event.Content)
+	assert.Equal(t, PipelineProgress, events[1].Type)
+	assert.Equal(t, "line 1\n", events[1].Event.Content)
+	assert.Equal(t, PipelineProgress, events[2].Type)
+	assert.Equal(t, PipelineFinal, events[4].Type)
+	assert.Equal(t, "final", events[4].Result.Content)
+}
+
+func TestPipelineExecuteStreamMiddlewarePreservesEmitter(t *testing.T) {
+	var progressReceived bool
+	base := func(ctx context.Context, tc ToolCall) Result {
+		emit := ToolEventEmitterFromContext(ctx)
+		if emit != nil {
+			emit(ToolEvent{Stage: EventDelta, Content: "progress"})
+			progressReceived = true
+		}
+		return Result{Content: "done"}
+	}
+
+	wrapper := func(next HandlerFunc) HandlerFunc {
+		return func(ctx context.Context, tc ToolCall) Result {
+			return next(ctx, tc)
+		}
+	}
+
+	p := NewPipeline(base, wrapper)
+	ch := p.ExecuteStream(context.Background(), ToolCall{
+		ID: "call-3", Name: "test",
+	})
+
+	var events []PipelineEvent
+	for ev := range ch {
+		events = append(events, ev)
+	}
+
+	assert.True(t, progressReceived)
+	require.Len(t, events, 2)
+	assert.Equal(t, PipelineProgress, events[0].Type)
+	assert.Equal(t, PipelineFinal, events[1].Type)
+}
+
+func TestToolEventEmitterFromContextNilWhenAbsent(t *testing.T) {
+	assert.Nil(t, ToolEventEmitterFromContext(context.Background()))
+}
+
+func TestWithToolEventEmitterNilEmitNoop(t *testing.T) {
+	ctx := WithToolEventEmitter(context.Background(), nil)
+	assert.Nil(t, ToolEventEmitterFromContext(ctx))
+}

--- a/pkg/agentsdk/pipeline_test.go
+++ b/pkg/agentsdk/pipeline_test.go
@@ -197,7 +197,22 @@ func TestToolEventEmitterFromContextNilWhenAbsent(t *testing.T) {
 	assert.Nil(t, ToolEventEmitterFromContext(context.Background()))
 }
 
-func TestWithToolEventEmitterNilEmitNoop(t *testing.T) {
-	ctx := WithToolEventEmitter(context.Background(), nil)
-	assert.Nil(t, ToolEventEmitterFromContext(ctx))
+func TestWithToolEventEmitterNilReturnsOriginalContext(t *testing.T) {
+	ctx := context.Background()
+	out := WithToolEventEmitter(ctx, nil)
+	assert.Equal(t, ctx, out, "nil emitter should return the original context unchanged")
+}
+
+func TestWithToolEventEmitterRoundTrip(t *testing.T) {
+	var called bool
+	emit := ToolEventEmitter(func(ev ToolEvent) {
+		called = true
+	})
+
+	ctx := WithToolEventEmitter(context.Background(), emit)
+	got := ToolEventEmitterFromContext(ctx)
+
+	require.NotNil(t, got)
+	got(ToolEvent{Stage: EventDelta, Content: "test"})
+	assert.True(t, called)
 }

--- a/pkg/agentsdk/pipeline_test.go
+++ b/pkg/agentsdk/pipeline_test.go
@@ -245,3 +245,30 @@ func TestPipelineExecuteStreamDoesNotLeakOnCancelledContext(t *testing.T) {
 		t.Fatal("ExecuteStream goroutine blocked on a full channel despite cancelled context")
 	}
 }
+
+func TestPipelineExecuteStreamDeliversFinalWhenBufferHasRoom(t *testing.T) {
+	// Even with an already-cancelled context, a consumer that is still
+	// draining must receive the PipelineFinal event when the buffered send
+	// would not block. A plain select{ch<-; ctx.Done()} drops it ~50% of
+	// the time (Go picks a ready arm at random); the non-blocking fast path
+	// must make delivery deterministic. Many iterations turn the racy
+	// regression into a certain failure.
+	base := func(ctx context.Context, tc ToolCall) Result {
+		return Result{Content: "final"}
+	}
+	p := NewPipeline(base)
+
+	for i := 0; i < 300; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		ch := p.ExecuteStream(ctx, ToolCall{ID: "c", Name: "t"})
+
+		var sawFinal bool
+		for ev := range ch {
+			if ev.Type == PipelineFinal {
+				sawFinal = true
+			}
+		}
+		require.Truef(t, sawFinal, "PipelineFinal dropped on cancelled-but-draining stream (iteration %d)", i)
+	}
+}

--- a/pkg/agentsdk/pipeline_test.go
+++ b/pkg/agentsdk/pipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -215,4 +216,32 @@ func TestWithToolEventEmitterRoundTrip(t *testing.T) {
 	require.NotNil(t, got)
 	got(ToolEvent{Stage: EventDelta, Content: "test"})
 	assert.True(t, called)
+}
+
+func TestPipelineExecuteStreamDoesNotLeakOnCancelledContext(t *testing.T) {
+	// A cancelled context plus an unread channel must not wedge the
+	// ExecuteStream goroutine: the base handler emits far more progress
+	// events than the channel buffer (32) holds, and nobody drains ch.
+	// Without ctx-aware sends the goroutine blocks forever at ~event 33.
+	baseReturned := make(chan struct{})
+	base := func(ctx context.Context, tc ToolCall) Result {
+		emit := ToolEventEmitterFromContext(ctx)
+		for i := 0; i < 100; i++ {
+			emit(ToolEvent{Stage: EventDelta, Content: "x"})
+		}
+		close(baseReturned)
+		return Result{Content: "done"}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before execution; consumer never reads ch
+
+	p := NewPipeline(base)
+	_ = p.ExecuteStream(ctx, ToolCall{ID: "c", Name: "t"})
+
+	select {
+	case <-baseReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ExecuteStream goroutine blocked on a full channel despite cancelled context")
+	}
 }


### PR DESCRIPTION
## Summary

First step of Phase 2 of the modular core redesign (`docs/MODULAR_CORE_REDESIGN.md`; follows #298–#301): promote the **tool-execution middleware pattern** — `ToolCall`, `Result`, `HandlerFunc`, `Middleware`, `Pipeline` — from `internal/toolexec` to `pkg/agentsdk`. This *is* the `Middleware` seam §4.1 describes.

`internal/toolexec.Pipeline` was already the working model the design doc pointed at, and (after Phase 1 step 3 aliased `tools.ToolEvent` to `agentsdk.ToolEvent`) had zero remaining internal dependencies — so this promotion needed no new abstractions, only a rename of the streaming event type to avoid a collision with the existing provider-level `agentsdk.StreamEvent`.

Two commits, Tidy-First discipline:

**`[BEHAVIORAL]`** — add the seam to `pkg/agentsdk` (TDD, 10 tests): `ToolCall`/`Result`/`HandlerFunc`/`Middleware`/`Pipeline` (`NewPipeline`, `Execute`), `PipelineEvent`/`PipelineEventType`/`PipelineProgress`/`PipelineFinal` (renamed from `toolexec.StreamEvent`/`StreamEventType`/`StreamProgress`/`StreamFinal`), and the context-carried `WithToolEventEmitter`/`ToolEventEmitterFromContext` that lets a `Middleware` or base `HandlerFunc` reach the emitter `ExecuteStream` wires up.

**`[STRUCTURAL]`** — `internal/toolexec` aliases everything to the promoted types (same pattern as Phase 0's `tools.Registry = agentsdk.Registry`); `NewPipeline`/`WithToolEventEmitter`/`ToolEventEmitterFromContext` become one-line delegations (matching the existing `NewRegistry`-style wrapper convention — pure plumbing, no policy, so keeping the internal name costs nothing). **Zero edits** to any of the 8 concrete middlewares (checkpoint, hooks, rules, shell safety, schema validation, evaluator verdicts, output offloading) or their call sites in `agent.go`/`main.go`. `internal/toolexec`'s `pipeline_test.go` and `stream_test.go` pass **completely unmodified**.

## What stays internal

The 8 concrete middlewares wrap genuinely internal-only subsystems (`checkpoint.Manager`, `evaluator.CheckerPipeline`, skill hooks, etc.) — only the generic composition seam moved. This is intentionally narrow: it proves the seam pattern works end-to-end (types promoted, zero new internal imports, existing tests untouched) before migrating any real subsystem behind it in a follow-up step.

## Testing

- `pkg/agentsdk`: 10 new tests (8 ported from `internal/toolexec/pipeline_test.go`, 2 for emitter nil-handling), full package green
- `internal/toolexec`: full suite green, `pipeline_test.go`/`stream_test.go` byte-identical to `main`
- `internal/agent`: full suite green unmodified
- Full `go test ./...`: only pre-existing environmental failures (`TestOpenSessionStore_Works`, `TestSessionListCmd_Execute`/`NoSessions` — sqlite session-store path in this container), none in touched packages
- `gofmt` clean, `go vet` clean

## Remaining Phase 2 work

Per the revised plan in `docs/MODULAR_CORE_REDESIGN.md` (#301): migrate real subsystems behind this seam and the others (`ContextStrategy`, `BackgroundCoordinator`, `Transport`) one at a time, then revisit full outer-loop unification once enough of `internal/agent.runLoop`'s orchestration has moved behind seams to converge safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_