### PR TITLE
Phase 4: examples/embed — compose the core with three seams (executable module-API proof)

### DIFF
--- a/docs/MODULAR_CORE_REDESIGN.md
+++ b/docs/MODULAR_CORE_REDESIGN.md
@@ -185,6 +185,8 @@ Reduce `cmd/rubichan/main.go` to composition only: build core, register modules,
 **Phase 4 — Publish the module API.**
 Document the ~7 seams in `pkg/…` with examples (`examples/` already exists). External apps now embed the **real** core and opt into exactly the modules they want (e.g. a NATS bridge with tools + checkpoint but no TUI).
 
+> **Status update (2026-07): first embedder example landed.** `examples/embed` composes `agent.New` with three seams at once — a custom `ContextStrategy`, a `BackgroundTask`, and a tool-execution middleware — over a self-contained canned provider, running one turn with no TUI/headless/ACP and no API key. A race-clean integration test asserts each module actually fires (the strategy's section reaches the system prompt, the middleware wraps the tool call, the task observes start/join/end), making the "adding a capability adds a module" thesis executable and regression-guarded. **One reachability gap remains, documented in the example:** the registration options (`WithContextStrategies`, `WithBackgroundTasks`, `WithToolMiddlewares`, …) still live on `internal/agent`, so a *different-module* embedder cannot call them yet — the interfaces are already public in `pkg/agentsdk`, but the core constructor must move to `pkg/` (Phase 1's "one loop" end state) to close it. That makes Phase 1 the highest-leverage remaining work: it's what turns "embeddable within this module" into "embeddable by anyone."
+
 Each phase is independently shippable and leaves the product fully working.
 
 ---

--- a/examples/embed/main.go
+++ b/examples/embed/main.go
@@ -1,0 +1,278 @@
+// Command embed is a runnable demonstration of embedding the rubichan
+// agent core in another program and opting into exactly the modules you
+// want — the payoff of the modular-core redesign (docs/MODULAR_CORE_REDESIGN.md).
+//
+// It composes agent.New with three of the seams the redesign introduced,
+// each a small interface in pkg/agentsdk:
+//
+//   - ContextStrategy    — contributes a section to every system prompt
+//   - BackgroundTask     — runs work concurrently with the agent loop
+//   - tool middleware    — wraps every tool execution
+//
+// No TUI, no headless runner, no ACP: just the core loop plus the modules
+// this embedder chose. Adding a capability adds a module, not a core
+// struct field.
+//
+// The example is self-contained — it uses a tiny canned provider so it
+// runs with no API key. In a real embedder you would pass a provider
+// built from internal/provider (Anthropic, OpenAI, Ollama, …) instead.
+//
+// Reachability note: the registration options (WithContextStrategies,
+// WithBackgroundTasks, WithToolMiddlewares) currently live on
+// internal/agent, so an embedder must be inside this module to call them
+// — as this example is. The interfaces they take (agentsdk.ContextStrategy,
+// agentsdk.BackgroundTask, agentsdk.Middleware) are already public and
+// stable in pkg/agentsdk; promoting the core constructor to pkg/ is the
+// remaining step that would let a different module embed it too.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/julianshen/rubichan/internal/agent"
+	"github.com/julianshen/rubichan/internal/config"
+	"github.com/julianshen/rubichan/internal/toolexec"
+	"github.com/julianshen/rubichan/internal/tools"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// sessionMemoryMaxTokens is the MaxTokens the built-in session-memory
+// extraction call uses (see internal/agent/session_memory_service.go). The
+// scripted provider routes those calls to a trivial reply so the async
+// extraction — registered automatically by agent.New — never disturbs the
+// two-response demo script or races on its counter.
+const sessionMemoryMaxTokens = 16384
+
+func main() {
+	if err := run(os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "embed example failed:", err)
+		os.Exit(1)
+	}
+}
+
+// embedder bundles the composed agent with handles to the modules it was
+// given, so both main and the integration test observe the same wiring.
+type embedder struct {
+	agent     *agent.Agent
+	provider  *scriptedProvider
+	strategy  *deploymentWindowStrategy
+	auditor   *sessionAuditor
+	toolCalls *callCounter
+}
+
+// compose wires the core with three modules. This is the whole point of
+// the example: agent.New plus a few Use-style options, no bespoke struct.
+func compose() embedder {
+	// A tool the demo turn will call, so the middleware and the
+	// background-task join both have something to observe.
+	registry := tools.NewRegistry()
+	_ = registry.Register(greetTool{})
+
+	// Module 1 — a ContextStrategy that injects a section into every
+	// system prompt. A real one might pull runbook links, on-call info,
+	// or feature-flag state.
+	deployWindow := &deploymentWindowStrategy{}
+
+	// Module 2 — a BackgroundTask that observes the loop lifecycle.
+	auditor := &sessionAuditor{}
+
+	// Module 3 — a tool-execution middleware that counts calls. A real
+	// one might enforce policy, add tracing, or redact output.
+	toolCalls := &callCounter{}
+	countingMW := func(next toolexec.HandlerFunc) toolexec.HandlerFunc {
+		return func(ctx context.Context, tc toolexec.ToolCall) toolexec.Result {
+			toolCalls.inc()
+			return next(ctx, tc)
+		}
+	}
+
+	provider := cannedProvider()
+	agentCore := agent.New(
+		provider,
+		registry,
+		autoApprove,
+		config.DefaultConfig(),
+		agent.WithContextStrategies(deployWindow),
+		agent.WithBackgroundTasks(auditor),
+		agent.WithToolMiddlewares(agent.ToolMiddlewares{
+			BeforeHooks: []toolexec.Middleware{countingMW},
+		}),
+	)
+
+	return embedder{
+		agent:     agentCore,
+		provider:  provider,
+		strategy:  deployWindow,
+		auditor:   auditor,
+		toolCalls: toolCalls,
+	}
+}
+
+// run composes the embedder, drives one turn, and reports what the modules
+// observed.
+func run(out interface{ Write([]byte) (int, error) }) error {
+	e := compose()
+
+	assistant, err := e.driveTurn(context.Background(), "greet the release team")
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "assistant said: %s\n", assistant)
+	fmt.Fprintf(out, "tool middleware saw %d call(s)\n", e.toolCalls.get())
+	fmt.Fprintf(out, "background task observed: %v\n", e.auditor.events())
+	fmt.Fprintf(out, "context strategy contributed %d time(s)\n", e.strategy.calls())
+	return nil
+}
+
+// driveTurn runs one turn to completion and returns the assistant text.
+func (e embedder) driveTurn(ctx context.Context, msg string) (string, error) {
+	ch, err := e.agent.Turn(ctx, msg)
+	if err != nil {
+		return "", fmt.Errorf("turn: %w", err)
+	}
+	var assistant string
+	for ev := range ch {
+		switch ev.Type {
+		case "text_delta":
+			assistant += ev.Text
+		case "error":
+			if ev.Error != nil {
+				return "", fmt.Errorf("turn error: %w", ev.Error)
+			}
+		}
+	}
+	return assistant, nil
+}
+
+// callCounter is a mutex-guarded counter — tool middleware may run off the
+// turn goroutine when tools execute in parallel.
+type callCounter struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (c *callCounter) inc() { c.mu.Lock(); c.n++; c.mu.Unlock() }
+func (c *callCounter) get() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
+}
+
+// autoApprove approves every tool call — fine for a non-interactive demo.
+func autoApprove(context.Context, string, json.RawMessage) (bool, error) {
+	return true, nil
+}
+
+// deploymentWindowStrategy is a ContextStrategy: it contributes one
+// system-prompt section per turn.
+type deploymentWindowStrategy struct{ n int }
+
+func (s *deploymentWindowStrategy) ContributePromptSections(_ context.Context, _ agentsdk.PromptContext) []agentsdk.PromptSection {
+	s.n++
+	return []agentsdk.PromptSection{{
+		Title:   "Deployment Window",
+		Content: "Production deploys are frozen this week; propose changes but do not apply them.",
+		Reason:  "operational state varies per run",
+	}}
+}
+
+func (s *deploymentWindowStrategy) calls() int { return s.n }
+
+// sessionAuditor is a BackgroundTask: started before each model call,
+// joined after tool execution, and signalled once at session end. Its log
+// is mutex-guarded because EndSession runs on its own goroutine, off the
+// turn's critical path.
+type sessionAuditor struct {
+	mu  sync.Mutex
+	log []string
+}
+
+func (a *sessionAuditor) record(s string) {
+	a.mu.Lock()
+	a.log = append(a.log, s)
+	a.mu.Unlock()
+}
+
+func (a *sessionAuditor) StartTurn(context.Context, agentsdk.BackgroundTurnInfo) func(context.Context) {
+	a.record("start")
+	return func(context.Context) { a.record("join") }
+}
+
+func (a *sessionAuditor) EndSession(context.Context) { a.record("end") }
+
+func (a *sessionAuditor) events() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.log...)
+}
+
+// scriptedProvider is a canned LLMProvider so the example runs with no
+// API key: the first foreground call asks for the greet tool, the second
+// replies with text. It records the system prompts it received so the
+// integration test can confirm the ContextStrategy's section arrived.
+type scriptedProvider struct {
+	mu         sync.Mutex
+	foreground int
+	systems    []string
+}
+
+func cannedProvider() *scriptedProvider { return &scriptedProvider{} }
+
+func (p *scriptedProvider) Stream(_ context.Context, req agentsdk.CompletionRequest) (<-chan agentsdk.StreamEvent, error) {
+	p.mu.Lock()
+	// Route async session-memory extraction calls to a trivial reply.
+	if req.MaxTokens == sessionMemoryMaxTokens {
+		p.mu.Unlock()
+		return streamOf(
+			agentsdk.StreamEvent{Type: "text_delta", Text: "- noted"},
+			agentsdk.StreamEvent{Type: "stop"},
+		), nil
+	}
+	p.systems = append(p.systems, req.System)
+	p.foreground++
+	first := p.foreground == 1
+	p.mu.Unlock()
+
+	if first {
+		return streamOf(
+			agentsdk.StreamEvent{Type: "tool_use", ToolUse: &agentsdk.ToolUseBlock{ID: "call-1", Name: "greet"}},
+			agentsdk.StreamEvent{Type: "text_delta", Text: "{}"},
+			agentsdk.StreamEvent{Type: "stop"},
+		), nil
+	}
+	return streamOf(
+		agentsdk.StreamEvent{Type: "text_delta", Text: "Release team greeted."},
+		agentsdk.StreamEvent{Type: "stop"},
+	), nil
+}
+
+// capturedSystems returns a copy of the system prompts the provider saw.
+func (p *scriptedProvider) capturedSystems() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.systems...)
+}
+
+func streamOf(events ...agentsdk.StreamEvent) <-chan agentsdk.StreamEvent {
+	ch := make(chan agentsdk.StreamEvent, len(events))
+	for _, e := range events {
+		ch <- e
+	}
+	close(ch)
+	return ch
+}
+
+// greetTool is a trivial tool so the demo turn has something to execute.
+type greetTool struct{}
+
+func (greetTool) Name() string                 { return "greet" }
+func (greetTool) Description() string          { return "Greet a named audience." }
+func (greetTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (greetTool) Execute(context.Context, json.RawMessage) (agentsdk.ToolResult, error) {
+	return agentsdk.ToolResult{Content: "greeted the release team"}, nil
+}

--- a/examples/embed/main.go
+++ b/examples/embed/main.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/julianshen/rubichan/internal/agent"
 	"github.com/julianshen/rubichan/internal/config"
@@ -122,6 +123,12 @@ func run(out interface{ Write([]byte) (int, error) }) error {
 		return err
 	}
 
+	// EndSession fires on its own goroutine after the loop exits, so the
+	// turn channel closing does not guarantee "end" has been recorded yet.
+	// Wait for it so the summary shows the full start/join/end lifecycle
+	// the example is meant to demonstrate.
+	e.auditor.waitForEnd(2 * time.Second)
+
 	fmt.Fprintf(out, "assistant said: %s\n", assistant)
 	fmt.Fprintf(out, "tool middleware saw %d call(s)\n", e.toolCalls.get())
 	fmt.Fprintf(out, "background task observed: %v\n", e.auditor.events())
@@ -209,6 +216,21 @@ func (a *sessionAuditor) events() []string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return append([]string(nil), a.log...)
+}
+
+// waitForEnd blocks until EndSession has been recorded or timeout elapses,
+// so callers can report the completed lifecycle.
+func (a *sessionAuditor) waitForEnd(timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		a.mu.Lock()
+		ended := len(a.log) > 0 && a.log[len(a.log)-1] == "end"
+		a.mu.Unlock()
+		if ended {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 }
 
 // scriptedProvider is a canned LLMProvider so the example runs with no

--- a/examples/embed/main_test.go
+++ b/examples/embed/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmbedderComposesThreeSeams is the example's reason for existing: it
+// proves the three modules an embedder opts into actually compose and fire
+// during a real turn against the core loop.
+func TestEmbedderComposesThreeSeams(t *testing.T) {
+	e := compose()
+
+	assistant, err := e.driveTurn(context.Background(), "greet the release team")
+	require.NoError(t, err)
+	assert.Equal(t, "Release team greeted.", assistant)
+
+	// Tool middleware wrapped the one tool call the script asked for.
+	assert.Equal(t, 1, e.toolCalls.get(), "tool middleware must wrap the tool execution")
+
+	// ContextStrategy: its section reached the system prompt the provider
+	// received — the strategy genuinely contributed to prompt construction,
+	// not just to a counter.
+	require.NotEmpty(t, e.provider.capturedSystems())
+	var sawSection bool
+	for _, sys := range e.provider.capturedSystems() {
+		if strings.Contains(sys, "Deployment Window") &&
+			strings.Contains(sys, "deploys are frozen") {
+			sawSection = true
+		}
+	}
+	assert.True(t, sawSection, "ContextStrategy section must appear in the system prompt")
+	assert.GreaterOrEqual(t, e.strategy.calls(), 1)
+
+	// BackgroundTask observed the full lifecycle. EndSession fires on its
+	// own goroutine after the loop exits, so wait for it.
+	require.Eventually(t, func() bool {
+		ev := e.auditor.events()
+		return len(ev) > 0 && ev[len(ev)-1] == "end"
+	}, 2*time.Second, 10*time.Millisecond, "EndSession must fire after the loop exits")
+
+	ev := e.auditor.events()
+	assert.Contains(t, ev, "start", "BackgroundTask must be started before a model call")
+	assert.Contains(t, ev, "join", "BackgroundTask must be joined after tool execution")
+	assert.Contains(t, ev, "end", "BackgroundTask must be signalled at session end")
+}
+
+// TestRunPrintsModuleObservations is a lightweight smoke test that the
+// runnable entrypoint executes end to end without error.
+func TestRunPrintsModuleObservations(t *testing.T) {
+	var buf strings.Builder
+	require.NoError(t, run(&buf))
+	out := buf.String()
+	assert.Contains(t, out, "assistant said: Release team greeted.")
+	assert.Contains(t, out, "tool middleware saw 1 call")
+}

--- a/examples/embed/main_test.go
+++ b/examples/embed/main_test.go
@@ -58,4 +58,7 @@ func TestRunPrintsModuleObservations(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "assistant said: Release team greeted.")
 	assert.Contains(t, out, "tool middleware saw 1 call")
+	// run must wait for EndSession so the summary shows the full lifecycle,
+	// not race ahead of the async "end" callback.
+	assert.Contains(t, out, "background task observed: [start join start end]")
 }


### PR DESCRIPTION
## Summary

With Phase 2 complete (all four seams shipped), this opens **Phase 4** — publishing the module API — with the first thing the redesign has lacked all along: an **executable proof that the seams actually compose**. `examples/` previously held only skills and CI configs; there was no Go embedder demonstrating the module API, and none of the four seams were exercised by any example.

`examples/embed` composes `agent.New` with three modules at once:

- a custom **`ContextStrategy`** (injects a "Deployment Window" section into every system prompt)
- a custom **`BackgroundTask`** (observes the loop lifecycle: start → join → end)
- a custom **tool-execution middleware** (counts calls)

…over a **self-contained canned provider**, running one turn with no TUI, no headless runner, no ACP, and no API key. It's the "adding a capability adds a module, not a core struct field" thesis made runnable.

## Why this is the right next step (and why not Phase 1/3 yet)

- **Phase 1 (one loop):** `internal/agent.runLoop` is still ~600 lines — the doc's own gate for safe loop unification ("small enough to converge") isn't met, so it stays premature.
- **Phase 3 (main.go teardown):** main.go is 3383 lines, deeply coupled to package-global cobra flags, and its test signal is compromised by the known environmental failures — high-risk terrain that doesn't fit the campaign's surgical, well-tested pattern.
- **This (Phase 4 example):** purely additive, zero risk to existing behavior, fully testable, and it validates the entire campaign's thesis in one place. Best value/risk ratio available right now.

## Honest reachability note (documented in the example)

The registration options (`WithContextStrategies`, `WithBackgroundTasks`, `WithToolMiddlewares`) still live on `internal/agent`, so a **different-module** embedder can't call them yet — this example works because it's inside the module. The *interfaces* they take are already public and stable in `pkg/agentsdk`. Closing the gap means promoting the core constructor to `pkg/` — which is exactly **Phase 1's end state**, making Phase 1 the highest-leverage remaining work. This is stated in the package doc and the design-doc status note rather than glossed over.

## Testing

- `TestEmbedderComposesThreeSeams` (**race-clean**): asserts the strategy's section reaches the system prompt the provider receives, the middleware wraps the tool call, and the background task observes start/join/end (EndSession awaited, since it fires async).
- `TestRunPrintsModuleObservations`: smoke-tests the runnable entrypoint end to end.
- `go build ./...`, `gofmt`, `go vet` clean; `./examples/...` green.

## Commits

1. `[BEHAVIORAL]` Add examples/embed: compose the core with three seams
2. `[STRUCTURAL]` Record the embedder example under Phase 4 in the redesign doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_