### PR TITLE
Repair the conversation correctly when a tool batch is cancelled

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1863,6 +1863,18 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 		results[it.index] = a.executeSingleToolWithApproval(ctx, ch, it.tc, it.approvalResult)
 	}
 
+	a.commitToolResults(ctx, ch, pendingTools, results)
+
+	// Snapshot after all tool results so a resume picks up from here.
+	a.saveSnapshotIfNeeded()
+
+	return false
+}
+
+// commitToolResults applies the aggregate result budget and then writes every
+// result into the conversation, the store, and the event channel, in the
+// model's original tool-call order. results is indexed 1:1 with pendingTools.
+func (a *Agent) commitToolResults(ctx context.Context, ch chan<- TurnEvent, pendingTools []provider.ToolUseBlock, results []toolExecResult) {
 	// Apply aggregate result budget before emitting results.
 	// Skip enforcement when budget is unlimited (<=0) to avoid allocation.
 	if a.resultBudget > 0 {
@@ -1895,11 +1907,6 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 		// Record progress for compaction-resistant tracking.
 		a.recordToolProgress(pendingTools[i], r)
 	}
-
-	// Snapshot after all tool results so a resume picks up from here.
-	a.saveSnapshotIfNeeded()
-
-	return false
 }
 
 func (a *Agent) executePlannedToolsSequential(ctx context.Context, ch chan<- TurnEvent, plannedTools []plannedToolCall, streamedResults map[string]toolExecResult) bool {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1791,7 +1791,7 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 	// tools run in parallel; unsafe tools run sequentially.
 	if len(autoApproved) > 0 {
 		if ctx.Err() != nil {
-			return true
+			return a.commitAndReportCancelled(ctx, ch, pendingTools, results)
 		}
 
 		// Build 1:1 mapping from batch index to plannedToolCall to avoid
@@ -1841,14 +1841,14 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 		}
 
 		if ctx.Err() != nil {
-			return true
+			return a.commitAndReportCancelled(ctx, ch, pendingTools, results)
 		}
 	}
 
 	// Execute auto-approved but non-parallelizable tools sequentially.
 	for _, it := range sequentialApproved {
 		if ctx.Err() != nil {
-			return true
+			return a.commitAndReportCancelled(ctx, ch, pendingTools, results)
 		}
 		a.emit(ctx, ch, makeToolCallEvent(it.tc))
 		results[it.index] = a.executeSingleTool(ctx, ch, it.tc)
@@ -1857,7 +1857,7 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 	// Execute needs-approval tools sequentially.
 	for _, it := range needsApproval {
 		if ctx.Err() != nil {
-			return true
+			return a.commitAndReportCancelled(ctx, ch, pendingTools, results)
 		}
 		a.emit(ctx, ch, makeToolCallEvent(it.tc))
 		results[it.index] = a.executeSingleToolWithApproval(ctx, ch, it.tc, it.approvalResult)
@@ -1871,6 +1871,20 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 	return false
 }
 
+// commitAndReportCancelled writes out the results collected before
+// cancellation interrupted the batch, then reports the cancellation.
+//
+// Without this, every result the batch had already produced would be dropped
+// on the floor and the caller's orphan sweeper would seal all of them as "did
+// not complete" — including tools whose side effects already landed. The
+// snapshot taken right after would make that false history durable, and a
+// resumed agent could repeat those side effects. Only the calls that genuinely
+// never ran are left for the sweeper.
+func (a *Agent) commitAndReportCancelled(ctx context.Context, ch chan<- TurnEvent, pendingTools []provider.ToolUseBlock, results []toolExecResult) bool {
+	a.commitToolResults(ctx, ch, pendingTools, results)
+	return true
+}
+
 // commitToolResults applies the aggregate result budget and then writes every
 // result into the conversation, the store, and the event channel, in the
 // model's original tool-call order. results is indexed 1:1 with pendingTools.
@@ -1881,6 +1895,9 @@ func (a *Agent) commitToolResults(ctx context.Context, ch chan<- TurnEvent, pend
 		enforcer := NewResultBudgetEnforcer(a.resultBudget, a.resultStore)
 		for i := range pendingTools {
 			r := results[i]
+			if r.toolUseID == "" {
+				continue
+			}
 			bounded, err := enforcer.Enforce(pendingTools[i].Name, pendingTools[i].ID, agentsdk.ToolResult{
 				Content:        r.content,
 				DisplayContent: r.event.ToolResult.DisplayContent,
@@ -1900,6 +1917,14 @@ func (a *Agent) commitToolResults(ctx context.Context, ch chan<- TurnEvent, pend
 	// Emit all results and update conversation in original tool call order.
 	for i := range pendingTools {
 		r := results[i]
+		// A zero-valued slot is a call that never ran, which only happens
+		// when a cancelled batch commits early. Writing it would answer a
+		// tool_use with empty content; the orphan sweeper seals those
+		// properly instead. On the uncancelled path every slot is filled,
+		// so this skips nothing.
+		if r.toolUseID == "" {
+			continue
+		}
 		a.conversation.AddToolResult(r.toolUseID, r.content, r.isError)
 		a.persistToolResult(r.toolUseID, r.content, r.isError)
 		a.emit(ctx, ch, r.event)

--- a/internal/agent/orphan_test.go
+++ b/internal/agent/orphan_test.go
@@ -183,43 +183,7 @@ func TestRunLoopToolCancelLeavesNoOrphans(t *testing.T) {
 		t.Fatalf("cancel tool was not invoked — test precondition failed")
 	}
 
-	// Walk the conversation: every tool_use in the final assistant message
-	// must have a matching tool_result somewhere after it.
-	msgs := a.conversation.Messages()
-	var assistantIdx = -1
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if msgs[i].Role == "assistant" {
-			assistantIdx = i
-			break
-		}
-	}
-	if assistantIdx == -1 {
-		t.Fatalf("no assistant message found in conversation")
-	}
-
-	var pending []string
-	for _, b := range msgs[assistantIdx].Content {
-		if b.Type == "tool_use" {
-			pending = append(pending, b.ID)
-		}
-	}
-	if len(pending) == 0 {
-		t.Fatalf("expected tool_use blocks in assistant message; got none")
-	}
-
-	answered := map[string]bool{}
-	for i := assistantIdx + 1; i < len(msgs); i++ {
-		for _, b := range msgs[i].Content {
-			if b.Type == "tool_result" {
-				answered[b.ToolUseID] = true
-			}
-		}
-	}
-	for _, id := range pending {
-		if !answered[id] {
-			t.Fatalf("orphan tool_use %q has no matching tool_result; sweeper not wired", id)
-		}
-	}
+	assertNoOrphanToolUses(t, a)
 }
 
 // TestLoadSessionHistory_SynthesizesOrphans verifies that loadSessionHistory

--- a/internal/agent/orphan_test.go
+++ b/internal/agent/orphan_test.go
@@ -315,3 +315,77 @@ func TestTaskCompletePathToolCancelLeavesNoOrphans(t *testing.T) {
 	require.True(t, cancelTool.invoked, "cancel tool was not invoked — test precondition failed")
 	assertNoOrphanToolUses(t, a)
 }
+
+// TestTaskCompletePathToolCancelPersistsSeal covers the persistence half of
+// the same defect. Sealing the batch in memory is not enough when a store is
+// attached: executeTools returns early on cancellation, skipping its trailing
+// snapshot save, so the newest snapshot is still the pre-provider one Turn
+// wrote. Because loadSessionHistory prefers a snapshot over the message log
+// whenever one exists, resuming would restore the session from before the
+// assistant turn — dropping the completed tool results along with the seal.
+func TestTaskCompletePathToolCancelPersistsSeal(t *testing.T) {
+	t.Parallel()
+
+	s, err := store.NewStore(":memory:")
+	require.NoError(t, err)
+	defer s.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cancelTool := &cancelOnExecuteTool{cancel: cancel}
+
+	mp := &mockProvider{
+		events: []provider.StreamEvent{
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "t1", Name: "cancel_tool", Input: json.RawMessage(`{}`)}},
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "t2", Name: tools.TaskCompleteName, Input: json.RawMessage(`{}`)}},
+			{Type: "stop"},
+		},
+	}
+
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(cancelTool))
+
+	a := New(mp, reg, autoApprove, config.DefaultConfig(), WithStore(s))
+
+	ch, err := a.Turn(ctx, "finish up")
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	require.True(t, cancelTool.invoked, "cancel tool was not invoked — test precondition failed")
+
+	snap, err := s.GetSnapshot(a.sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, snap, "Turn always writes a snapshot, so one must exist")
+
+	// A resume loads exactly these messages, so the assistant turn and the
+	// seal for the tool that never ran must both be in them.
+	assertSnapshotSealsToolUses(t, snap)
+}
+
+// assertSnapshotSealsToolUses fails if the persisted messages contain a
+// tool_use with no matching tool_result — the shape a resume would restore.
+func assertSnapshotSealsToolUses(t *testing.T, msgs []provider.Message) {
+	t.Helper()
+	answered := map[string]bool{}
+	var pending []provider.ContentBlock
+	for _, m := range msgs {
+		for _, b := range m.Content {
+			switch b.Type {
+			case "tool_use":
+				pending = append(pending, b)
+			case "tool_result":
+				answered[b.ToolUseID] = true
+			}
+		}
+	}
+	if len(pending) == 0 {
+		t.Fatalf("snapshot has no tool_use blocks; the assistant turn was never persisted, so a resume would lose it entirely")
+	}
+	for _, b := range pending {
+		if !answered[b.ID] {
+			t.Fatalf("snapshot leaves tool_use %q (%s) unanswered; a resumed session would replay it and fail a protocol check", b.ID, b.Name)
+		}
+	}
+}

--- a/internal/agent/orphan_test.go
+++ b/internal/agent/orphan_test.go
@@ -389,3 +389,84 @@ func assertSnapshotSealsToolUses(t *testing.T, msgs []provider.Message) {
 		}
 	}
 }
+
+// sideEffectTool records that it ran and returns a distinctive result, so a
+// test can tell a real execution apart from a synthesized cancellation seal.
+type sideEffectTool struct{ invoked bool }
+
+func (s *sideEffectTool) Name() string        { return "side_effect_tool" }
+func (s *sideEffectTool) Description() string { return "performs a side effect" }
+func (s *sideEffectTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{"type":"object"}`)
+}
+
+func (s *sideEffectTool) Execute(context.Context, json.RawMessage) (agentsdk.ToolResult, error) {
+	s.invoked = true
+	return agentsdk.ToolResult{Content: sideEffectResultText}, nil
+}
+
+const sideEffectResultText = "side effect committed"
+
+// TestToolCancelKeepsCompletedBatchResults covers the batched execution path
+// (the one taken when an approvalChecker is configured). executeTools collects
+// every result from the BatchExecutor and only afterwards checks ctx.Err(),
+// returning before any of them reaches the conversation. The orphan sweeper
+// then seals every call as "did not complete" — including tools that ran and
+// whose side effects already landed — and the snapshot save makes that false
+// history durable, so a resumed agent may repeat those side effects.
+//
+// Only the calls that genuinely did not run may be sealed.
+func TestToolCancelKeepsCompletedBatchResults(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sideEffect := &sideEffectTool{}
+	cancelTool := &cancelOnExecuteTool{cancel: cancel}
+
+	// The side-effect tool runs first and completes; the cancelling tool runs
+	// second, so the batch is interrupted only after a real result exists.
+	mp := &mockProvider{
+		events: []provider.StreamEvent{
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "t1", Name: "side_effect_tool", Input: json.RawMessage(`{}`)}},
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "t2", Name: "cancel_tool", Input: json.RawMessage(`{}`)}},
+			{Type: "stop"},
+		},
+	}
+
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(sideEffect))
+	require.NoError(t, reg.Register(cancelTool))
+
+	// An approvalChecker selects the batched path; without one executeTools
+	// falls back to the sequential executor, which commits as it goes.
+	a := New(mp, reg, autoApprove, config.DefaultConfig(),
+		WithApprovalChecker(AlwaysAutoApprove{}))
+
+	ch, err := a.Turn(ctx, "do the thing")
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	require.True(t, sideEffect.invoked, "side-effect tool did not run — test precondition failed")
+
+	got := toolResultText(t, a, "t1")
+	require.Equal(t, sideEffectResultText, got,
+		"the completed tool's real result was replaced by a cancellation seal; "+
+			"a resumed agent would see the side effect as never having happened")
+}
+
+// toolResultText returns the content of the tool_result answering toolUseID.
+func toolResultText(t *testing.T, a *Agent, toolUseID string) string {
+	t.Helper()
+	for _, m := range a.conversation.Messages() {
+		for _, b := range m.Content {
+			if b.Type == "tool_result" && b.ToolUseID == toolUseID {
+				return b.Text
+			}
+		}
+	}
+	t.Fatalf("no tool_result found for %q", toolUseID)
+	return ""
+}

--- a/internal/agent/orphan_test.go
+++ b/internal/agent/orphan_test.go
@@ -309,15 +309,9 @@ func TestTaskCompletePathToolCancelLeavesNoOrphans(t *testing.T) {
 	ch, err := a.Turn(ctx, "finish up")
 	require.NoError(t, err)
 
-	var exitReason agentsdk.TurnExitReason
-	for ev := range ch {
-		if ev.Type == "done" {
-			exitReason = ev.ExitReason
-		}
+	for range ch {
 	}
 
 	require.True(t, cancelTool.invoked, "cancel tool was not invoked — test precondition failed")
 	assertNoOrphanToolUses(t, a)
-	require.Equal(t, agentsdk.ExitCancelled, exitReason,
-		"a batch cancelled before task_complete ran should report cancellation, not task completion")
 }

--- a/internal/agent/orphan_test.go
+++ b/internal/agent/orphan_test.go
@@ -283,3 +283,77 @@ func TestLoadSessionHistory_SynthesizesOrphans(t *testing.T) {
 		t.Fatalf("no tool_result found for orphan_call_1 after session load; orphan repair not wired into loadSessionHistory")
 	}
 }
+
+// assertNoOrphanToolUses fails if any tool_use in the last assistant message
+// lacks a matching tool_result later in the conversation.
+func assertNoOrphanToolUses(t *testing.T, a *Agent) {
+	t.Helper()
+	msgs := a.conversation.Messages()
+	assistantIdx := -1
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == "assistant" {
+			assistantIdx = i
+			break
+		}
+	}
+	if assistantIdx == -1 {
+		t.Fatalf("no assistant message found in conversation")
+	}
+	answered := map[string]bool{}
+	for i := assistantIdx + 1; i < len(msgs); i++ {
+		for _, b := range msgs[i].Content {
+			if b.Type == "tool_result" {
+				answered[b.ToolUseID] = true
+			}
+		}
+	}
+	for _, b := range msgs[assistantIdx].Content {
+		if b.Type == "tool_use" && !answered[b.ID] {
+			t.Fatalf("orphan tool_use %q (%s) has no matching tool_result; "+
+				"the next provider call would fail with a protocol error", b.ID, b.Name)
+		}
+	}
+}
+
+// TestTaskCompletePathToolCancelLeavesNoOrphans covers the task_complete
+// terminal path, which executes the whole pending batch before exiting. If the
+// batch is cancelled part-way the trailing tool_use blocks never get results,
+// so the sweeper must run here too — not only on the main execution path.
+func TestTaskCompletePathToolCancelLeavesNoOrphans(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cancelTool := &cancelOnExecuteTool{cancel: cancel}
+
+	// The cancelling tool runs first; task_complete is later in the batch and
+	// so is skipped by the sequential executor once ctx is cancelled.
+	mp := &mockProvider{
+		events: []provider.StreamEvent{
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "t1", Name: "cancel_tool", Input: json.RawMessage(`{}`)}},
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "t2", Name: tools.TaskCompleteName, Input: json.RawMessage(`{}`)}},
+			{Type: "stop"},
+		},
+	}
+
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(cancelTool))
+
+	a := New(mp, reg, autoApprove, config.DefaultConfig())
+
+	ch, err := a.Turn(ctx, "finish up")
+	require.NoError(t, err)
+
+	var exitReason agentsdk.TurnExitReason
+	for ev := range ch {
+		if ev.Type == "done" {
+			exitReason = ev.ExitReason
+		}
+	}
+
+	require.True(t, cancelTool.invoked, "cancel tool was not invoked — test precondition failed")
+	assertNoOrphanToolUses(t, a)
+	require.Equal(t, agentsdk.ExitCancelled, exitReason,
+		"a batch cancelled before task_complete ran should report cancellation, not task completion")
+}

--- a/internal/agent/tool_phase.go
+++ b/internal/agent/tool_phase.go
@@ -57,9 +57,7 @@ func (a *Agent) runToolPhase(ctx context.Context, ch chan<- TurnEvent, ls *loopS
 		a.logger.Warn("token budget stop: %s (%d%%)", reason, dec.Pct)
 		// A cancelled batch leaves trailing tool_use blocks unanswered; seal
 		// them before exiting or the next provider call fails a protocol check.
-		if cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults); cancelled {
-			synthesizeMissingToolResults(a.conversation, orphanReasonToolCancel)
-		}
+		a.executeToolsSealingCancellation(ctx, ch, pendingTools, streamedResults)
 		joinBackgroundTasks()
 		a.emit(ctx, ch, TurnEvent{Type: "budget_stop"})
 		exitReason := agentsdk.ExitBudgetExceeded
@@ -98,9 +96,7 @@ func (a *Agent) runToolPhase(ctx context.Context, ch chan<- TurnEvent, ls *loopS
 			// before execution). Reporting ExitCancelled here would make the
 			// hook's classification and the done event disagree for one turn;
 			// correcting both together is a separate change.
-			if cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults); cancelled {
-				synthesizeMissingToolResults(a.conversation, orphanReasonToolCancel)
-			}
+			a.executeToolsSealingCancellation(ctx, ch, pendingTools, streamedResults)
 			joinBackgroundTasks()
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitTaskComplete))
 			return stepEnded
@@ -108,8 +104,7 @@ func (a *Agent) runToolPhase(ctx context.Context, ch chan<- TurnEvent, ls *loopS
 	}
 
 	// Execute tool calls — parallelize auto-approved tools when possible.
-	if cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults); cancelled {
-		synthesizeMissingToolResults(a.conversation, orphanReasonToolCancel)
+	if cancelled := a.executeToolsSealingCancellation(ctx, ch, pendingTools, streamedResults); cancelled {
 		joinBackgroundTasks()
 		a.emit(ctx, ch, TurnEvent{Type: "error", Error: ctx.Err()})
 		a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCancelled))
@@ -134,4 +129,21 @@ func (a *Agent) runToolPhase(ctx context.Context, ch chan<- TurnEvent, ls *loopS
 	}
 
 	return stepProceed
+}
+
+// executeToolsSealingCancellation runs a pending tool batch and, if it was
+// cancelled part-way, seals the tool_use blocks that never got a result. The
+// wire protocol requires every tool_use to be answered, so an unsealed batch
+// makes the next provider call fail a protocol check. It reports whether the
+// batch was cancelled.
+//
+// All three of runToolPhase's execution sites — budget stop, task_complete,
+// and the main path — need the same sealing, so they share this wrapper rather
+// than each remembering to check executeTools' return.
+func (a *Agent) executeToolsSealingCancellation(ctx context.Context, ch chan<- TurnEvent, pendingTools []provider.ToolUseBlock, streamedResults map[string]toolExecResult) bool {
+	cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults)
+	if cancelled {
+		synthesizeMissingToolResults(a.conversation, orphanReasonToolCancel)
+	}
+	return cancelled
 }

--- a/internal/agent/tool_phase.go
+++ b/internal/agent/tool_phase.go
@@ -132,18 +132,26 @@ func (a *Agent) runToolPhase(ctx context.Context, ch chan<- TurnEvent, ls *loopS
 }
 
 // executeToolsSealingCancellation runs a pending tool batch and, if it was
-// cancelled part-way, seals the tool_use blocks that never got a result. The
-// wire protocol requires every tool_use to be answered, so an unsealed batch
-// makes the next provider call fail a protocol check. It reports whether the
-// batch was cancelled.
+// cancelled part-way, seals the tool_use blocks that never got a result and
+// persists the repaired conversation. The wire protocol requires every
+// tool_use to be answered, so an unsealed batch makes the next provider call
+// fail a protocol check. It reports whether the batch was cancelled.
 //
 // All three of runToolPhase's execution sites — budget stop, task_complete,
 // and the main path — need the same sealing, so they share this wrapper rather
 // than each remembering to check executeTools' return.
+//
+// The snapshot save matters because executeTools returns early on
+// cancellation, skipping the one it normally performs after a full batch. Left
+// alone, the newest snapshot would still be the pre-provider one Turn wrote —
+// and loadSessionHistory prefers a snapshot over the message log whenever one
+// exists, so resuming would restore the session from before the assistant turn
+// and silently drop the tool results that did complete.
 func (a *Agent) executeToolsSealingCancellation(ctx context.Context, ch chan<- TurnEvent, pendingTools []provider.ToolUseBlock, streamedResults map[string]toolExecResult) bool {
 	cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults)
 	if cancelled {
 		synthesizeMissingToolResults(a.conversation, orphanReasonToolCancel)
+		a.saveSnapshotIfNeeded()
 	}
 	return cancelled
 }

--- a/internal/agent/tool_phase.go
+++ b/internal/agent/tool_phase.go
@@ -89,15 +89,20 @@ func (a *Agent) runToolPhase(ctx context.Context, ch chan<- TurnEvent, ls *loopS
 	for _, tc := range pendingTools {
 		if tc.Name == tools.TaskCompleteName {
 			// If the batch is cancelled part-way, task_complete itself may
-			// never run: seal the unanswered tool_use blocks and report the
-			// cancellation rather than claiming the task finished.
-			exitReason := agentsdk.ExitTaskComplete
+			// never run; seal the unanswered tool_use blocks so the
+			// conversation stays protocol-valid for resume.
+			//
+			// The exit reason stays ExitTaskComplete even when cancelled,
+			// matching what assembleAssistantTurn already handed the
+			// after-response hook (terminalExitReason resolves task_complete
+			// before execution). Reporting ExitCancelled here would make the
+			// hook's classification and the done event disagree for one turn;
+			// correcting both together is a separate change.
 			if cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults); cancelled {
 				synthesizeMissingToolResults(a.conversation, orphanReasonToolCancel)
-				exitReason = agentsdk.ExitCancelled
 			}
 			joinBackgroundTasks()
-			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, exitReason))
+			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitTaskComplete))
 			return stepEnded
 		}
 	}

--- a/internal/agent/tool_phase.go
+++ b/internal/agent/tool_phase.go
@@ -55,7 +55,11 @@ func (a *Agent) runToolPhase(ctx context.Context, ch chan<- TurnEvent, ls *loopS
 			reason = "diminishing returns"
 		}
 		a.logger.Warn("token budget stop: %s (%d%%)", reason, dec.Pct)
-		a.executeTools(ctx, ch, pendingTools, streamedResults)
+		// A cancelled batch leaves trailing tool_use blocks unanswered; seal
+		// them before exiting or the next provider call fails a protocol check.
+		if cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults); cancelled {
+			synthesizeMissingToolResults(a.conversation, orphanReasonToolCancel)
+		}
 		joinBackgroundTasks()
 		a.emit(ctx, ch, TurnEvent{Type: "budget_stop"})
 		exitReason := agentsdk.ExitBudgetExceeded
@@ -84,9 +88,16 @@ func (a *Agent) runToolPhase(ctx context.Context, ch chan<- TurnEvent, ls *loopS
 	// the model often pairs task_complete with a final write or commit.
 	for _, tc := range pendingTools {
 		if tc.Name == tools.TaskCompleteName {
-			a.executeTools(ctx, ch, pendingTools, streamedResults)
+			// If the batch is cancelled part-way, task_complete itself may
+			// never run: seal the unanswered tool_use blocks and report the
+			// cancellation rather than claiming the task finished.
+			exitReason := agentsdk.ExitTaskComplete
+			if cancelled := a.executeTools(ctx, ch, pendingTools, streamedResults); cancelled {
+				synthesizeMissingToolResults(a.conversation, orphanReasonToolCancel)
+				exitReason = agentsdk.ExitCancelled
+			}
 			joinBackgroundTasks()
-			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitTaskComplete))
+			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, exitReason))
 			return stepEnded
 		}
 	}


### PR DESCRIPTION
## Summary

Started as the follow-up promised on #321 — CodeRabbit found the original defect while reviewing that extraction, and it **predates** it, which is why it was deferred out of a `[STRUCTURAL]` PR. Codex&#39;s review then surfaced two further layers of the same problem. The PR now covers all three.

**What goes wrong when a tool batch is cancelled part-way**, in the order the layers were found:

1. **Orphan `tool_use` blocks were left unanswered.** The budget-stop and `task_complete` paths ran the batch for its side effects and discarded `executeTools`&#39; cancellation signal; only the main path swept. The wire protocol requires every `tool_use` to be answered, so the next provider call on a resumed session fails a protocol check.
2. **The repair was never persisted.** `executeTools` returns early on cancellation (`agent.go:1843`), skipping the `saveSnapshotIfNeeded()` it performs after a completed batch — so the newest snapshot stayed the pre-provider one `Turn` writes at `agent.go:1097`. `loadSessionHistory` (`agent.go:947`) prefers a snapshot over the message log whenever one exists, falling back only on *error*, so resume restored state from before the assistant turn and dropped the tool results that **had** completed.
3. **Completed results were being thrown away and then sealed as failures.** `executeTools` maps every `BatchExecutor` result into `results[]` (`agent.go:1833-1841`) and only *then* checks `ctx.Err()`, returning before the commit loop at the tail. The sweeper marked all of them &#34;did not complete&#34; — including tools whose side effects had already landed — and (2)&#39;s snapshot made that false history durable, so a resumed agent could repeat those side effects.

## The fix

- All three execution sites in `runToolPhase` — budget stop, `task_complete`, main path — go through `executeToolsSealingCancellation`, which seals unanswered `tool_use` blocks **and** persists the repaired conversation.
- All four early returns in `executeTools`&#39; batched path commit whatever completed before reporting the cancellation. Calls that genuinely never ran stay zero-valued; `commitToolResults` skips those slots rather than answering a `tool_use` with empty content, so the sweeper still seals exactly them. The uncancelled path fills every slot, so nothing changes there.
- `executePlannedToolsSequential` adds results as it goes and never had either window.

Codex named the `task_complete` and budget-stop branches in (2) and the post-batch return in (3); the main cancellation path and the three sibling returns had the same gaps and are covered too.

## Deliberately out of scope — tracked as #323

The `task_complete` path still reports `ExitTaskComplete` on a cancelled batch. An earlier revision changed it to `ExitCancelled`; that was reverted, and both bots ended up agreeing on why.

The ordering is forced: `applyAfterResponseHook` rewrites `blocks` before `AddAssistant` persists them (`assemble_turn.go:161-170`), and `AddAssistant` must precede tool execution because the protocol requires `tool_use` in history before any `tool_result`. So the hook fires strictly before tools run and cannot observe the outcome — `terminalExitReason` (`agent.go:1350`) resolving `ExitTaskComplete` early is a consequence of that, not an oversight.

Making the `done` event honest while leaving the hook alone reinstates the divergence [Codex flagged](https://github.com/julianshen/rubichan/pull/322#discussion_r3651821953). Aligning them, which [CodeRabbit asked for](https://github.com/julianshen/rubichan/pull/322#issuecomment-5082302067) and is the right end state, means changing what `HookDataExitReason` promises — skill-visible, so a compatibility decision rather than a refactor.

**#323** carries it: split *why is this the final response* (pre-execution, what the hook needs) from *how did the turn end* (post-execution, what `done` should carry), then report cancellation honestly. It also restores the exit-reason assertion this PR dropped. CodeRabbit agreed to the deferral and is leaving its finding open there.

## Tests

All three red first.

| Test | Red output |
|---|---|
| `TestTaskCompletePathToolCancelLeavesNoOrphans` | `orphan tool_use "t2" (task_complete) has no matching tool_result; the next provider call would fail with a protocol error` |
| `TestTaskCompletePathToolCancelPersistsSeal` — asserts the **persisted snapshot**, not the in-memory conversation | `snapshot has no tool_use blocks; the assistant turn was never persisted, so a resume would lose it entirely` |
| `TestToolCancelKeepsCompletedBatchResults` — `[side_effect_tool, cancel_tool]` with an `approvalChecker` to select the batched path | `the completed tool's real result was replaced by a cancellation seal` — got `tool side_effect_tool did not complete: cancelled during tool execution`, want `side effect committed` |

## Commits (Tidy-First)

| | |
|---|---|
| `[BEHAVIORAL]` | Seal orphan tool results on terminal tool paths |
| `[STRUCTURAL]` | Inline Method: reuse `assertNoOrphanToolUses` in the older test (CodeRabbit) |
| `[BEHAVIORAL]` | Keep `task_complete` exit reason when a batch is cancelled — the split-out revert (Codex) |
| `[STRUCTURAL]` | Extract Method: `executeToolsSealingCancellation` |
| `[BEHAVIORAL]` | Persist the sealed conversation when a tool batch is cancelled (Codex) |
| `[STRUCTURAL]` | Extract Method: `commitToolResults` from `executeTools` |
| `[BEHAVIORAL]` | Keep completed batch results when cancellation interrupts (Codex) |

## Verification

Full `internal/agent` (26.9s), `internal/toolexec`, `internal/modes/...`, `test/e2e` green. `gofmt`/`go vet`/`go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK