### PR TITLE
Extract runToolPhase from runLoop (loop convergence, final slice)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1512,7 +1512,6 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		}
 
 		cs := a.consumeProviderStream(ctx, ch, ls, stream, &totalInputTokens, &totalOutputTokens)
-		execStream := cs.execStream
 
 		asm, asmOutcome := a.assembleAssistantTurn(ctx, ch, ls, cs.acc, cs.execStream, cs.thinkingBuf, cs.stopReason, useNativeTools, totalInputTokens, totalOutputTokens)
 		if asmOutcome == stepRetryTurn {
@@ -1527,97 +1526,9 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 			return
 		}
 
-		// If no pending tool calls, we're done. Drain any background
-		// dispatches so goroutines don't outlive the turn (should be
-		// empty in this branch, but Drain is cheap and safe).
-		if len(pendingTools) == 0 {
-			_ = execStream.Drain()
-			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, exitReason))
+		if a.runToolPhase(ctx, ch, ls, asm, cs.execStream, joinBackgroundTasks, systemPrompt, skillPromptText, activeTools, totalInputTokens, totalOutputTokens) == stepEnded {
 			return
 		}
-
-		// Drain any tools dispatched during streaming; executeTools
-		// will merge these results into its output by tool_use ID.
-		var streamedResults map[string]toolExecResult
-		if drained := execStream.Drain(); len(drained) > 0 {
-			streamedResults = make(map[string]toolExecResult, len(drained))
-			for _, r := range drained {
-				streamedResults[r.toolUseID] = r
-			}
-		}
-
-		// Check token budget before executing tools.
-		// EffectiveWindow is used as the budget limit; this monitors output tokens
-		// against the available context window and stops before overflow.
-		ctxBudget := a.context.Budget()
-		dec := CheckTokenBudget(ls.budgetTracker, "", ctxBudget.EffectiveWindow(), totalOutputTokens)
-		if dec.Action == BudgetStop {
-			reason := "completion threshold"
-			if dec.CompletionEvent.DiminishingReturns {
-				reason = "diminishing returns"
-			}
-			a.logger.Warn("token budget stop: %s (%d%%)", reason, dec.Pct)
-			a.executeTools(ctx, ch, pendingTools, streamedResults)
-			joinBackgroundTasks()
-			a.emit(ctx, ch, TurnEvent{Type: "budget_stop"})
-			exitReason := agentsdk.ExitBudgetExceeded
-			if dec.CompletionEvent.DiminishingReturns {
-				exitReason = agentsdk.ExitDiminishingReturns
-			}
-			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, exitReason))
-			return
-		}
-
-		// Inject budget nudge if provided and not already emitted.
-		if dec.NudgeMessage != "" && !ls.nudgeEmitted {
-			a.conversation.AddUser(dec.NudgeMessage)
-			ls.nudgeEmitted = true
-		}
-
-		signature := pendingToolSignature(pendingTools)
-		if ls.recordToolSignature(signature, hasTextContent(blocks)) {
-			a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("detected no progress after %d repeated tool-only rounds", ls.repeatedToolRounds)})
-			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitNoProgress))
-			return
-		}
-
-		// Check if the model signaled task completion via task_complete tool.
-		// All sibling tools in the same batch are executed before exiting —
-		// the model often pairs task_complete with a final write or commit.
-		for _, tc := range pendingTools {
-			if tc.Name == tools.TaskCompleteName {
-				a.executeTools(ctx, ch, pendingTools, streamedResults)
-				joinBackgroundTasks()
-				a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitTaskComplete))
-				return
-			}
-		}
-
-		// Execute tool calls — parallelize auto-approved tools when possible.
-		if cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults); cancelled {
-			synthesizeMissingToolResults(a.conversation, orphanReasonToolCancel)
-			joinBackgroundTasks()
-			a.emit(ctx, ch, TurnEvent{Type: "error", Error: ctx.Err()})
-			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCancelled))
-			return
-		}
-
-		// Drain any pending wake events from background subagents.
-		a.drainWakeEvents(ctx, ch)
-
-		// Session memory extraction now rides the background-task joins
-		// below — no inline dispatch here, so terminal tool turns (which
-		// also run the joins) count toward extraction too.
-
-		// Re-measure after tool execution so the context window status reflects
-		// the current conversation state (tool results may have grown messages).
-		a.context.MeasureUsage(a.conversation, systemPrompt, skillPromptText, activeTools)
-		status := a.windowManager.Status()
-		if status.WarningLevel != WarningNone && !ls.nudgeEmitted {
-			a.conversation.AddUser(status.Advice)
-			ls.nudgeEmitted = true
-		}
-
 		// Join background tasks after tool execution. Their async work is
 		// started before the LLM call and joined here to overlap it with
 		// the model's execution, reducing perceived latency for the next turn.

--- a/internal/agent/tool_phase.go
+++ b/internal/agent/tool_phase.go
@@ -103,9 +103,10 @@ func (a *Agent) runToolPhase(ctx context.Context, ch chan<- TurnEvent, ls *loopS
 	// Drain any pending wake events from background subagents.
 	a.drainWakeEvents(ctx, ch)
 
-	// Session memory extraction now rides the background-task joins
-	// below — no inline dispatch here, so terminal tool turns (which
-	// also run the joins) count toward extraction too.
+	// Session memory extraction rides the background-task joins run by
+	// the caller after stepProceed (and by the terminal paths above), so
+	// terminal tool turns count toward extraction too — no inline
+	// dispatch here.
 
 	// Re-measure after tool execution so the context window status reflects
 	// the current conversation state (tool results may have grown messages).

--- a/internal/agent/tool_phase.go
+++ b/internal/agent/tool_phase.go
@@ -1,0 +1,120 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/tools"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// runToolPhase is the tool half of one loop iteration, starting after the
+// stop-hook gate: clean completion when nothing is pending, merging of
+// results from tools already dispatched mid-stream, the token-budget gate
+// (with its nudge), no-progress detection, the task_complete exit (siblings
+// executed first), tool execution itself, wake-event draining, and the
+// post-execution context re-measure with window advice. Extracted from
+// runLoop so the loop reads as orchestration; behavior is unchanged.
+//
+// joinBackgroundTasks is the current iteration's join closure; terminal
+// paths that executed tools invoke it before emitting done so per-turn
+// background work is collected, exactly as the inline code did. stepEnded
+// means a terminal path already emitted its events and runLoop must return;
+// stepProceed means tools ran and the loop should continue to the next turn.
+func (a *Agent) runToolPhase(ctx context.Context, ch chan<- TurnEvent, ls *loopState, asm assembledTurn, execStream *streamingToolExecutor, joinBackgroundTasks func(), systemPrompt, skillPromptText string, activeTools []provider.ToolDef, totalInputTokens, totalOutputTokens int) loopStepOutcome {
+	blocks, pendingTools, exitReason := asm.blocks, asm.pendingTools, asm.exitReason
+
+	// If no pending tool calls, we're done. Drain any background
+	// dispatches so goroutines don't outlive the turn (should be
+	// empty in this branch, but Drain is cheap and safe).
+	if len(pendingTools) == 0 {
+		_ = execStream.Drain()
+		a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, exitReason))
+		return stepEnded
+	}
+
+	// Drain any tools dispatched during streaming; executeTools
+	// will merge these results into its output by tool_use ID.
+	var streamedResults map[string]toolExecResult
+	if drained := execStream.Drain(); len(drained) > 0 {
+		streamedResults = make(map[string]toolExecResult, len(drained))
+		for _, r := range drained {
+			streamedResults[r.toolUseID] = r
+		}
+	}
+
+	// Check token budget before executing tools.
+	// EffectiveWindow is used as the budget limit; this monitors output tokens
+	// against the available context window and stops before overflow.
+	ctxBudget := a.context.Budget()
+	dec := CheckTokenBudget(ls.budgetTracker, "", ctxBudget.EffectiveWindow(), totalOutputTokens)
+	if dec.Action == BudgetStop {
+		reason := "completion threshold"
+		if dec.CompletionEvent.DiminishingReturns {
+			reason = "diminishing returns"
+		}
+		a.logger.Warn("token budget stop: %s (%d%%)", reason, dec.Pct)
+		a.executeTools(ctx, ch, pendingTools, streamedResults)
+		joinBackgroundTasks()
+		a.emit(ctx, ch, TurnEvent{Type: "budget_stop"})
+		exitReason := agentsdk.ExitBudgetExceeded
+		if dec.CompletionEvent.DiminishingReturns {
+			exitReason = agentsdk.ExitDiminishingReturns
+		}
+		a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, exitReason))
+		return stepEnded
+	}
+
+	// Inject budget nudge if provided and not already emitted.
+	if dec.NudgeMessage != "" && !ls.nudgeEmitted {
+		a.conversation.AddUser(dec.NudgeMessage)
+		ls.nudgeEmitted = true
+	}
+
+	signature := pendingToolSignature(pendingTools)
+	if ls.recordToolSignature(signature, hasTextContent(blocks)) {
+		a.emit(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("detected no progress after %d repeated tool-only rounds", ls.repeatedToolRounds)})
+		a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitNoProgress))
+		return stepEnded
+	}
+
+	// Check if the model signaled task completion via task_complete tool.
+	// All sibling tools in the same batch are executed before exiting —
+	// the model often pairs task_complete with a final write or commit.
+	for _, tc := range pendingTools {
+		if tc.Name == tools.TaskCompleteName {
+			a.executeTools(ctx, ch, pendingTools, streamedResults)
+			joinBackgroundTasks()
+			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitTaskComplete))
+			return stepEnded
+		}
+	}
+
+	// Execute tool calls — parallelize auto-approved tools when possible.
+	if cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults); cancelled {
+		synthesizeMissingToolResults(a.conversation, orphanReasonToolCancel)
+		joinBackgroundTasks()
+		a.emit(ctx, ch, TurnEvent{Type: "error", Error: ctx.Err()})
+		a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCancelled))
+		return stepEnded
+	}
+
+	// Drain any pending wake events from background subagents.
+	a.drainWakeEvents(ctx, ch)
+
+	// Session memory extraction now rides the background-task joins
+	// below — no inline dispatch here, so terminal tool turns (which
+	// also run the joins) count toward extraction too.
+
+	// Re-measure after tool execution so the context window status reflects
+	// the current conversation state (tool results may have grown messages).
+	a.context.MeasureUsage(a.conversation, systemPrompt, skillPromptText, activeTools)
+	status := a.windowManager.Status()
+	if status.WarningLevel != WarningNone && !ls.nudgeEmitted {
+		a.conversation.AddUser(status.Advice)
+		ls.nudgeEmitted = true
+	}
+
+	return stepProceed
+}


### PR DESCRIPTION
## Summary

Fourth and final slice of shrink-before-converge (#317, #319, #320). One `[STRUCTURAL]` commit.

**Extract Method**: `runToolPhase` (new `internal/agent/tool_phase.go`) takes the tool half of a loop iteration out of `runLoop`, verbatim:

- clean completion when no tools are pending (drain + done)
- merging of results from tools already dispatched **mid-stream** by #320's executor
- the token-budget gate (`BudgetStop` → execute + join + `budget_stop` + done) and its nudge injection
- no-progress detection via repeated tool signatures
- the `task_complete` exit — siblings executed first, exactly as inline
- tool execution with the cancelled-batch terminal path (orphan-result synthesis)
- wake-event draining and the post-execution context re-measure with window advice

It takes the `assembledTurn` from #319 and the iteration's `joinBackgroundTasks` closure, and returns the shared `loopStepOutcome`: `stepEnded` (terminal events already emitted; return) or `stepProceed` (continue to the next turn). The loop-bottom join and continue-reason stay in `runLoop` as loop bookkeeping. Terminal paths that executed tools invoke the join before done, exactly as before.

## The series, complete

| Slice | PR | runLoop |
|---|---|---|
| — | (start) | 600 |
| `streamWithRecovery` | #317 | 499 |
| `assembleAssistantTurn` | #319 | 371 |
| `consumeProviderStream` | #320 | 249 |
| `runToolPhase` | this | **160** |

`runLoop` is now per-turn setup, prompt/tool assembly, and four step calls dispatched on `loopStepOutcome` — the orchestration-only shape the design doc's convergence gate was waiting for. What "one loop" should mean from here (unify with the SDK loop vs. declare this layered structure the end state) is a deliberate next decision, not part of this PR.

## Verification

No behavior change intended, validated per Tidy-First: full `internal/agent` (27.2s), `internal/modes/...`, `test/e2e`, `pkg/agentsdk` green before and after. `gofmt`/`go vet`/`go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved agent turn processing and tool execution flow.
  * Enhanced handling of token limits, cancellations, completed tasks, and repeated no-progress rounds.
  * Improved coordination of background tasks and streamed tool results.
* **Bug Fixes**
  * Added clearer completion behavior when tool execution is cancelled or exceeds available context.
  * Improved context-usage monitoring and guidance during longer agent interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->