### PR TITLE
Phase 2 (step 3): single dispatch site for before-tool-call hooks

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -84,8 +84,10 @@ func (a *Agent) buildPipeline(t *tools.Registry) *toolexec.Pipeline {
 	// outermost so blocked calls never reach hooks or capture.
 	middlewares = append(middlewares, a.toolMiddlewares.BeforeHooks...)
 
-	// Hook middleware for before-tool-call dispatch.
-	hookAdapter := &toolexec.SkillHookAdapter{Runtime: a.skillRuntime}
+	// Hook middleware for before-tool-call dispatch. The adapter carries
+	// the logger so hook dispatch failures leave an operator-facing
+	// warning — the middlewares surface errors only through tool results.
+	hookAdapter := &toolexec.SkillHookAdapter{Runtime: a.skillRuntime, Logger: a.logger}
 	middlewares = append(middlewares, toolexec.HookMiddleware(hookAdapter))
 
 	// Root slot: safety middlewares (e.g. shell safety) run after

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2676,29 +2676,11 @@ func (a *Agent) executeSingleTool(ctx context.Context, ch chan<- TurnEvent, tc p
 		}
 	}()
 
-	// Dispatch HookOnBeforeToolCall. If a hook cancels the call, return
-	// an error result immediately without executing the tool.
-	if a.skillRuntime != nil {
-		hookResult, err := a.skillRuntime.DispatchHook(skills.HookEvent{
-			Phase: skills.HookOnBeforeToolCall,
-			Ctx:   ctx,
-			Data: map[string]any{
-				skills.HookDataToolName: tc.Name,
-				skills.HookDataInput:    tc.Input,
-			},
-		})
-		if err != nil {
-			a.logger.Warn("HookOnBeforeToolCall failed for %s: %v", tc.Name, err)
-		} else if hookResult != nil && hookResult.Cancel {
-			cancelMsg := fmt.Sprintf("tool %q cancelled by skill hook", tc.Name)
-			return toolExecResult{
-				toolUseID: tc.ID,
-				content:   cancelMsg,
-				isError:   true,
-				event:     makeToolResultEvent(tc.ID, tc.Name, cancelMsg, "", true),
-			}
-		}
-	}
+	// HookOnBeforeToolCall is dispatched by the pipeline's HookMiddleware
+	// (with input encoded as the string its consumers assert, and only for
+	// calls that pass the gate middlewares). No inline dispatch here — it
+	// fired every hook a second time with a json.RawMessage payload that
+	// no filter or template consumer could read.
 
 	emit := agentsdk.MakeToolProgressEmitter(tc.ID, tc.Name, func(ev TurnEvent) { a.emit(ctx, ch, ev) })
 	result := a.pipeline.Execute(toolexec.WithToolEventEmitter(ctx, emit), toolexec.ToolCall{

--- a/internal/agent/pipeline_composition_test.go
+++ b/internal/agent/pipeline_composition_test.go
@@ -363,3 +363,40 @@ func TestReadResultPagesAreNeverReOffloaded(t *testing.T) {
 	assert.Equal(t, payload, rrRes.Content,
 		"read_result page must not be re-offloaded into a nested reference")
 }
+
+// TestBeforeToolHooksDispatchOnceWithStringInput completes the hook-
+// dispatch rationalization started with the after-result hooks: the
+// pipeline's HookMiddleware is the single dispatch site for
+// HookOnBeforeToolCall, firing exactly once per call with HookDataInput
+// encoded as a string (the contract pre_edit/pre_shell filters and
+// template variables assert). The removed inline dispatch in
+// executeSingleTool fired a second time with a json.RawMessage payload
+// that no consumer could read.
+func TestBeforeToolHooksDispatchOnceWithStringInput(t *testing.T) {
+	var inputs []any
+	hooks := map[skills.HookPhase]skills.HookHandler{
+		skills.HookOnBeforeToolCall: func(event skills.HookEvent) (skills.HookResult, error) {
+			inputs = append(inputs, event.Data[skills.HookDataInput])
+			return skills.HookResult{}, nil
+		},
+	}
+	rt := makeTestRuntime(t, "before-hook", toolManifest("before-hook"), nil, hooks)
+
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(stubFileTool{}))
+
+	cfg := config.DefaultConfig()
+	a := New(&mockProvider{}, reg, autoApprove, cfg, WithSkillRuntime(rt))
+
+	input := `{"operation":"write","path":"main.go"}`
+	ch := make(chan TurnEvent, 64)
+	res := a.executeSingleTool(context.Background(), ch, provider.ToolUseBlock{
+		ID: "tc-b", Name: "file", Input: json.RawMessage(input),
+	})
+	require.False(t, res.isError)
+
+	require.Len(t, inputs, 1, "before-tool hook must fire exactly once per call")
+	inputStr, ok := inputs[0].(string)
+	require.True(t, ok, "HookDataInput must be a string (consumers assert .(string)); got %T", inputs[0])
+	assert.JSONEq(t, input, inputStr)
+}

--- a/internal/agent/pipeline_composition_test.go
+++ b/internal/agent/pipeline_composition_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -399,4 +400,45 @@ func TestBeforeToolHooksDispatchOnceWithStringInput(t *testing.T) {
 	inputStr, ok := inputs[0].(string)
 	require.True(t, ok, "HookDataInput must be a string (consumers assert .(string)); got %T", inputs[0])
 	assert.JSONEq(t, input, inputStr)
+}
+
+type warnCapturingLogger struct{ warns []string }
+
+func (l *warnCapturingLogger) Debug(format string, args ...any) {}
+func (l *warnCapturingLogger) Info(format string, args ...any)  {}
+func (l *warnCapturingLogger) Warn(format string, args ...any) {
+	l.warns = append(l.warns, fmt.Sprintf(format, args...))
+}
+func (l *warnCapturingLogger) Error(format string, args ...any) {}
+
+// TestBeforeHookFailureIsLogged pins the operator diagnostic for hook
+// failures: with the pipeline middleware as the single dispatch site, a
+// broken skill hook still blocks the call (HookMiddleware policy) AND
+// leaves a warning in the log — the removed inline dispatch was
+// previously the only place that logged these failures.
+func TestBeforeHookFailureIsLogged(t *testing.T) {
+	hooks := map[skills.HookPhase]skills.HookHandler{
+		skills.HookOnBeforeToolCall: func(event skills.HookEvent) (skills.HookResult, error) {
+			return skills.HookResult{}, fmt.Errorf("hook exploded")
+		},
+	}
+	rt := makeTestRuntime(t, "err-hook", toolManifest("err-hook"), nil, hooks)
+
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(stubFileTool{}))
+
+	logger := &warnCapturingLogger{}
+	cfg := config.DefaultConfig()
+	a := New(&mockProvider{}, reg, autoApprove, cfg, WithSkillRuntime(rt), WithLogger(logger))
+
+	ch := make(chan TurnEvent, 64)
+	res := a.executeSingleTool(context.Background(), ch, provider.ToolUseBlock{
+		ID: "tc-e", Name: "file", Input: json.RawMessage(`{"operation":"read","path":"x"}`),
+	})
+	require.True(t, res.isError)
+	require.Contains(t, res.content, "hook error")
+
+	joined := strings.Join(logger.warns, "\n")
+	assert.Contains(t, joined, "HookOnBeforeToolCall failed",
+		"hook failure must leave an operator-facing warning in the log")
 }

--- a/internal/toolexec/hookadapter.go
+++ b/internal/toolexec/hookadapter.go
@@ -5,11 +5,23 @@ import (
 	"encoding/json"
 
 	"github.com/julianshen/rubichan/internal/skills"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
 // SkillHookAdapter adapts a skills.Runtime to the HookDispatcher interface.
+// When Logger is set, hook dispatch failures are logged as warnings — the
+// middlewares themselves surface errors only through the tool result (or
+// swallow them, for after-result hooks), so this is the operator-facing
+// diagnostic for a broken skill hook.
 type SkillHookAdapter struct {
 	Runtime *skills.Runtime
+	Logger  agentsdk.Logger
+}
+
+func (h *SkillHookAdapter) warnf(format string, args ...any) {
+	if h.Logger != nil {
+		h.Logger.Warn(format, args...)
+	}
 }
 
 // DispatchBeforeToolCall dispatches a before-tool-call hook via the skill runtime.
@@ -27,6 +39,7 @@ func (h *SkillHookAdapter) DispatchBeforeToolCall(ctx context.Context, toolName 
 		Ctx: ctx,
 	})
 	if err != nil {
+		h.warnf("HookOnBeforeToolCall failed for %s: %v", toolName, err)
 		return false, err
 	}
 	if result != nil && result.Cancel {
@@ -54,6 +67,7 @@ func (h *SkillHookAdapter) DispatchAfterToolResult(ctx context.Context, toolName
 		Ctx: ctx,
 	})
 	if err != nil {
+		h.warnf("HookOnAfterToolResult failed for %s: %v", toolName, err)
 		return nil, err
 	}
 	if result != nil {


### PR DESCRIPTION
## Summary

Small follow-up completing the hook-dispatch rationalization from #303 (which established the pipeline as the single dispatch site for *after-result* hooks): the *before-tool-call* hooks had the same defects, flagged on that PR as out-of-scope follow-up.

## The problem

`executeSingleTool` dispatched `HookOnBeforeToolCall` inline, in addition to the pipeline's `HookMiddleware`:

- **Every before-hook fired twice per call** — side-effecting skill hooks (counters, loggers, notifiers) observed double the calls.
- The inline dispatch passed `HookDataInput` as `json.RawMessage` — the encoding no consumer can read (`pre_edit`/`pre_shell` filters and `{{file}}`/`{{command}}` template variables assert `.(string)`), so the spurious dispatch never matched user-hook filters yet still double-fired unfiltered skill hooks.

## The fix

Remove the inline dispatch. `HookMiddleware` (which already encodes input as a string) is the single site. One `[BEHAVIORAL]` commit, red→green: `TestBeforeToolHooksDispatchOnceWithStringInput`.

Two declared semantic alignments vs. the old double path:
- **Hook errors now block the call** (the middleware's policy) — the old chain net-blocked anyway, since the middleware ran right after the non-blocking inline attempt.
- **Hooks fire only for calls that pass the gate middlewares** (schema/classifier/rules) — the documented composition order; previously the inline dispatch also fired for calls the rules then blocked.

The cancel path is observably unchanged — the pre-existing `TestAgentBeforeToolCallHook` passes unmodified.

## Testing

- `internal/agent` + `internal/toolexec`: full suites green; hook lifecycle tests (before + after + cancel) all pass
- `gofmt` clean, `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed duplicate before-tool hook notifications during tool execution.
  - Tool hook input is now delivered consistently as readable string content.
  - Prevented downstream consumers from receiving unreadable raw payloads during tool calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->