### PR TITLE
Phase 2: BackgroundCoordinator seam — prefetch and auto-dream behind agentsdk.BackgroundTask

### DIFF
--- a/docs/MODULAR_CORE_REDESIGN.md
+++ b/docs/MODULAR_CORE_REDESIGN.md
@@ -170,6 +170,11 @@ Make `internal/agent` build on the `pkg` core loop instead of reimplementing `ru
 **Phase 2 — Extract feature modules out of the god struct (structural, one subsystem per PR).**
 For each subsystem, introduce the right seam interface and move it behind it, replacing the `With…` field option with a `Use(module)` registration: checkpoint/evaluator/security → *tool-execution middleware* (`toolexec.Middleware`); knowledge-graph/memory/persona/prompt-fragments/compaction → *`ContextStrategy`*; prefetch/auto-dream → *`BackgroundCoordinator`* (async); ACP → *`Transport`*. Struct shrinks one subsystem at a time; tests stay green.
 
+> **Status update (2026-07):** Two of the four seams are in place.
+> *Middleware* (#302–#304): `Pipeline`/`Middleware` promoted to `pkg/agentsdk`; composition is agent-owned (`WithToolMiddlewares` slots around a core chain of canonicalize → hooks → checkpoint → fused verdict+offload), which revived three production subsystems that main.go's wholesale `WithPipeline` replacement had silently dropped; hook dispatch (before and after) has a single site in the pipeline.
+> *BackgroundCoordinator*: `agentsdk.BackgroundTask` — started before each model call, joined after tool execution, signalled at session end on every loop exit. Prefetch and auto-dream moved behind it; their dedicated Agent fields are gone and the loop dispatches generically. Moving auto-dream fixed a latent placement defect (its trigger sat only on the max-turns exit, so normally-ending sessions never consolidated). Note: neither prefetch nor auto-dream is currently registered by `cmd/rubichan/main.go` — wiring them into the product is a pending product decision, separate from the seam.
+> Remaining: *Transport* (ACP) and *ContextStrategy* (compaction/memory/knowledge/persona — the largest).
+
 **Phase 3 — Adapters over the core.**
 Reduce `cmd/rubichan/main.go` to composition only: build core, register modules, pick an adapter. Move mode wiring into `internal/modes/*` (or `pkg` for reusable ones). Target: `main.go` under a few hundred lines.
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -525,6 +525,7 @@ type Agent struct {
 	agentRegistry       *AgentRegistry
 	stopHookRegistry    *hooks.StopHookRegistry
 	prefetchMgr         *PrefetchManager
+	backgroundTasks     []agentsdk.BackgroundTask
 	sessionMemory       *SessionMemoryService
 	summaryCallback     agentsdk.SummaryCallback
 	summaryHandle       atomic.Pointer[SummaryHandle]
@@ -1572,6 +1573,9 @@ func replaceAssistantText(blocks []provider.ContentBlock, newText string) []prov
 
 // runLoop iteratively processes LLM responses and tool calls.
 func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int, lastUserMessage string) {
+	// Signal session end to background tasks on every exit path.
+	defer a.endBackgroundSession()
+
 	var totalInputTokens, totalOutputTokens int
 	ls := newLoopState(a.maxTurns, turnCount, a.configuredMaxTokens)
 	if a.skillRuntime != nil {
@@ -1667,6 +1671,13 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			memHandle = a.prefetchMgr.StartMemoryPrefetch(ctx, lastUserMessage, budget.SkillPrompts)
 			skillHandle = a.prefetchMgr.StartSkillPrefetch(ctx, a.buildSkillTriggerContext(lastUserMessage))
 		}
+
+		// Start registered background tasks so their async work overlaps
+		// the model call; joins run after tool execution.
+		bgJoins := a.startBackgroundTurn(ctx, agentsdk.BackgroundTurnInfo{
+			UserMessage:  lastUserMessage,
+			MemoryBudget: budget.SkillPrompts,
+		})
 
 		req := provider.CompletionRequest{
 			Model:            a.model,
@@ -2173,6 +2184,10 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			if _, err := skillHandle.Consume(ctx); err != nil {
 				a.logger.Warn("skill prefetch failed: %v", err)
 			}
+		}
+
+		for _, join := range bgJoins {
+			join(ctx)
 		}
 
 		// Continue to the next turn after tool results.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -212,10 +212,15 @@ func WithSummaryCallback(cb agentsdk.SummaryCallback) AgentOption {
 	}
 }
 
-// WithAutoDream attaches an auto-dream service for periodic memory consolidation.
+// WithAutoDream attaches an auto-dream service for periodic memory
+// consolidation, registered as a background task whose session-end signal
+// gates and runs the consolidation pass.
 func WithAutoDream(svc *AutoDreamService) AgentOption {
 	return func(a *Agent) {
-		a.autoDreamSvc = svc
+		if svc == nil {
+			return
+		}
+		a.backgroundTasks = append(a.backgroundTasks, &autoDreamBackgroundTask{agent: a, svc: svc})
 	}
 }
 
@@ -534,7 +539,6 @@ type Agent struct {
 	sessionMemory       *SessionMemoryService
 	summaryCallback     agentsdk.SummaryCallback
 	summaryHandle       atomic.Pointer[SummaryHandle]
-	autoDreamSvc        *AutoDreamService
 	collapseStore       *CollapseStore
 	cacheBreakDetector  *CacheBreakDetector
 	windowManager       *ContextWindowManager
@@ -2173,69 +2177,11 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		ls.lastContinueReason = ContinueNextTurn
 	}
 
-	// Reached max turns.
+	// Reached max turns. Auto-dream consolidation, formerly triggered only
+	// here, now runs via the BackgroundTask session-end signal on every
+	// exit path (see the deferred endBackgroundSession above).
 	a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("max turns (%d) exceeded", a.maxTurns)})
 	a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitMaxTurns))
-
-	// Trigger auto-dream consolidation at session end if configured.
-	// Run async to avoid blocking turnMu on I/O.
-	go a.triggerAutoDream(context.Background())
-}
-
-// triggerAutoDream runs the auto-dream consolidation if conditions are met.
-func (a *Agent) triggerAutoDream(ctx context.Context) {
-	if a.autoDreamSvc == nil || !a.autoDreamSvc.IsGateOpen() {
-		return
-	}
-
-	lock := NewConsolidationLock(a.autoDreamSvc.memoryDir)
-	lastConsolidated, err := lock.ReadLastConsolidatedAt()
-	if err != nil {
-		a.logger.Warn("auto-dream: read last consolidated: %v", err)
-		return
-	}
-
-	transcriptDir := filepath.Join(a.workingDir, ".claude", "transcripts")
-	sessions, err := ListSessionsTouchedSince(transcriptDir, lastConsolidated)
-	if err != nil {
-		a.logger.Warn("auto-dream: list sessions: %v", err)
-		return
-	}
-
-	if !a.autoDreamSvc.ShouldRun(sessions, lastConsolidated, a.sessionID) {
-		return
-	}
-
-	params := agentsdk.DreamParams{
-		MemoryRoot:    a.autoDreamSvc.memoryDir,
-		TranscriptDir: transcriptDir,
-	}
-
-	err = a.autoDreamSvc.ExecuteDream(ctx, params, func(ctx context.Context, prompt string) (string, error) {
-		req := provider.CompletionRequest{
-			Model:     a.model,
-			System:    "You are a memory consolidation assistant.",
-			Messages:  []provider.Message{provider.NewUserMessage(prompt)},
-			MaxTokens: 4096,
-		}
-		stream, err := a.provider.Stream(ctx, req)
-		if err != nil {
-			return "", err
-		}
-		var result strings.Builder
-		for event := range stream {
-			if event.Error != nil {
-				return "", fmt.Errorf("dream stream error: %w", event.Error)
-			}
-			if event.Type == agentsdk.EventTextDelta {
-				result.WriteString(event.Text)
-			}
-		}
-		return result.String(), nil
-	})
-	if err != nil {
-		a.logger.Warn("auto-dream: execute dream: %v", err)
-	}
 }
 
 const maxRepeatedPendingToolRounds = 3

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1673,11 +1673,19 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		}
 
 		// Start registered background tasks (prefetch among them) so their
-		// async work overlaps the model call; joins run after tool execution.
+		// async work overlaps the model call. joinBackgroundTasks must run
+		// on every path that executed tools — including terminal ones
+		// (budget stop, task_complete, cancellation) — so per-turn work is
+		// collected before the deferred session-end signal.
 		bgJoins := a.startBackgroundTurn(ctx, agentsdk.BackgroundTurnInfo{
 			UserMessage:  lastUserMessage,
 			MemoryBudget: budget.SkillPrompts,
 		})
+		joinBackgroundTasks := func() {
+			for _, join := range bgJoins {
+				join(ctx)
+			}
+		}
 
 		req := provider.CompletionRequest{
 			Model:            a.model,
@@ -2098,6 +2106,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			}
 			a.logger.Warn("token budget stop: %s (%d%%)", reason, dec.Pct)
 			a.executeTools(ctx, ch, pendingTools, streamedResults)
+			joinBackgroundTasks()
 			a.emit(ctx, ch, TurnEvent{Type: "budget_stop"})
 			exitReason := agentsdk.ExitBudgetExceeded
 			if dec.CompletionEvent.DiminishingReturns {
@@ -2126,6 +2135,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		for _, tc := range pendingTools {
 			if tc.Name == tools.TaskCompleteName {
 				a.executeTools(ctx, ch, pendingTools, streamedResults)
+				joinBackgroundTasks()
 				a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitTaskComplete))
 				return
 			}
@@ -2134,6 +2144,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// Execute tool calls — parallelize auto-approved tools when possible.
 		if cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults); cancelled {
 			synthesizeMissingToolResults(a.conversation, orphanReasonToolCancel)
+			joinBackgroundTasks()
 			a.emit(ctx, ch, TurnEvent{Type: "error", Error: ctx.Err()})
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCancelled))
 			return
@@ -2169,9 +2180,7 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// Join background tasks after tool execution. Their async work is
 		// started before the LLM call and joined here to overlap it with
 		// the model's execution, reducing perceived latency for the next turn.
-		for _, join := range bgJoins {
-			join(ctx)
-		}
+		joinBackgroundTasks()
 
 		// Continue to the next turn after tool results.
 		ls.lastContinueReason = ContinueNextTurn

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -313,9 +313,15 @@ func WithFallbackModel(model string) AgentOption {
 }
 
 // WithPrefetchManager returns an option that configures the agent to use
-// the given prefetch manager for async memory/skill loading.
+// the given prefetch manager for async memory/skill loading. The manager
+// is registered as a background task on the BackgroundTask seam.
 func WithPrefetchManager(pm *PrefetchManager) AgentOption {
-	return func(a *Agent) { a.prefetchMgr = pm }
+	return func(a *Agent) {
+		if pm == nil {
+			return
+		}
+		a.backgroundTasks = append(a.backgroundTasks, &prefetchBackgroundTask{agent: a, mgr: pm})
+	}
 }
 
 // WithSessionMemory attaches a session memory service to the agent.
@@ -524,7 +530,6 @@ type Agent struct {
 	agentDef            *agentsdk.AgentDefinition
 	agentRegistry       *AgentRegistry
 	stopHookRegistry    *hooks.StopHookRegistry
-	prefetchMgr         *PrefetchManager
 	backgroundTasks     []agentsdk.BackgroundTask
 	sessionMemory       *SessionMemoryService
 	summaryCallback     agentsdk.SummaryCallback
@@ -1663,17 +1668,8 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			a.saveSnapshotIfNeeded()
 		}
 
-		// Start async prefetches before LLM call
-		var memHandle *PrefetchHandle[[]kg.ScoredEntity]
-		var skillHandle *PrefetchHandle[struct{}]
-
-		if a.prefetchMgr != nil {
-			memHandle = a.prefetchMgr.StartMemoryPrefetch(ctx, lastUserMessage, budget.SkillPrompts)
-			skillHandle = a.prefetchMgr.StartSkillPrefetch(ctx, a.buildSkillTriggerContext(lastUserMessage))
-		}
-
-		// Start registered background tasks so their async work overlaps
-		// the model call; joins run after tool execution.
+		// Start registered background tasks (prefetch among them) so their
+		// async work overlaps the model call; joins run after tool execution.
 		bgJoins := a.startBackgroundTurn(ctx, agentsdk.BackgroundTurnInfo{
 			UserMessage:  lastUserMessage,
 			MemoryBudget: budget.SkillPrompts,
@@ -2166,26 +2162,9 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			ls.nudgeEmitted = true
 		}
 
-		// Consume prefetch results after tool execution. Prefetches are started
-		// before the LLM call and consumed here to overlap async work with the
-		// model's execution, reducing perceived latency for the next turn.
-		if memHandle != nil {
-			entities, err := memHandle.Consume(ctx)
-			if err != nil {
-				a.logger.Warn("memory prefetch failed: %v", err)
-			} else if len(entities) > 0 && a.knowledgeSelector != nil {
-				if err := a.knowledgeSelector.RecordUsage(ctx, entities); err != nil {
-					a.logger.Warn("record knowledge usage failed: %v", err)
-				}
-			}
-		}
-
-		if skillHandle != nil {
-			if _, err := skillHandle.Consume(ctx); err != nil {
-				a.logger.Warn("skill prefetch failed: %v", err)
-			}
-		}
-
+		// Join background tasks after tool execution. Their async work is
+		// started before the LLM call and joined here to overlap it with
+		// the model's execution, reducing perceived latency for the next turn.
 		for _, join := range bgJoins {
 			join(ctx)
 		}

--- a/internal/agent/autodream.go
+++ b/internal/agent/autodream.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
@@ -105,6 +107,75 @@ func (l *ConsolidationLock) RecordConsolidation() error {
 type SessionInfo struct {
 	SessionID string
 	MTime     time.Time
+}
+
+// autoDreamBackgroundTask adapts an AutoDreamService onto the
+// BackgroundTask seam: consolidation is gated and (when due) executed on
+// the seam's session-end signal, which fires at every loop exit.
+type autoDreamBackgroundTask struct {
+	agent *Agent
+	svc   *AutoDreamService
+}
+
+func (d *autoDreamBackgroundTask) StartTurn(context.Context, agentsdk.BackgroundTurnInfo) func(context.Context) {
+	return nil
+}
+
+// EndSession runs the auto-dream consolidation if conditions are met.
+func (d *autoDreamBackgroundTask) EndSession(ctx context.Context) {
+	a, svc := d.agent, d.svc
+	if !svc.IsGateOpen() {
+		return
+	}
+
+	lock := NewConsolidationLock(svc.memoryDir)
+	lastConsolidated, err := lock.ReadLastConsolidatedAt()
+	if err != nil {
+		a.logger.Warn("auto-dream: read last consolidated: %v", err)
+		return
+	}
+
+	transcriptDir := filepath.Join(a.workingDir, ".claude", "transcripts")
+	sessions, err := ListSessionsTouchedSince(transcriptDir, lastConsolidated)
+	if err != nil {
+		a.logger.Warn("auto-dream: list sessions: %v", err)
+		return
+	}
+
+	if !svc.ShouldRun(sessions, lastConsolidated, a.sessionID) {
+		return
+	}
+
+	params := agentsdk.DreamParams{
+		MemoryRoot:    svc.memoryDir,
+		TranscriptDir: transcriptDir,
+	}
+
+	err = svc.ExecuteDream(ctx, params, func(ctx context.Context, prompt string) (string, error) {
+		req := provider.CompletionRequest{
+			Model:     a.model,
+			System:    "You are a memory consolidation assistant.",
+			Messages:  []provider.Message{provider.NewUserMessage(prompt)},
+			MaxTokens: 4096,
+		}
+		stream, err := a.provider.Stream(ctx, req)
+		if err != nil {
+			return "", err
+		}
+		var result strings.Builder
+		for event := range stream {
+			if event.Error != nil {
+				return "", fmt.Errorf("dream stream error: %w", event.Error)
+			}
+			if event.Type == agentsdk.EventTextDelta {
+				result.WriteString(event.Text)
+			}
+		}
+		return result.String(), nil
+	})
+	if err != nil {
+		a.logger.Warn("auto-dream: execute dream: %v", err)
+	}
 }
 
 // AutoDreamService performs periodic cross-session memory consolidation.

--- a/internal/agent/autodream.go
+++ b/internal/agent/autodream.go
@@ -117,6 +117,12 @@ type autoDreamBackgroundTask struct {
 	svc   *AutoDreamService
 }
 
+// autoDreamTimeout bounds one consolidation pass. EndSession runs on
+// context.Background() by design (session-end work outlives the turn), so
+// without a local deadline a hung provider stream would leak the
+// goroutine forever.
+const autoDreamTimeout = 5 * time.Minute
+
 func (d *autoDreamBackgroundTask) StartTurn(context.Context, agentsdk.BackgroundTurnInfo) func(context.Context) {
 	return nil
 }
@@ -127,6 +133,9 @@ func (d *autoDreamBackgroundTask) EndSession(ctx context.Context) {
 	if !svc.IsGateOpen() {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, autoDreamTimeout)
+	defer cancel()
 
 	lock := NewConsolidationLock(svc.memoryDir)
 	lastConsolidated, err := lock.ReadLastConsolidatedAt()

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -8,10 +8,15 @@ import (
 
 // WithBackgroundTasks registers tasks that run concurrently with the agent
 // loop: started before each model call, joined after tool execution, and
-// signalled once when the loop exits. See agentsdk.BackgroundTask.
+// signalled once when the loop exits. Nil tasks are ignored. See
+// agentsdk.BackgroundTask.
 func WithBackgroundTasks(tasks ...agentsdk.BackgroundTask) AgentOption {
 	return func(a *Agent) {
-		a.backgroundTasks = append(a.backgroundTasks, tasks...)
+		for _, task := range tasks {
+			if task != nil {
+				a.backgroundTasks = append(a.backgroundTasks, task)
+			}
+		}
 	}
 }
 
@@ -31,9 +36,18 @@ func (a *Agent) startBackgroundTurn(ctx context.Context, info agentsdk.Backgroun
 // endBackgroundSession signals session end to every registered background
 // task. Each task runs on its own goroutine with a fresh context so
 // session-end work is not bound to the (likely finished) turn context and
-// never blocks the loop's caller.
+// never blocks the loop's caller. Panics are recovered per task — this is
+// a public seam running third-party code on unsupervised goroutines, where
+// an unrecovered panic would take down the whole process.
 func (a *Agent) endBackgroundSession() {
 	for _, task := range a.backgroundTasks {
-		go task.EndSession(context.Background())
+		go func(t agentsdk.BackgroundTask) {
+			defer func() {
+				if r := recover(); r != nil {
+					a.logger.Warn("background task EndSession panicked: %v", r)
+				}
+			}()
+			t.EndSession(context.Background())
+		}(task)
 	}
 }

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -1,0 +1,39 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// WithBackgroundTasks registers tasks that run concurrently with the agent
+// loop: started before each model call, joined after tool execution, and
+// signalled once when the loop exits. See agentsdk.BackgroundTask.
+func WithBackgroundTasks(tasks ...agentsdk.BackgroundTask) AgentOption {
+	return func(a *Agent) {
+		a.backgroundTasks = append(a.backgroundTasks, tasks...)
+	}
+}
+
+// startBackgroundTurn starts every registered background task for the
+// current turn and returns the join functions to invoke after tool
+// execution.
+func (a *Agent) startBackgroundTurn(ctx context.Context, info agentsdk.BackgroundTurnInfo) []func(context.Context) {
+	var joins []func(context.Context)
+	for _, task := range a.backgroundTasks {
+		if join := task.StartTurn(ctx, info); join != nil {
+			joins = append(joins, join)
+		}
+	}
+	return joins
+}
+
+// endBackgroundSession signals session end to every registered background
+// task. Each task runs on its own goroutine with a fresh context so
+// session-end work is not bound to the (likely finished) turn context and
+// never blocks the loop's caller.
+func (a *Agent) endBackgroundSession() {
+	for _, task := range a.backgroundTasks {
+		go task.EndSession(context.Background())
+	}
+}

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -22,15 +22,42 @@ func WithBackgroundTasks(tasks ...agentsdk.BackgroundTask) AgentOption {
 
 // startBackgroundTurn starts every registered background task for the
 // current turn and returns the join functions to invoke after tool
-// execution.
+// execution. StartTurn and the joins run on the main turn goroutine, so
+// panics are recovered per task: a bad background optimization must not
+// abort the foreground turn (the outer Turn recover would grade it
+// ExitPanic) or starve sibling tasks.
 func (a *Agent) startBackgroundTurn(ctx context.Context, info agentsdk.BackgroundTurnInfo) []func(context.Context) {
 	var joins []func(context.Context)
 	for _, task := range a.backgroundTasks {
-		if join := task.StartTurn(ctx, info); join != nil {
-			joins = append(joins, join)
+		if join := a.startTaskRecovering(ctx, task, info); join != nil {
+			joins = append(joins, a.recoveringJoin(join))
 		}
 	}
 	return joins
+}
+
+// startTaskRecovering invokes one task's StartTurn behind a recover
+// boundary; on panic the task contributes no join for this turn.
+func (a *Agent) startTaskRecovering(ctx context.Context, task agentsdk.BackgroundTask, info agentsdk.BackgroundTurnInfo) (join func(context.Context)) {
+	defer func() {
+		if r := recover(); r != nil {
+			a.logger.Warn("background task StartTurn panicked: %v", r)
+		}
+	}()
+	return task.StartTurn(ctx, info)
+}
+
+// recoveringJoin wraps a task's join so a panic in it is contained and
+// logged instead of aborting the turn.
+func (a *Agent) recoveringJoin(join func(context.Context)) func(context.Context) {
+	return func(ctx context.Context) {
+		defer func() {
+			if r := recover(); r != nil {
+				a.logger.Warn("background task join panicked: %v", r)
+			}
+		}()
+		join(ctx)
+	}
 }
 
 // endBackgroundSession signals session end to every registered background

--- a/internal/agent/background_test.go
+++ b/internal/agent/background_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -176,4 +178,52 @@ func TestPrefetchLoopStartsAndRecordsUsage(t *testing.T) {
 	defer selB.mu.Unlock()
 	require.Len(t, selB.recorded, 1, "prefetched entities must be recorded after tool execution")
 	assert.Equal(t, "prefetched-entity", selB.recorded[0].Entity.ID)
+}
+
+// TestAutoDreamTriggersOnNormalLoopExit pins the auto-dream trigger to
+// the BackgroundTask seam's session-end signal, which fires on every
+// loop exit. Previously the trigger sat only on the max-turns exit path,
+// so a session that ended normally — the overwhelmingly common case —
+// could never consolidate memory regardless of the configured gate.
+func TestAutoDreamTriggersOnNormalLoopExit(t *testing.T) {
+	workDir := t.TempDir()
+	memoryDir := filepath.Join(workDir, "memories")
+
+	// Satisfy the consolidation gate: no lock file (last consolidation at
+	// zero time) and one recent session from another session ID.
+	transcriptDir := filepath.Join(workDir, ".claude", "transcripts")
+	require.NoError(t, os.MkdirAll(transcriptDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(transcriptDir, "other-session.jsonl"), []byte("{}"), 0o644))
+
+	dmp := &dynamicMockProvider{responses: [][]provider.StreamEvent{
+		{
+			{Type: "text_delta", Text: "all done"},
+			{Type: "stop"},
+		},
+		{
+			// Served to the async consolidation call after the loop exits.
+			{Type: "text_delta", Text: "consolidated"},
+			{Type: "stop"},
+		},
+	}}
+
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	svc := NewAutoDreamService(memoryDir, AutoDreamConfig{MinHours: 1, MinSessions: 1})
+	a := New(dmp, reg, autoApprove, cfg,
+		WithWorkingDir(workDir),
+		WithAutoDream(svc),
+	)
+
+	ch, err := a.Turn(context.Background(), "wrap up")
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	lockPath := filepath.Join(memoryDir, ".consolidate-lock")
+	require.Eventually(t, func() bool {
+		_, statErr := os.Stat(lockPath)
+		return statErr == nil
+	}, 3*time.Second, 20*time.Millisecond,
+		"consolidation must run after a normal loop exit when the gate is satisfied")
 }

--- a/internal/agent/background_test.go
+++ b/internal/agent/background_test.go
@@ -1,0 +1,105 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/julianshen/rubichan/internal/config"
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/tools"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// recordingBackgroundTask records the lifecycle calls the loop makes on a
+// registered background task.
+type recordingBackgroundTask struct {
+	mu    sync.Mutex
+	calls []string
+	infos []agentsdk.BackgroundTurnInfo
+}
+
+func (r *recordingBackgroundTask) record(call string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, call)
+}
+
+func (r *recordingBackgroundTask) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.calls...)
+}
+
+func (r *recordingBackgroundTask) StartTurn(_ context.Context, info agentsdk.BackgroundTurnInfo) func(context.Context) {
+	r.mu.Lock()
+	r.infos = append(r.infos, info)
+	r.mu.Unlock()
+	r.record("start")
+	return func(context.Context) { r.record("join") }
+}
+
+func (r *recordingBackgroundTask) EndSession(context.Context) { r.record("end") }
+
+// recordingTool marks tool execution in the shared call log so tests can
+// assert lifecycle ordering relative to tool dispatch.
+type recordingTool struct{ onExecute func() }
+
+func (recordingTool) Name() string                 { return "rec_tool" }
+func (recordingTool) Description() string          { return "records execution" }
+func (recordingTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (t recordingTool) Execute(context.Context, json.RawMessage) (tools.ToolResult, error) {
+	t.onExecute()
+	return tools.ToolResult{Content: "ok"}, nil
+}
+
+// TestBackgroundTasksObserveLoopLifecycle pins the BackgroundCoordinator
+// seam: a task registered via WithBackgroundTasks is started before each
+// model call, joined after tool execution, and told once — asynchronously —
+// when the loop ends. Turn 2 is the final text-only response; its join is
+// not invoked because the join site sits on the tool-execution path
+// (matching prefetch semantics, where unjoined async work still completes).
+func TestBackgroundTasksObserveLoopLifecycle(t *testing.T) {
+	task := &recordingBackgroundTask{}
+
+	dmp := &dynamicMockProvider{responses: [][]provider.StreamEvent{
+		{
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "bg-1", Name: "rec_tool"}},
+			{Type: "text_delta", Text: `{}`},
+			{Type: "stop"},
+		},
+		{
+			{Type: "text_delta", Text: "done"},
+			{Type: "stop"},
+		},
+	}}
+
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(recordingTool{onExecute: func() { task.record("tool") }}))
+
+	cfg := config.DefaultConfig()
+	a := New(dmp, reg, autoApprove, cfg, WithBackgroundTasks(task))
+
+	ch, err := a.Turn(context.Background(), "do the thing")
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	require.Eventually(t, func() bool {
+		calls := task.snapshot()
+		return len(calls) > 0 && calls[len(calls)-1] == "end"
+	}, 2*time.Second, 10*time.Millisecond, "EndSession must fire after the loop exits")
+
+	assert.Equal(t, []string{"start", "tool", "join", "start", "end"}, task.snapshot())
+
+	task.mu.Lock()
+	defer task.mu.Unlock()
+	require.Len(t, task.infos, 2)
+	assert.Equal(t, "do the thing", task.infos[0].UserMessage)
+	assert.Equal(t, "do the thing", task.infos[1].UserMessage)
+}

--- a/internal/agent/background_test.go
+++ b/internal/agent/background_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/tools"
 	"github.com/julianshen/rubichan/pkg/agentsdk"
+	kg "github.com/julianshen/rubichan/pkg/knowledgegraph"
 )
 
 // recordingBackgroundTask records the lifecycle calls the loop makes on a
@@ -102,4 +103,77 @@ func TestBackgroundTasksObserveLoopLifecycle(t *testing.T) {
 	require.Len(t, task.infos, 2)
 	assert.Equal(t, "do the thing", task.infos[0].UserMessage)
 	assert.Equal(t, "do the thing", task.infos[1].UserMessage)
+}
+
+// prefetchRecordingSelector records Select queries and RecordUsage calls.
+// Select runs on the prefetch goroutine, so access is mutex-guarded.
+type prefetchRecordingSelector struct {
+	mu       sync.Mutex
+	results  []kg.ScoredEntity
+	selects  []string
+	recorded []kg.ScoredEntity
+}
+
+func (s *prefetchRecordingSelector) Select(_ context.Context, query string, _ int) ([]kg.ScoredEntity, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.selects = append(s.selects, query)
+	return s.results, nil
+}
+
+func (s *prefetchRecordingSelector) RecordUsage(_ context.Context, entities []kg.ScoredEntity) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recorded = append(s.recorded, entities...)
+	return nil
+}
+
+// TestPrefetchLoopStartsAndRecordsUsage pins the WithPrefetchManager loop
+// behavior: the memory prefetch starts with the user's message as query,
+// and after tool execution its entities are recorded against the agent's
+// knowledge selector. Two distinct selectors separate the prefetch path
+// (selA, feeds the manager) from the knowledge path (selB, receives
+// RecordUsage) so the cross-wiring is unambiguous; selB returns no
+// entities so the prompt builder's own Select/RecordUsage stays silent.
+func TestPrefetchLoopStartsAndRecordsUsage(t *testing.T) {
+	selA := &prefetchRecordingSelector{results: []kg.ScoredEntity{
+		{Entity: &kg.Entity{ID: "prefetched-entity"}, Score: 1},
+	}}
+	selB := &prefetchRecordingSelector{}
+
+	dmp := &dynamicMockProvider{responses: [][]provider.StreamEvent{
+		{
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "pf-1", Name: "rec_tool"}},
+			{Type: "text_delta", Text: `{}`},
+			{Type: "stop"},
+		},
+		{
+			{Type: "text_delta", Text: "done"},
+			{Type: "stop"},
+		},
+	}}
+
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(recordingTool{onExecute: func() {}}))
+
+	cfg := config.DefaultConfig()
+	a := New(dmp, reg, autoApprove, cfg,
+		WithPrefetchManager(NewPrefetchManager(selA, nil)),
+		WithKnowledgeGraph(selB),
+	)
+
+	ch, err := a.Turn(context.Background(), "look this up")
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	selA.mu.Lock()
+	defer selA.mu.Unlock()
+	require.NotEmpty(t, selA.selects, "memory prefetch must query the selector")
+	assert.Equal(t, "look this up", selA.selects[0])
+
+	selB.mu.Lock()
+	defer selB.mu.Unlock()
+	require.Len(t, selB.recorded, 1, "prefetched entities must be recorded after tool execution")
+	assert.Equal(t, "prefetched-entity", selB.recorded[0].Entity.ID)
 }

--- a/internal/agent/background_test.go
+++ b/internal/agent/background_test.go
@@ -354,6 +354,73 @@ func TestEndSessionPanicIsRecovered(t *testing.T) {
 		"a panicking EndSession must be recovered and logged, not crash the process")
 }
 
+// startPanickingTask panics in StartTurn; joinPanickingTask panics in the
+// join it returns.
+type startPanickingTask struct{}
+
+func (startPanickingTask) StartTurn(context.Context, agentsdk.BackgroundTurnInfo) func(context.Context) {
+	panic("start exploded")
+}
+func (startPanickingTask) EndSession(context.Context) {}
+
+type joinPanickingTask struct{}
+
+func (joinPanickingTask) StartTurn(context.Context, agentsdk.BackgroundTurnInfo) func(context.Context) {
+	return func(context.Context) { panic("join exploded") }
+}
+func (joinPanickingTask) EndSession(context.Context) {}
+
+// TestStartTurnAndJoinPanicsAreContained pins the per-task recover
+// boundary on the turn-side callbacks: StartTurn and joins run on the
+// main turn goroutine, so without recovery a panicking third-party task
+// would abort the entire user turn as ExitPanic and starve sibling
+// tasks. A healthy task must run its full lifecycle alongside a task
+// panicking in StartTurn and one panicking in its join, and the turn
+// must finish normally.
+func TestStartTurnAndJoinPanicsAreContained(t *testing.T) {
+	healthy := &recordingBackgroundTask{}
+	logger := &syncWarnLogger{}
+
+	dmp := &dynamicMockProvider{responses: [][]provider.StreamEvent{
+		{
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "pc-1", Name: "rec_tool"}},
+			{Type: "text_delta", Text: `{}`},
+			{Type: "stop"},
+		},
+		{
+			{Type: "text_delta", Text: "done"},
+			{Type: "stop"},
+		},
+	}}
+
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(recordingTool{onExecute: func() {}}))
+
+	cfg := config.DefaultConfig()
+	a := New(dmp, reg, autoApprove, cfg,
+		WithBackgroundTasks(startPanickingTask{}, joinPanickingTask{}, healthy),
+		WithLogger(logger),
+	)
+
+	ch, err := a.Turn(context.Background(), "keep going")
+	require.NoError(t, err)
+	var exitReason agentsdk.TurnExitReason
+	for ev := range ch {
+		if ev.Type == "done" {
+			exitReason = ev.ExitReason
+		}
+	}
+
+	assert.NotEqual(t, agentsdk.ExitPanic, exitReason,
+		"a panicking background task must not abort the user turn")
+	calls := healthy.snapshot()
+	assert.Contains(t, calls, "start", "healthy sibling task must still start")
+	assert.Contains(t, calls, "join", "healthy sibling task must still join")
+	joined := logger.joined()
+	assert.Contains(t, joined, "StartTurn panicked")
+	assert.Contains(t, joined, "join panicked")
+}
+
 // deadlineCapturingProvider records whether the consolidation call arrived
 // with a deadline-bearing context.
 type deadlineCapturingProvider struct {

--- a/internal/agent/background_test.go
+++ b/internal/agent/background_test.go
@@ -227,3 +227,39 @@ func TestAutoDreamTriggersOnNormalLoopExit(t *testing.T) {
 	}, 3*time.Second, 20*time.Millisecond,
 		"consolidation must run after a normal loop exit when the gate is satisfied")
 }
+
+// TestBackgroundJoinsRunOnTerminalToolTurns pins the seam contract on
+// terminal tool paths: task_complete executes its tool batch and exits the
+// loop immediately, but the turn *did* execute tools, so registered
+// background tasks must still be joined — before EndSession — rather than
+// leaving their per-turn work uncollected.
+func TestBackgroundJoinsRunOnTerminalToolTurns(t *testing.T) {
+	task := &recordingBackgroundTask{}
+
+	dmp := &dynamicMockProvider{responses: [][]provider.StreamEvent{
+		{
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "done-1", Name: "task_complete"}},
+			{Type: "text_delta", Text: `{"summary":"finished"}`},
+			{Type: "stop"},
+		},
+	}}
+
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(tools.NewCompletionSignalTool()))
+
+	cfg := config.DefaultConfig()
+	a := New(dmp, reg, autoApprove, cfg, WithBackgroundTasks(task))
+
+	ch, err := a.Turn(context.Background(), "finish up")
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	require.Eventually(t, func() bool {
+		calls := task.snapshot()
+		return len(calls) > 0 && calls[len(calls)-1] == "end"
+	}, 2*time.Second, 10*time.Millisecond, "EndSession must fire after the loop exits")
+
+	assert.Equal(t, []string{"start", "join", "end"}, task.snapshot(),
+		"a terminal tool turn must join background tasks before session end")
+}

--- a/internal/agent/background_test.go
+++ b/internal/agent/background_test.go
@@ -3,8 +3,10 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -114,6 +116,7 @@ type prefetchRecordingSelector struct {
 	results  []kg.ScoredEntity
 	selects  []string
 	recorded []kg.ScoredEntity
+	onRecord func()
 }
 
 func (s *prefetchRecordingSelector) Select(_ context.Context, query string, _ int) ([]kg.ScoredEntity, error) {
@@ -125,8 +128,12 @@ func (s *prefetchRecordingSelector) Select(_ context.Context, query string, _ in
 
 func (s *prefetchRecordingSelector) RecordUsage(_ context.Context, entities []kg.ScoredEntity) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.recorded = append(s.recorded, entities...)
+	cb := s.onRecord
+	s.mu.Unlock()
+	if cb != nil {
+		cb()
+	}
 	return nil
 }
 
@@ -138,10 +145,18 @@ func (s *prefetchRecordingSelector) RecordUsage(_ context.Context, entities []kg
 // RecordUsage) so the cross-wiring is unambiguous; selB returns no
 // entities so the prompt builder's own Select/RecordUsage stays silent.
 func TestPrefetchLoopStartsAndRecordsUsage(t *testing.T) {
+	var orderMu sync.Mutex
+	var order []string
+	appendEvent := func(e string) {
+		orderMu.Lock()
+		defer orderMu.Unlock()
+		order = append(order, e)
+	}
+
 	selA := &prefetchRecordingSelector{results: []kg.ScoredEntity{
 		{Entity: &kg.Entity{ID: "prefetched-entity"}, Score: 1},
 	}}
-	selB := &prefetchRecordingSelector{}
+	selB := &prefetchRecordingSelector{onRecord: func() { appendEvent("record") }}
 
 	dmp := &dynamicMockProvider{responses: [][]provider.StreamEvent{
 		{
@@ -156,7 +171,7 @@ func TestPrefetchLoopStartsAndRecordsUsage(t *testing.T) {
 	}}
 
 	reg := tools.NewRegistry()
-	require.NoError(t, reg.Register(recordingTool{onExecute: func() {}}))
+	require.NoError(t, reg.Register(recordingTool{onExecute: func() { appendEvent("tool") }}))
 
 	cfg := config.DefaultConfig()
 	a := New(dmp, reg, autoApprove, cfg,
@@ -175,9 +190,14 @@ func TestPrefetchLoopStartsAndRecordsUsage(t *testing.T) {
 	assert.Equal(t, "look this up", selA.selects[0])
 
 	selB.mu.Lock()
-	defer selB.mu.Unlock()
 	require.Len(t, selB.recorded, 1, "prefetched entities must be recorded after tool execution")
 	assert.Equal(t, "prefetched-entity", selB.recorded[0].Entity.ID)
+	selB.mu.Unlock()
+
+	orderMu.Lock()
+	defer orderMu.Unlock()
+	assert.Equal(t, []string{"tool", "record"}, order,
+		"usage recording (join) must happen after tool execution")
 }
 
 // TestAutoDreamTriggersOnNormalLoopExit pins the auto-dream trigger to
@@ -262,4 +282,121 @@ func TestBackgroundJoinsRunOnTerminalToolTurns(t *testing.T) {
 
 	assert.Equal(t, []string{"start", "join", "end"}, task.snapshot(),
 		"a terminal tool turn must join background tasks before session end")
+}
+
+// TestWithBackgroundTasksFiltersNil pins the nil-guard on the public
+// variadic option: a nil task must not be registered (it would panic on
+// the first StartTurn dispatch), matching WithPrefetchManager/WithAutoDream.
+func TestWithBackgroundTasksFiltersNil(t *testing.T) {
+	task := &recordingBackgroundTask{}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	a := New(&mockProvider{}, reg, autoApprove, cfg, WithBackgroundTasks(nil, task, nil))
+
+	require.Len(t, a.backgroundTasks, 1, "nil tasks must be filtered out at registration")
+	require.NotPanics(t, func() {
+		joins := a.startBackgroundTurn(context.Background(), agentsdk.BackgroundTurnInfo{})
+		for _, join := range joins {
+			join(context.Background())
+		}
+	})
+}
+
+// panickingBackgroundTask panics in EndSession.
+type panickingBackgroundTask struct{}
+
+func (panickingBackgroundTask) StartTurn(context.Context, agentsdk.BackgroundTurnInfo) func(context.Context) {
+	return nil
+}
+func (panickingBackgroundTask) EndSession(context.Context) { panic("task exploded") }
+
+// syncWarnLogger captures Warn calls behind a mutex — EndSession dispatch
+// runs on its own goroutine, so the capture must be race-safe.
+type syncWarnLogger struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *syncWarnLogger) Debug(string, ...any) {}
+func (l *syncWarnLogger) Info(string, ...any)  {}
+func (l *syncWarnLogger) Warn(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, fmt.Sprintf(format, args...))
+}
+func (l *syncWarnLogger) Error(string, ...any) {}
+
+func (l *syncWarnLogger) joined() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Join(l.warns, "\n")
+}
+
+// TestEndSessionPanicIsRecovered pins the recover boundary on the
+// session-end fan-out: WithBackgroundTasks is a public seam, and its
+// EndSession dispatches run on dedicated goroutines — without recovery a
+// buggy third-party task would take down the entire process. The panic
+// must be contained and surfaced as an operator warning.
+func TestEndSessionPanicIsRecovered(t *testing.T) {
+	logger := &syncWarnLogger{}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	a := New(&mockProvider{}, reg, autoApprove, cfg,
+		WithBackgroundTasks(panickingBackgroundTask{}),
+		WithLogger(logger),
+	)
+
+	a.endBackgroundSession()
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(logger.joined(), "panicked")
+	}, 2*time.Second, 10*time.Millisecond,
+		"a panicking EndSession must be recovered and logged, not crash the process")
+}
+
+// deadlineCapturingProvider records whether the consolidation call arrived
+// with a deadline-bearing context.
+type deadlineCapturingProvider struct {
+	mu          sync.Mutex
+	called      bool
+	hadDeadline bool
+}
+
+func (p *deadlineCapturingProvider) Stream(ctx context.Context, _ provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
+	p.mu.Lock()
+	p.called = true
+	_, p.hadDeadline = ctx.Deadline()
+	p.mu.Unlock()
+
+	ch := make(chan provider.StreamEvent, 2)
+	ch <- provider.StreamEvent{Type: "text_delta", Text: "consolidated"}
+	ch <- provider.StreamEvent{Type: "stop"}
+	close(ch)
+	return ch, nil
+}
+
+// TestAutoDreamEndSessionBoundsProviderCall pins the timeout on the
+// consolidation model call: EndSession runs on context.Background() by
+// design (session-end work outlives the turn), so without a local
+// deadline a hung provider stream would leak the goroutine forever.
+func TestAutoDreamEndSessionBoundsProviderCall(t *testing.T) {
+	workDir := t.TempDir()
+	memoryDir := filepath.Join(workDir, "memories")
+	transcriptDir := filepath.Join(workDir, ".claude", "transcripts")
+	require.NoError(t, os.MkdirAll(transcriptDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(transcriptDir, "other.jsonl"), []byte("{}"), 0o644))
+
+	p := &deadlineCapturingProvider{}
+	reg := tools.NewRegistry()
+	cfg := config.DefaultConfig()
+	svc := NewAutoDreamService(memoryDir, AutoDreamConfig{MinHours: 1, MinSessions: 1})
+	a := New(p, reg, autoApprove, cfg, WithWorkingDir(workDir), WithAutoDream(svc))
+
+	task := &autoDreamBackgroundTask{agent: a, svc: svc}
+	task.EndSession(context.Background())
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	require.True(t, p.called, "consolidation must reach the provider")
+	assert.True(t, p.hadDeadline, "the consolidation model call must carry a deadline")
 }

--- a/internal/agent/prefetch.go
+++ b/internal/agent/prefetch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/julianshen/rubichan/internal/skills"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
 	kg "github.com/julianshen/rubichan/pkg/knowledgegraph"
 )
 
@@ -60,6 +61,37 @@ func (pm *PrefetchManager) StartMemoryPrefetch(ctx context.Context, query string
 
 	return handle
 }
+
+// prefetchBackgroundTask adapts a PrefetchManager onto the BackgroundTask
+// seam: memory and skill prefetches start before the model call, and the
+// join — invoked after tool execution — consumes both handles, recording
+// prefetched entities against the agent's knowledge selector.
+type prefetchBackgroundTask struct {
+	agent *Agent
+	mgr   *PrefetchManager
+}
+
+func (p *prefetchBackgroundTask) StartTurn(ctx context.Context, info agentsdk.BackgroundTurnInfo) func(context.Context) {
+	memHandle := p.mgr.StartMemoryPrefetch(ctx, info.UserMessage, info.MemoryBudget)
+	skillHandle := p.mgr.StartSkillPrefetch(ctx, p.agent.buildSkillTriggerContext(info.UserMessage))
+
+	return func(ctx context.Context) {
+		entities, err := memHandle.Consume(ctx)
+		if err != nil {
+			p.agent.logger.Warn("memory prefetch failed: %v", err)
+		} else if len(entities) > 0 && p.agent.knowledgeSelector != nil {
+			if err := p.agent.knowledgeSelector.RecordUsage(ctx, entities); err != nil {
+				p.agent.logger.Warn("record knowledge usage failed: %v", err)
+			}
+		}
+
+		if _, err := skillHandle.Consume(ctx); err != nil {
+			p.agent.logger.Warn("skill prefetch failed: %v", err)
+		}
+	}
+}
+
+func (p *prefetchBackgroundTask) EndSession(context.Context) {}
 
 // StartSkillPrefetch begins async evaluation of skill triggers.
 // If skillRuntime is nil, the handle completes immediately with no error.

--- a/internal/agent/prefetch.go
+++ b/internal/agent/prefetch.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 
 	"github.com/julianshen/rubichan/internal/skills"
 	"github.com/julianshen/rubichan/pkg/agentsdk"
@@ -76,16 +77,20 @@ func (p *prefetchBackgroundTask) StartTurn(ctx context.Context, info agentsdk.Ba
 	skillHandle := p.mgr.StartSkillPrefetch(ctx, p.agent.buildSkillTriggerContext(info.UserMessage))
 
 	return func(ctx context.Context) {
+		// Cancellation is not a prefetch failure: joins also run on the
+		// cancelled-turn exit path, where Consume returns ctx.Err().
 		entities, err := memHandle.Consume(ctx)
 		if err != nil {
-			p.agent.logger.Warn("memory prefetch failed: %v", err)
+			if !errors.Is(err, context.Canceled) {
+				p.agent.logger.Warn("memory prefetch failed: %v", err)
+			}
 		} else if len(entities) > 0 && p.agent.knowledgeSelector != nil {
 			if err := p.agent.knowledgeSelector.RecordUsage(ctx, entities); err != nil {
 				p.agent.logger.Warn("record knowledge usage failed: %v", err)
 			}
 		}
 
-		if _, err := skillHandle.Consume(ctx); err != nil {
+		if _, err := skillHandle.Consume(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			p.agent.logger.Warn("skill prefetch failed: %v", err)
 		}
 	}

--- a/pkg/agentsdk/background.go
+++ b/pkg/agentsdk/background.go
@@ -1,0 +1,32 @@
+package agentsdk
+
+import "context"
+
+// BackgroundTurnInfo carries the per-turn inputs the agent loop offers to
+// background tasks when a turn starts.
+type BackgroundTurnInfo struct {
+	// UserMessage is the user message that started the current loop.
+	UserMessage string
+	// MemoryBudget is the token budget available for prefetched context
+	// (the loop's skill-prompt budget share).
+	MemoryBudget int
+}
+
+// BackgroundTask runs work concurrently with the agent loop. The loop is
+// the caller: it starts tasks before each model call so their async work
+// overlaps model latency, joins them after tool execution, and signals
+// session end once the loop exits.
+//
+// StartTurn is invoked before every model call. Implementations kick off
+// their async work and return a join function, which the loop invokes
+// after tool execution on the same turn; return nil when there is nothing
+// to join. On turns that end the loop without tool calls the join is not
+// invoked — async work started there still runs, but its results are not
+// collected, so joins must not be required for correctness.
+//
+// EndSession is invoked exactly once when the loop exits, on a goroutine
+// off the loop's critical path, with a context independent of the turn's.
+type BackgroundTask interface {
+	StartTurn(ctx context.Context, info BackgroundTurnInfo) (join func(context.Context))
+	EndSession(ctx context.Context)
+}


### PR DESCRIPTION
## Summary

Next Phase 2 seam from `docs/MODULAR_CORE_REDESIGN.md`: the **BackgroundCoordinator**. Async, loop-concurrent subsystems (prefetch, auto-dream) move behind one public contract, and their dedicated `Agent` fields disappear.

## The seam

`agentsdk.BackgroundTask` (zero `internal/` imports):

- **`StartTurn`** — invoked before every model call so async work overlaps model latency; returns a join function (or nil).
- **join** — invoked after tool execution on the same turn. On turns that end the loop without tool calls the join is not invoked (matching existing prefetch semantics — documented on the interface, with the implication that joins must not be required for correctness).
- **`EndSession`** — invoked exactly once per loop exit, on a goroutine off the loop's critical path.

Registration is `WithBackgroundTasks(...)`; the loop dispatches generically via `startBackgroundTurn` / join loop / deferred `endBackgroundSession`. `WithPrefetchManager` and `WithAutoDream` are now thin registrations of internal adapters — the `prefetchMgr` and `autoDreamSvc` struct fields are gone.

## Declared behavior change (auto-dream)

The auto-dream trigger previously sat **only on the max-turns exit path** — sessions that ended normally (task complete, final text, cancellation) could never consolidate memory regardless of the configured gate. The session-end signal now fires on **every** loop exit. The gate itself is unchanged (min-hours + min-sessions check, `running` flag, consolidation lock), so this changes *when the check runs*, not *how often consolidation is allowed*. Red→green: `TestAutoDreamTriggersOnNormalLoopExit`.

## Observation for follow-up (not addressed here)

Neither `WithPrefetchManager` nor `WithAutoDream` is called by `cmd/rubichan/main.go` — both subsystems are currently dead options with no production wiring. Wiring them in (and choosing config like the memory directory) is a product decision, flagged in the design-doc status note.

## Commits (Tidy First)

1. `[BEHAVIORAL]` Add BackgroundTask seam for loop-concurrent work
2. `[STRUCTURAL]` Move prefetch behind the seam (behavior pinned before the move by `TestPrefetchLoopStartsAndRecordsUsage`, green before and after)
3. `[BEHAVIORAL]` Auto-dream consolidation triggers at every loop exit
4. `[STRUCTURAL]` Record Phase 2 seam progress in redesign doc

## Testing

- New: `TestBackgroundTasksObserveLoopLifecycle` (full lifecycle ordering: start → tool → join → start → end, plus turn-info payload), `TestPrefetchLoopStartsAndRecordsUsage`, `TestAutoDreamTriggersOnNormalLoopExit`
- `internal/agent` + `pkg/agentsdk`: full suites green; `gofmt` and `go vet` clean
- Full-repo run shows only the known environmental failures (root-container unreadable-file/sqlite tests, pre-existing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for background tasks that run during agent turns and when sessions end.
  * Improved prefetch processing and knowledge usage recording after tool execution.
  * Auto-dream consolidation now runs automatically when eligible sessions end.
  * Added lifecycle coordination to ensure background work completes before terminal turns finish.

* **Documentation**
  * Updated modular core redesign status and documented remaining Transport and ContextStrategy work.

* **Tests**
  * Added coverage for background task ordering, prefetching, auto-dream, and terminal-tool behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->