### PR TITLE
Extract streamWithRecovery from runLoop (loop convergence, slice 1)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -26,7 +26,6 @@ import (
 	"github.com/julianshen/rubichan/internal/knowledgegraph"
 	"github.com/julianshen/rubichan/internal/persona"
 	"github.com/julianshen/rubichan/internal/provider"
-	"github.com/julianshen/rubichan/internal/provider/normalize"
 	"github.com/julianshen/rubichan/internal/skills"
 	"github.com/julianshen/rubichan/internal/store"
 	"github.com/julianshen/rubichan/internal/text"
@@ -1505,115 +1504,14 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		// first non-empty value; empty means "use provider default."
 		req.Capabilities.ReasoningEffort = a.latches.latchReasoningEffort(a.capabilities.ReasoningEffort)
 
-		if a.rateLimiter != nil {
-			if !a.rateLimiter.AllowNow() {
-				a.emit(ctx, ch, TurnEvent{Type: "rate_limited"})
-			}
-			if err := a.rateLimiter.Wait(ctx); err != nil {
-				a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("rate limiter: %w", err)})
-				a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitRateLimited))
-				return
-			}
+		stream, callOutcome := a.streamWithRecovery(ctx, ch, ls, req, totalInputTokens, totalOutputTokens)
+		if callOutcome == providerCallRetryTurn {
+			continue
 		}
-
-		retryCfg := TurnRetryConfig{
-			Source: agentsdk.QuerySourceForeground, // user-facing query
-		}
-		// Providers that implement NonStreamer get a non-streaming
-		// fallback wired in automatically. TurnRetry only invokes it
-		// after all streaming attempts exhaust with retryable errors,
-		// so the common path still hits the streaming endpoint first.
-		if ns, ok := a.provider.(NonStreamer); ok {
-			reqCopy := req
-			retryCfg.NonStreamFallback = func(ctx context.Context) ([]provider.StreamEvent, error) {
-				return ns.NonStream(ctx, reqCopy)
-			}
-		}
-		onRetry := func(attempt int, delay time.Duration, cause error) {
-			a.emit(ctx, ch, TurnEvent{
-				Type:  "retrying",
-				Error: fmt.Errorf("attempt %d after %s: %w", attempt, delay, cause),
-			})
-		}
-		stream, err := TurnRetry(ctx, retryCfg, func(ctx context.Context) (<-chan provider.StreamEvent, error) {
-			return a.provider.Stream(ctx, req)
-		}, onRetry)
-		if err != nil {
-			class := errorclass.Classify(err)
-			a.logger.Warn("provider error classified as %s: %v", class, err)
-
-			if class == errorclass.ClassPromptTooLong || class == errorclass.ClassMaxOutputTokens {
-				ls.withheldErrors.Add(class, err)
-				if a.attemptRecovery(ctx, ch, ls, class, nil) {
-					ls.withheldErrors.MarkRecovered(class)
-					ls.turnCount--
-					if class == errorclass.ClassPromptTooLong {
-						ls.lastContinueReason = ContinuePromptTooLongRetry
-					} else {
-						ls.lastContinueReason = ContinueMaxTokensRecovery
-					}
-					continue
-				}
-				// Recovery exhausted — surface the withheld error with class context
-				// so consumers can distinguish prompt-too-long from max_tokens without parsing strings.
-				lastErr, ok := ls.withheldErrors.LastUnrecovered()
-				if ok {
-					a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream (%s): %w", lastErr.Class, lastErr.Err)})
-				} else {
-					// Buffer was cleared or marked recovered unexpectedly — still emit the original error
-					// so the consumer always sees an error before done on failed recovery.
-					a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream (%s): %w", class, err)})
-				}
-				ls.withheldErrors.Clear()
-				exitReason := agentsdk.ExitContextOverflow
-				if class == errorclass.ClassMaxOutputTokens {
-					exitReason = agentsdk.ExitMaxOutputTokens
-				}
-				a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, exitReason))
-				return
-			}
-
-			if class == errorclass.ClassModelOverloaded && a.fallbackModel != "" {
-				a.logger.Warn("primary model overloaded; retrying with fallback model %s", a.fallbackModel)
-				a.emit(ctx, ch, TurnEvent{Type: "model_fallback", Model: a.fallbackModel})
-
-				// Tombstone partial messages from the failed attempt so they
-				// don't pollute the fallback model's context.
-				tombstonedCount := a.conversation.TombstoneSinceLastAssistant(agentsdk.TombstoneReasonModelFallback)
-				if tombstonedCount > 0 {
-					a.logger.Warn("tombstoned %d partial messages before fallback", tombstonedCount)
-				}
-
-				fallbackReq := req
-				fallbackReq.Model = a.fallbackModel
-				fallbackReq.Messages = normalize.FilterTombstoned(stripThinkingBlocks(req.Messages))
-				fallbackRetryCfg := TurnRetryConfig{}
-				if ns, ok := a.provider.(NonStreamer); ok {
-					fbReq := fallbackReq
-					fallbackRetryCfg.NonStreamFallback = func(ctx context.Context) ([]provider.StreamEvent, error) {
-						return ns.NonStream(ctx, fbReq)
-					}
-				}
-				var fallbackErr error
-				stream, fallbackErr = TurnRetry(ctx, fallbackRetryCfg, func(ctx context.Context) (<-chan provider.StreamEvent, error) {
-					return a.provider.Stream(ctx, fallbackReq)
-				}, onRetry)
-				if fallbackErr == nil {
-					ls.lastContinueReason = ContinueModelFallback
-					goto processStream
-				}
-				a.logger.Warn("fallback model also failed: %v", fallbackErr)
-				a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream (fallback): %w", fallbackErr)})
-				a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError))
-				return
-			}
-
-			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream: %w", err)})
-			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError))
+		if callOutcome == providerCallEnded {
 			return
 		}
 
-	processStream:
 		// Accumulate assistant content blocks and track tool calls via the
 		// shared StreamAccumulator (pkg/agentsdk).
 		ls.resetPerTurn()

--- a/internal/agent/provider_call.go
+++ b/internal/agent/provider_call.go
@@ -1,0 +1,152 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/julianshen/rubichan/internal/agent/errorclass"
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/provider/normalize"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// providerCallOutcome tells runLoop how to proceed after a provider call.
+type providerCallOutcome int
+
+const (
+	// providerCallProceed: the stream is ready; process it.
+	providerCallProceed providerCallOutcome = iota
+	// providerCallRetryTurn: a recovery action (compaction, token bump)
+	// mutated loop state; re-enter the loop without consuming a turn. The
+	// callee has already decremented ls.turnCount to cancel the loop's
+	// post-statement increment and set ls.lastContinueReason.
+	providerCallRetryTurn
+	// providerCallEnded: a terminal failure was emitted (error followed by
+	// done); runLoop must return.
+	providerCallEnded
+)
+
+// streamWithRecovery performs the foreground model call for one loop
+// iteration: rate limiting, streaming with retry (and a non-streaming
+// fallback for providers that support it), error classification, in-loop
+// recovery for prompt-too-long / max-output-tokens, and the overloaded-model
+// fallback. This is the recovery state machine the design doc contrasts with
+// the SDK loop's simple overflow check — extracted from runLoop so the loop
+// reads as orchestration and this machine can be reasoned about (and one day
+// seamed) in isolation.
+//
+// The returned stream is non-nil only for providerCallProceed. Terminal
+// paths emit their own error and done events before returning; totals are
+// passed in solely so those done events carry accurate token usage.
+func (a *Agent) streamWithRecovery(ctx context.Context, ch chan<- TurnEvent, ls *loopState, req provider.CompletionRequest, totalInputTokens, totalOutputTokens int) (<-chan provider.StreamEvent, providerCallOutcome) {
+	if a.rateLimiter != nil {
+		if !a.rateLimiter.AllowNow() {
+			a.emit(ctx, ch, TurnEvent{Type: "rate_limited"})
+		}
+		if err := a.rateLimiter.Wait(ctx); err != nil {
+			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("rate limiter: %w", err)})
+			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitRateLimited))
+			return nil, providerCallEnded
+		}
+	}
+
+	retryCfg := TurnRetryConfig{
+		Source: agentsdk.QuerySourceForeground, // user-facing query
+	}
+	// Providers that implement NonStreamer get a non-streaming
+	// fallback wired in automatically. TurnRetry only invokes it
+	// after all streaming attempts exhaust with retryable errors,
+	// so the common path still hits the streaming endpoint first.
+	if ns, ok := a.provider.(NonStreamer); ok {
+		reqCopy := req
+		retryCfg.NonStreamFallback = func(ctx context.Context) ([]provider.StreamEvent, error) {
+			return ns.NonStream(ctx, reqCopy)
+		}
+	}
+	onRetry := func(attempt int, delay time.Duration, cause error) {
+		a.emit(ctx, ch, TurnEvent{
+			Type:  "retrying",
+			Error: fmt.Errorf("attempt %d after %s: %w", attempt, delay, cause),
+		})
+	}
+	stream, err := TurnRetry(ctx, retryCfg, func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+		return a.provider.Stream(ctx, req)
+	}, onRetry)
+	if err != nil {
+		class := errorclass.Classify(err)
+		a.logger.Warn("provider error classified as %s: %v", class, err)
+
+		if class == errorclass.ClassPromptTooLong || class == errorclass.ClassMaxOutputTokens {
+			ls.withheldErrors.Add(class, err)
+			if a.attemptRecovery(ctx, ch, ls, class, nil) {
+				ls.withheldErrors.MarkRecovered(class)
+				ls.turnCount--
+				if class == errorclass.ClassPromptTooLong {
+					ls.lastContinueReason = ContinuePromptTooLongRetry
+				} else {
+					ls.lastContinueReason = ContinueMaxTokensRecovery
+				}
+				return nil, providerCallRetryTurn
+			}
+			// Recovery exhausted — surface the withheld error with class context
+			// so consumers can distinguish prompt-too-long from max_tokens without parsing strings.
+			lastErr, ok := ls.withheldErrors.LastUnrecovered()
+			if ok {
+				a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream (%s): %w", lastErr.Class, lastErr.Err)})
+			} else {
+				// Buffer was cleared or marked recovered unexpectedly — still emit the original error
+				// so the consumer always sees an error before done on failed recovery.
+				a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream (%s): %w", class, err)})
+			}
+			ls.withheldErrors.Clear()
+			exitReason := agentsdk.ExitContextOverflow
+			if class == errorclass.ClassMaxOutputTokens {
+				exitReason = agentsdk.ExitMaxOutputTokens
+			}
+			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, exitReason))
+			return nil, providerCallEnded
+		}
+
+		if class == errorclass.ClassModelOverloaded && a.fallbackModel != "" {
+			a.logger.Warn("primary model overloaded; retrying with fallback model %s", a.fallbackModel)
+			a.emit(ctx, ch, TurnEvent{Type: "model_fallback", Model: a.fallbackModel})
+
+			// Tombstone partial messages from the failed attempt so they
+			// don't pollute the fallback model's context.
+			tombstonedCount := a.conversation.TombstoneSinceLastAssistant(agentsdk.TombstoneReasonModelFallback)
+			if tombstonedCount > 0 {
+				a.logger.Warn("tombstoned %d partial messages before fallback", tombstonedCount)
+			}
+
+			fallbackReq := req
+			fallbackReq.Model = a.fallbackModel
+			fallbackReq.Messages = normalize.FilterTombstoned(stripThinkingBlocks(req.Messages))
+			fallbackRetryCfg := TurnRetryConfig{}
+			if ns, ok := a.provider.(NonStreamer); ok {
+				fbReq := fallbackReq
+				fallbackRetryCfg.NonStreamFallback = func(ctx context.Context) ([]provider.StreamEvent, error) {
+					return ns.NonStream(ctx, fbReq)
+				}
+			}
+			var fallbackErr error
+			stream, fallbackErr = TurnRetry(ctx, fallbackRetryCfg, func(ctx context.Context) (<-chan provider.StreamEvent, error) {
+				return a.provider.Stream(ctx, fallbackReq)
+			}, onRetry)
+			if fallbackErr == nil {
+				ls.lastContinueReason = ContinueModelFallback
+				return stream, providerCallProceed
+			}
+			a.logger.Warn("fallback model also failed: %v", fallbackErr)
+			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream (fallback): %w", fallbackErr)})
+			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError))
+			return nil, providerCallEnded
+		}
+
+		a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream: %w", err)})
+		a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError))
+		return nil, providerCallEnded
+	}
+
+	return stream, providerCallProceed
+}


### PR DESCRIPTION
## Summary

First slice of the **shrink-before-converge** plan for Phase 1's "exactly one loop" end state.

Measurement that motivated it: after all of Phase 2, `internal/agent.runLoop` was still **600 lines** (vs. the SDK loop's 82) — the seams changed where extension points register, not the loop's inline orchestration. Converging today would mean either growing the SDK loop with `internal/`-importing code (tripping the #312 guard) or a big-bang rewrite — both explicitly warned against in the design doc. So the path is extracting cohesive collaborators out of `runLoop` one per PR until what remains is small enough to converge safely.

## What moved

`streamWithRecovery` (new `internal/agent/provider_call.go`) now owns the foreground provider-call machinery, extracted verbatim from `runLoop`:

- rate limiting (`rate_limited` event, `ExitRateLimited` termination)
- `TurnRetry` with the automatic `NonStreamer` non-streaming fallback
- error classification (`errorclass.Classify`)
- prompt-too-long / max-output-tokens **recovery** via `withheldErrors` + `attemptRecovery`, including the recovery-exhausted surfacing rules
- the **overloaded-model fallback** (tombstoning partial messages, thinking-block stripping, fallback retry)

It returns `(stream, outcome)` with a three-way outcome: **proceed** (process the stream), **retry turn** (recovery mutated state; re-enter the loop without consuming a turn), **ended** (terminal error + done already emitted).

`runLoop` keeps the request build and a two-line dispatch. **600 → 499 lines.**

## Semantics preserved — two spots worth a reviewer's attention

1. **The goto is gone.** The overloaded-fallback success path used `goto processStream`; as an extracted function it's an ordinary `providerCallProceed` return, and the label is deleted (it had exactly one referent).
2. **Retry-turn accounting is unchanged.** The original did `ls.turnCount--; continue`, netting to an unconsumed turn via the loop's post-statement increment. The decrement stays in the callee; the `continue` stays in `runLoop` — same net effect, documented on the outcome constant.

## Verification

No behavior change intended, validated per Tidy-First: `internal/agent` (full, 27.5s), `internal/modes/...`, `test/e2e`, and `pkg/agentsdk` suites green **before and after**. `gofmt`/`go vet`/`go build ./...` clean. One commit, `[STRUCTURAL]`.

## Next slices (separate PRs)

Post-stream assembly (~135 lines: max_tokens continuation, truncated-tool detection, thinking blocks, XML tool parsing), then stream consumption, then tool-execution/budget tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of temporary provider failures with automatic retries.
  - Added more reliable recovery for prompts that are too long or exceed output limits.
  - Improved behavior when models are overloaded by automatically switching to a configured fallback model.
  - Enhanced error reporting and completion handling when requests cannot continue.
  - Added clearer rate-limit handling during provider requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->