### PR TITLE
Extract assembleAssistantTurn from runLoop (loop convergence, slice 2)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1505,10 +1505,10 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		req.Capabilities.ReasoningEffort = a.latches.latchReasoningEffort(a.capabilities.ReasoningEffort)
 
 		stream, callOutcome := a.streamWithRecovery(ctx, ch, ls, req, totalInputTokens, totalOutputTokens)
-		if callOutcome == providerCallRetryTurn {
+		if callOutcome == stepRetryTurn {
 			continue
 		}
-		if callOutcome == providerCallEnded {
+		if callOutcome == stepEnded {
 			return
 		}
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1637,142 +1637,14 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			}
 		}
 
-		// Handle max_tokens truncation: inject a continuation message and
-		// retry so the model can complete its response, up to
-		// maxOutputTokensRecoveryLimit times. Only retry when there are no
-		// pending tool calls; otherwise the truncated-tool detection below
-		// handles it.
-		if stopReason == agentsdk.StopReasonMaxTokens {
-			hasPendingTools := len(acc.PendingTools()) > 0 || acc.HasPartialTool()
-			if hasPendingTools {
-				a.logger.Warn("response hit output token limit with %d pending tool calls; tool arguments may be truncated", len(acc.PendingTools()))
-			} else if ls.maxOutputTokens < escalatedMaxOutputTokens {
-				a.logger.Warn("output token limit hit; escalating max_tokens from %d to %d", ls.maxOutputTokens, escalatedMaxOutputTokens)
-				a.escalateMaxTokens(ls)
-				a.emit(ctx, ch, TurnEvent{Type: "max_tokens_escalation"})
-				ls.turnCount--
-				ls.lastContinueReason = ContinueMaxTokensRecovery
-				continue
-			} else if ls.maxTokensRecoveryAttempts < maxOutputTokensRecoveryLimit {
-				ls.maxTokensRecoveryAttempts++
-				// Finalize buffered text so the truncated partial response is
-				// retained in history — the continuation prompt is meaningless
-				// if the model can't see what it already wrote. No partial tool
-				// can exist here: this branch requires hasPendingTools == false.
-				acc.Finish()
-				partialBlocks := acc.Blocks()
-				a.conversation.AddAssistant(partialBlocks)
-				a.persistMessage("assistant", partialBlocks)
-				a.conversation.AddUser(fmt.Sprintf(
-					"[max_output_tokens recovery %d/%d] Continue your response from where you left off.",
-					ls.maxTokensRecoveryAttempts, maxOutputTokensRecoveryLimit))
-				a.emit(ctx, ch, TurnEvent{Type: "max_tokens_recovery"})
-				a.saveSnapshotIfNeeded()
-				ls.turnCount--
-				ls.lastContinueReason = ContinueMaxTokensRecovery
-				continue
-			} else {
-				a.logger.Warn("response truncated by output token limit after %d recovery attempts", ls.maxTokensRecoveryAttempts)
-			}
+		asm, asmOutcome := a.assembleAssistantTurn(ctx, ch, ls, acc, execStream, thinkingBuf, stopReason, useNativeTools, totalInputTokens, totalOutputTokens)
+		if asmOutcome == stepRetryTurn {
+			continue
 		}
-
-		// Capture accumulated text before finalizing, for text-based tool extraction.
-		accumulatedText := acc.CurrentText()
-
-		// Detect truncated tool calls: if the stream ended with a partially
-		// accumulated tool whose input JSON is invalid, discard it and warn.
-		if acc.DropInvalidPartialTool() {
-			a.emit(ctx, ch, TurnEvent{Type: "text_delta", Text: "\n⚠️ Tool call truncated by output limit.\n"})
-		}
-
-		// Finalize any remaining text or tool.
-		acc.Finish()
-		blocks := acc.Blocks()
-		pendingTools := acc.PendingTools()
-
-		// Prepend thinking block if the model produced extended thinking output.
-		if thinkingBuf != "" {
-			blocks = append([]provider.ContentBlock{{
-				Type: agentsdk.BlockTypeThinking,
-				Text: thinkingBuf,
-			}}, blocks...)
-		}
-
-		// On stream error, discard partial blocks to prevent conversation
-		// corruption but surface any completed streaming dispatches to the
-		// event channel. executeSingleTool emits tool_progress events as
-		// the tool runs; if we don't also emit a matching tool_call +
-		// tool_result, the UI sees orphan progress with no terminal event.
-		if ls.streamErr {
-			if unmatched := surfaceStreamedResults(ctx, a, ch, pendingTools, execStream.Drain()); unmatched > 0 {
-				// Invariant broken: every dispatched tool should have been
-				// appended to pendingTools before Dispatch ran. If this
-				// fires, a future refactor reordered the Dispatch site.
-				a.logger.Warn("streamErr: %d drained tool result(s) had IDs not in pendingTools; tool_call events were skipped", unmatched)
-			}
-			// Defensive: currently a no-op because AddAssistant has not been called
-			// yet on this path, but protects against future reorderings.
-			synthesizeMissingToolResults(a.conversation, orphanReasonStreamError)
-			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError))
+		if asmOutcome == stepEnded {
 			return
 		}
-
-		// For non-native models, parse <tool_use> XML blocks from the text response
-		// and inject them into pendingTools so the normal execution path handles them.
-		if !useNativeTools && len(pendingTools) == 0 && accumulatedText != "" {
-			textCalls := tools.ParseTextToolCalls(accumulatedText)
-			if len(textCalls) == 0 && strings.Contains(accumulatedText, "<tool_use>") {
-				a.logger.Warn("model attempted tool call in text but XML parsing found no valid blocks")
-			}
-			if len(textCalls) > 0 {
-				// Strip <tool_use> XML from the text block so the model
-				// doesn't see its own XML format echoed back on the next turn.
-				for i := range blocks {
-					if blocks[i].Type == "text" {
-						blocks[i].Text = strings.TrimSpace(tools.StripToolUseXML(blocks[i].Text))
-					}
-				}
-			}
-			for _, tc := range textCalls {
-				pendingTools = append(pendingTools, tc)
-				blocks = append(blocks, provider.ContentBlock{
-					Type:  "tool_use",
-					ID:    tc.ID,
-					Name:  tc.Name,
-					Input: tc.Input,
-				})
-			}
-		}
-
-		// If the LLM returned no content at all (no text, no tool calls),
-		// emit an error and add a placeholder assistant message to keep the
-		// conversation valid (every user message must be followed by an
-		// assistant message). The placeholder downgrades the exit reason
-		// from ExitCompleted to ExitEmptyResponse so observability can
-		// distinguish "model said nothing" from "model finished normally".
-		exitReason := agentsdk.ExitCompleted
-		if len(blocks) == 0 && len(pendingTools) == 0 {
-			blocks = append(blocks, provider.ContentBlock{Type: "text", Text: emptyModelResponseText})
-			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("empty response from model")})
-			exitReason = agentsdk.ExitEmptyResponse
-		}
-
-		// On final-response turns, give HookOnAfterResponse handlers a chance
-		// to rewrite the assistant text before it's persisted. The streamed
-		// text already reached the user, but the persisted version is what
-		// subsequent turns see in conversation context — that's the surface
-		// transform skills target. A turn is final on either no-pending-tools
-		// (clean completion) or when task_complete is in the pending batch.
-		finalReason, isFinal := terminalExitReason(pendingTools, exitReason)
-		if isFinal {
-			blocks = a.applyAfterResponseHook(ctx, blocks, finalReason)
-		}
-
-		// Add assistant message with accumulated blocks
-		if len(blocks) > 0 {
-			a.conversation.AddAssistant(blocks)
-			a.persistMessage("assistant", blocks)
-		}
+		blocks, pendingTools, exitReason := asm.blocks, asm.pendingTools, asm.exitReason
 
 		if blocked := a.runStopHooks(ctx, ch, ls, blocks, pendingTools, exitReason, totalInputTokens, totalOutputTokens); blocked {
 			return

--- a/internal/agent/assemble_turn.go
+++ b/internal/agent/assemble_turn.go
@@ -1,0 +1,173 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/tools"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// assembledTurn is what runLoop needs from a completed stream: the assistant
+// content blocks (already committed to the conversation and persisted), the
+// tool calls awaiting execution, and the exit reason a clean terminal path
+// should report for this turn.
+type assembledTurn struct {
+	blocks       []provider.ContentBlock
+	pendingTools []provider.ToolUseBlock
+	exitReason   agentsdk.TurnExitReason
+}
+
+// assembleAssistantTurn turns a consumed stream into a committed assistant
+// message: max-output-tokens recovery (escalation, then continuation
+// prompts), truncated-tool cleanup, thinking-block prepending, stream-error
+// terminalization, text-based tool extraction for non-native models, the
+// empty-response placeholder, the after-response hook, and finally the
+// conversation commit. Extracted from runLoop so the loop reads as
+// orchestration; behavior is unchanged.
+//
+// The result is meaningful only for stepProceed. stepRetryTurn means a
+// recovery mutated loop state and the turn must re-enter without being
+// consumed; stepEnded means terminal events were already emitted.
+func (a *Agent) assembleAssistantTurn(ctx context.Context, ch chan<- TurnEvent, ls *loopState, acc *agentsdk.StreamAccumulator, execStream *streamingToolExecutor, thinkingBuf, stopReason string, useNativeTools bool, totalInputTokens, totalOutputTokens int) (assembledTurn, loopStepOutcome) {
+	// Handle max_tokens truncation: inject a continuation message and
+	// retry so the model can complete its response, up to
+	// maxOutputTokensRecoveryLimit times. Only retry when there are no
+	// pending tool calls; otherwise the truncated-tool detection below
+	// handles it.
+	if stopReason == agentsdk.StopReasonMaxTokens {
+		hasPendingTools := len(acc.PendingTools()) > 0 || acc.HasPartialTool()
+		if hasPendingTools {
+			a.logger.Warn("response hit output token limit with %d pending tool calls; tool arguments may be truncated", len(acc.PendingTools()))
+		} else if ls.maxOutputTokens < escalatedMaxOutputTokens {
+			a.logger.Warn("output token limit hit; escalating max_tokens from %d to %d", ls.maxOutputTokens, escalatedMaxOutputTokens)
+			a.escalateMaxTokens(ls)
+			a.emit(ctx, ch, TurnEvent{Type: "max_tokens_escalation"})
+			ls.turnCount--
+			ls.lastContinueReason = ContinueMaxTokensRecovery
+			return assembledTurn{}, stepRetryTurn
+		} else if ls.maxTokensRecoveryAttempts < maxOutputTokensRecoveryLimit {
+			ls.maxTokensRecoveryAttempts++
+			// Finalize buffered text so the truncated partial response is
+			// retained in history — the continuation prompt is meaningless
+			// if the model can't see what it already wrote. No partial tool
+			// can exist here: this branch requires hasPendingTools == false.
+			acc.Finish()
+			partialBlocks := acc.Blocks()
+			a.conversation.AddAssistant(partialBlocks)
+			a.persistMessage("assistant", partialBlocks)
+			a.conversation.AddUser(fmt.Sprintf(
+				"[max_output_tokens recovery %d/%d] Continue your response from where you left off.",
+				ls.maxTokensRecoveryAttempts, maxOutputTokensRecoveryLimit))
+			a.emit(ctx, ch, TurnEvent{Type: "max_tokens_recovery"})
+			a.saveSnapshotIfNeeded()
+			ls.turnCount--
+			ls.lastContinueReason = ContinueMaxTokensRecovery
+			return assembledTurn{}, stepRetryTurn
+		} else {
+			a.logger.Warn("response truncated by output token limit after %d recovery attempts", ls.maxTokensRecoveryAttempts)
+		}
+	}
+
+	// Capture accumulated text before finalizing, for text-based tool extraction.
+	accumulatedText := acc.CurrentText()
+
+	// Detect truncated tool calls: if the stream ended with a partially
+	// accumulated tool whose input JSON is invalid, discard it and warn.
+	if acc.DropInvalidPartialTool() {
+		a.emit(ctx, ch, TurnEvent{Type: "text_delta", Text: "\n⚠️ Tool call truncated by output limit.\n"})
+	}
+
+	// Finalize any remaining text or tool.
+	acc.Finish()
+	blocks := acc.Blocks()
+	pendingTools := acc.PendingTools()
+
+	// Prepend thinking block if the model produced extended thinking output.
+	if thinkingBuf != "" {
+		blocks = append([]provider.ContentBlock{{
+			Type: agentsdk.BlockTypeThinking,
+			Text: thinkingBuf,
+		}}, blocks...)
+	}
+
+	// On stream error, discard partial blocks to prevent conversation
+	// corruption but surface any completed streaming dispatches to the
+	// event channel. executeSingleTool emits tool_progress events as
+	// the tool runs; if we don't also emit a matching tool_call +
+	// tool_result, the UI sees orphan progress with no terminal event.
+	if ls.streamErr {
+		if unmatched := surfaceStreamedResults(ctx, a, ch, pendingTools, execStream.Drain()); unmatched > 0 {
+			// Invariant broken: every dispatched tool should have been
+			// appended to pendingTools before Dispatch ran. If this
+			// fires, a future refactor reordered the Dispatch site.
+			a.logger.Warn("streamErr: %d drained tool result(s) had IDs not in pendingTools; tool_call events were skipped", unmatched)
+		}
+		// Defensive: currently a no-op because AddAssistant has not been called
+		// yet on this path, but protects against future reorderings.
+		synthesizeMissingToolResults(a.conversation, orphanReasonStreamError)
+		a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError))
+		return assembledTurn{}, stepEnded
+	}
+
+	// For non-native models, parse <tool_use> XML blocks from the text response
+	// and inject them into pendingTools so the normal execution path handles them.
+	if !useNativeTools && len(pendingTools) == 0 && accumulatedText != "" {
+		textCalls := tools.ParseTextToolCalls(accumulatedText)
+		if len(textCalls) == 0 && strings.Contains(accumulatedText, "<tool_use>") {
+			a.logger.Warn("model attempted tool call in text but XML parsing found no valid blocks")
+		}
+		if len(textCalls) > 0 {
+			// Strip <tool_use> XML from the text block so the model
+			// doesn't see its own XML format echoed back on the next turn.
+			for i := range blocks {
+				if blocks[i].Type == "text" {
+					blocks[i].Text = strings.TrimSpace(tools.StripToolUseXML(blocks[i].Text))
+				}
+			}
+		}
+		for _, tc := range textCalls {
+			pendingTools = append(pendingTools, tc)
+			blocks = append(blocks, provider.ContentBlock{
+				Type:  "tool_use",
+				ID:    tc.ID,
+				Name:  tc.Name,
+				Input: tc.Input,
+			})
+		}
+	}
+
+	// If the LLM returned no content at all (no text, no tool calls),
+	// emit an error and add a placeholder assistant message to keep the
+	// conversation valid (every user message must be followed by an
+	// assistant message). The placeholder downgrades the exit reason
+	// from ExitCompleted to ExitEmptyResponse so observability can
+	// distinguish "model said nothing" from "model finished normally".
+	exitReason := agentsdk.ExitCompleted
+	if len(blocks) == 0 && len(pendingTools) == 0 {
+		blocks = append(blocks, provider.ContentBlock{Type: "text", Text: emptyModelResponseText})
+		a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("empty response from model")})
+		exitReason = agentsdk.ExitEmptyResponse
+	}
+
+	// On final-response turns, give HookOnAfterResponse handlers a chance
+	// to rewrite the assistant text before it's persisted. The streamed
+	// text already reached the user, but the persisted version is what
+	// subsequent turns see in conversation context — that's the surface
+	// transform skills target. A turn is final on either no-pending-tools
+	// (clean completion) or when task_complete is in the pending batch.
+	finalReason, isFinal := terminalExitReason(pendingTools, exitReason)
+	if isFinal {
+		blocks = a.applyAfterResponseHook(ctx, blocks, finalReason)
+	}
+
+	// Add assistant message with accumulated blocks
+	if len(blocks) > 0 {
+		a.conversation.AddAssistant(blocks)
+		a.persistMessage("assistant", blocks)
+	}
+
+	return assembledTurn{blocks: blocks, pendingTools: pendingTools, exitReason: exitReason}, stepProceed
+}

--- a/internal/agent/provider_call.go
+++ b/internal/agent/provider_call.go
@@ -11,20 +11,23 @@ import (
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
-// providerCallOutcome tells runLoop how to proceed after a provider call.
-type providerCallOutcome int
+// loopStepOutcome tells runLoop how to proceed after one of its extracted
+// steps (provider call, turn assembly): use the result, retry the turn, or
+// return because the step already terminated the turn.
+type loopStepOutcome int
 
 const (
-	// providerCallProceed: the stream is ready; process it.
-	providerCallProceed providerCallOutcome = iota
-	// providerCallRetryTurn: a recovery action (compaction, token bump)
-	// mutated loop state; re-enter the loop without consuming a turn. The
-	// callee has already decremented ls.turnCount to cancel the loop's
-	// post-statement increment and set ls.lastContinueReason.
-	providerCallRetryTurn
-	// providerCallEnded: a terminal failure was emitted (error followed by
+	// stepProceed: the step succeeded; use its result.
+	stepProceed loopStepOutcome = iota
+	// stepRetryTurn: a recovery action (compaction, token bump,
+	// continuation prompt) mutated loop state; re-enter the loop without
+	// consuming a turn. The callee has already decremented ls.turnCount to
+	// cancel the loop's post-statement increment and set
+	// ls.lastContinueReason.
+	stepRetryTurn
+	// stepEnded: the step emitted its own terminal events (error and/or
 	// done); runLoop must return.
-	providerCallEnded
+	stepEnded
 )
 
 // streamWithRecovery performs the foreground model call for one loop
@@ -36,10 +39,10 @@ const (
 // reads as orchestration and this machine can be reasoned about (and one day
 // seamed) in isolation.
 //
-// The returned stream is non-nil only for providerCallProceed. Terminal
+// The returned stream is non-nil only for stepProceed. Terminal
 // paths emit their own error and done events before returning; totals are
 // passed in solely so those done events carry accurate token usage.
-func (a *Agent) streamWithRecovery(ctx context.Context, ch chan<- TurnEvent, ls *loopState, req provider.CompletionRequest, totalInputTokens, totalOutputTokens int) (<-chan provider.StreamEvent, providerCallOutcome) {
+func (a *Agent) streamWithRecovery(ctx context.Context, ch chan<- TurnEvent, ls *loopState, req provider.CompletionRequest, totalInputTokens, totalOutputTokens int) (<-chan provider.StreamEvent, loopStepOutcome) {
 	if a.rateLimiter != nil {
 		if !a.rateLimiter.AllowNow() {
 			a.emit(ctx, ch, TurnEvent{Type: "rate_limited"})
@@ -47,7 +50,7 @@ func (a *Agent) streamWithRecovery(ctx context.Context, ch chan<- TurnEvent, ls 
 		if err := a.rateLimiter.Wait(ctx); err != nil {
 			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("rate limiter: %w", err)})
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitRateLimited))
-			return nil, providerCallEnded
+			return nil, stepEnded
 		}
 	}
 
@@ -87,7 +90,7 @@ func (a *Agent) streamWithRecovery(ctx context.Context, ch chan<- TurnEvent, ls 
 				} else {
 					ls.lastContinueReason = ContinueMaxTokensRecovery
 				}
-				return nil, providerCallRetryTurn
+				return nil, stepRetryTurn
 			}
 			// Recovery exhausted — surface the withheld error with class context
 			// so consumers can distinguish prompt-too-long from max_tokens without parsing strings.
@@ -105,7 +108,7 @@ func (a *Agent) streamWithRecovery(ctx context.Context, ch chan<- TurnEvent, ls 
 				exitReason = agentsdk.ExitMaxOutputTokens
 			}
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, exitReason))
-			return nil, providerCallEnded
+			return nil, stepEnded
 		}
 
 		if class == errorclass.ClassModelOverloaded && a.fallbackModel != "" {
@@ -135,18 +138,18 @@ func (a *Agent) streamWithRecovery(ctx context.Context, ch chan<- TurnEvent, ls 
 			}, onRetry)
 			if fallbackErr == nil {
 				ls.lastContinueReason = ContinueModelFallback
-				return stream, providerCallProceed
+				return stream, stepProceed
 			}
 			a.logger.Warn("fallback model also failed: %v", fallbackErr)
 			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream (fallback): %w", fallbackErr)})
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError))
-			return nil, providerCallEnded
+			return nil, stepEnded
 		}
 
 		a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("provider stream: %w", err)})
 		a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitProviderError))
-		return nil, providerCallEnded
+		return nil, stepEnded
 	}
 
-	return stream, providerCallProceed
+	return stream, stepProceed
 }


### PR DESCRIPTION
## Summary

Second slice of shrink-before-converge (after #317). Two `[STRUCTURAL]` commits:

1. **Rename Type**: `providerCallOutcome` → `loopStepOutcome` (`stepProceed` / `stepRetryTurn` / `stepEnded`). The three-way outcome isn't provider-specific — this slice's extraction speaks the same vocabulary, so the name stops lying about its scope before it's reused.
2. **Extract Method**: `assembleAssistantTurn` (new `internal/agent/assemble_turn.go`) takes the post-stream assembly out of `runLoop`, verbatim:
   - max-output-tokens recovery — escalation first, then continuation prompts up to the limit, with the partial response committed so the continuation prompt is meaningful
   - truncated-tool cleanup (`DropInvalidPartialTool`)
   - thinking-block prepending
   - stream-error terminalization (surfacing already-dispatched streaming tool results, orphan-result synthesis)
   - `<tool_use>` XML extraction for non-native models, with XML stripped from the persisted text
   - empty-response placeholder + `ExitEmptyResponse` downgrade
   - after-response hook on final turns
   - the conversation commit (`AddAssistant` + persist)

   It returns `(assembledTurn{blocks, pendingTools, exitReason}, loopStepOutcome)`; `runLoop` keeps a three-line dispatch.

## Semantics preserved — same two spots as slice 1

- The two recovery `continue`s became `stepRetryTurn` returns: `ls.turnCount--` stays in the callee, `continue` stays in the caller, so a recovered turn is still not consumed.
- The stream-error path emits its own error/done and returns `stepEnded`, exactly as the inline code did.

## Numbers

`runLoop`: 600 → 499 (#317) → **371 lines**. Remaining for later slices: stream consumption (~120 lines) and the tool-execution/budget tail.

## Verification

No behavior change intended, validated per Tidy-First: full `internal/agent` (27s), `internal/modes/...`, `test/e2e`, `pkg/agentsdk` green **before and after** each commit. `gofmt`/`go vet`/`go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when responses exceed token limits, including safer retries and partial-response handling.
  * Improved handling of interrupted or failed streaming responses, including clearer completion status and tool-result recovery.
  * Improved detection and processing of tool calls in supported response formats.
  * Prevented malformed or empty model responses from disrupting conversations by providing a fallback response.
* **Reliability**
  * Improved final response assembly and conversation history consistency across retries, errors, and tool execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->