### PR TITLE
Report cancellation honestly on the task_complete path

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1880,7 +1880,11 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 	// Snapshot after all tool results so a resume picks up from here.
 	a.saveSnapshotIfNeeded()
 
-	return false
+	// Every loop above tests ctx.Err() before a call, never after, so
+	// cancellation during the *last* tool would otherwise be reported as a
+	// clean batch — and callers that exit immediately on that answer would
+	// claim the turn finished normally. Ask once more on the way out.
+	return ctx.Err() != nil
 }
 
 // commitAndReportCancelled writes out the results collected before
@@ -1976,7 +1980,10 @@ func (a *Agent) executePlannedToolsSequential(ctx context.Context, ch chan<- Tur
 	// Snapshot after all tool results so a resume picks up from here.
 	a.saveSnapshotIfNeeded()
 
-	return false
+	// The loop tests ctx.Err() before each call, never after the last one,
+	// so a cancellation landing during the final tool would look like a
+	// clean batch. See the matching check in executeTools.
+	return ctx.Err() != nil
 }
 
 // executeSingleToolWithApproval runs approval check then delegates to executeSingleTool.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1303,7 +1303,7 @@ func assistantText(blocks []provider.ContentBlock) string {
 // rewritten so the persisted assistant message reflects the transform. This is
 // the consumer side of the transform-skill design (see internal/skills/integration.go).
 // No-op when skillRuntime is unset.
-func (a *Agent) applyAfterResponseHook(ctx context.Context, blocks []provider.ContentBlock, reason agentsdk.TurnExitReason) []provider.ContentBlock {
+func (a *Agent) applyAfterResponseHook(ctx context.Context, blocks []provider.ContentBlock, responseReason agentsdk.TurnExitReason) []provider.ContentBlock {
 	if a.skillRuntime == nil {
 		return blocks
 	}
@@ -1314,7 +1314,7 @@ func (a *Agent) applyAfterResponseHook(ctx context.Context, blocks []provider.Co
 		Ctx:   ctx,
 		Data: map[string]any{
 			skills.HookDataResponse:   original,
-			skills.HookDataExitReason: reason.String(),
+			skills.HookDataExitReason: responseReason.String(),
 		},
 	}
 	hookResult, err := a.skillRuntime.DispatchHook(event)
@@ -1343,11 +1343,18 @@ func (a *Agent) applyAfterResponseHook(ctx context.Context, blocks []provider.Co
 	return replaceAssistantText(blocks, mutated)
 }
 
-// terminalExitReason reports whether the current pending-tool batch
+// finalResponseReason reports whether the current pending-tool batch
 // terminates the turn — i.e. no further LLM round will run after the
-// pending tools execute. Returns the final exit reason in that case.
+// pending tools execute — and if so, why this response is the final one.
 // Used to decide whether HookOnAfterResponse should fire on this turn.
-func terminalExitReason(pendingTools []provider.ToolUseBlock, defaultReason agentsdk.TurnExitReason) (agentsdk.TurnExitReason, bool) {
+//
+// This answers "why is this the final response", not "how did the turn
+// end". It is necessarily resolved before the pending tools run, so it
+// cannot account for anything that happens during execution; a batch
+// containing task_complete reports task_complete here even if execution
+// is later cancelled. The turn's actual outcome is a separate value,
+// carried by the done event.
+func finalResponseReason(pendingTools []provider.ToolUseBlock, defaultReason agentsdk.TurnExitReason) (agentsdk.TurnExitReason, bool) {
 	if len(pendingTools) == 0 {
 		return defaultReason, true
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1303,6 +1303,11 @@ func assistantText(blocks []provider.ContentBlock) string {
 // rewritten so the persisted assistant message reflects the transform. This is
 // the consumer side of the transform-skill design (see internal/skills/integration.go).
 // No-op when skillRuntime is unset.
+//
+// responseReason says why this response is the turn's last, not how the turn
+// ended — see HookDataResponseReason. This hook must run before the assistant
+// message is persisted, which in turn must precede tool execution, so the
+// outcome is simply not known yet at this point.
 func (a *Agent) applyAfterResponseHook(ctx context.Context, blocks []provider.ContentBlock, responseReason agentsdk.TurnExitReason) []provider.ContentBlock {
 	if a.skillRuntime == nil {
 		return blocks
@@ -1313,8 +1318,8 @@ func (a *Agent) applyAfterResponseHook(ctx context.Context, blocks []provider.Co
 		Phase: skills.HookOnAfterResponse,
 		Ctx:   ctx,
 		Data: map[string]any{
-			skills.HookDataResponse:   original,
-			skills.HookDataExitReason: responseReason.String(),
+			skills.HookDataResponse:       original,
+			skills.HookDataResponseReason: responseReason.String(),
 		},
 	}
 	hookResult, err := a.skillRuntime.DispatchHook(event)

--- a/internal/agent/agent_skills_test.go
+++ b/internal/agent/agent_skills_test.go
@@ -521,7 +521,11 @@ func TestAgentAfterResponseHookFires(t *testing.T) {
 
 	assert.True(t, hookCalled, "HookOnAfterResponse should fire when turn completes cleanly")
 	assert.Equal(t, "hello world", capturedText, "response text should be passed in event data")
-	assert.NotEmpty(t, capturedReason, "response_reason should be passed in event data")
+	// This provider returns text and stops, so the turn has no pending tools
+	// and the reason is deterministic — pin it rather than accepting any
+	// non-empty string, which would tolerate a wrong classification.
+	assert.Equal(t, agentsdk.ExitCompleted.String(), capturedReason,
+		"a clean completion should publish the completed response reason")
 }
 
 // TestAgentAfterResponseHookCanModifyPersistedText asserts that handlers

--- a/internal/agent/agent_skills_test.go
+++ b/internal/agent/agent_skills_test.go
@@ -494,7 +494,7 @@ func TestAgentAfterResponseHookFires(t *testing.T) {
 			if text, ok := event.Data[skills.HookDataResponse].(string); ok {
 				capturedText = text
 			}
-			if reason, ok := event.Data[skills.HookDataExitReason].(string); ok {
+			if reason, ok := event.Data[skills.HookDataResponseReason].(string); ok {
 				capturedReason = reason
 			}
 			return skills.HookResult{}, nil
@@ -521,7 +521,7 @@ func TestAgentAfterResponseHookFires(t *testing.T) {
 
 	assert.True(t, hookCalled, "HookOnAfterResponse should fire when turn completes cleanly")
 	assert.Equal(t, "hello world", capturedText, "response text should be passed in event data")
-	assert.NotEmpty(t, capturedReason, "exit_reason should be passed in event data")
+	assert.NotEmpty(t, capturedReason, "response_reason should be passed in event data")
 }
 
 // TestAgentAfterResponseHookCanModifyPersistedText asserts that handlers
@@ -642,7 +642,14 @@ func TestAgentAfterResponseHookFiresOnTaskComplete(t *testing.T) {
 
 	require.NotNil(t, captured, "HookOnAfterResponse should fire on task_complete exit too")
 	assert.Equal(t, "all done", captured[skills.HookDataResponse])
-	assert.Equal(t, agentsdk.ExitTaskComplete.String(), captured[skills.HookDataExitReason])
+	assert.Equal(t, agentsdk.ExitTaskComplete.String(), captured[skills.HookDataResponseReason])
+
+	// The hook fires before the pending tools run, so it can only report why
+	// this response is final — never how the turn ended. Publishing that
+	// pre-execution value under "exit_reason" invited skills to read it as
+	// the outcome, which is wrong the moment execution is cancelled.
+	assert.NotContains(t, captured, "exit_reason",
+		"the after-response hook must not publish a turn outcome it cannot know yet")
 }
 
 // TestAgentConversationStartHookFiresOnce asserts that HookOnConversationStart

--- a/internal/agent/assemble_turn.go
+++ b/internal/agent/assemble_turn.go
@@ -158,9 +158,9 @@ func (a *Agent) assembleAssistantTurn(ctx context.Context, ch chan<- TurnEvent, 
 	// subsequent turns see in conversation context — that's the surface
 	// transform skills target. A turn is final on either no-pending-tools
 	// (clean completion) or when task_complete is in the pending batch.
-	finalReason, isFinal := terminalExitReason(pendingTools, exitReason)
+	responseReason, isFinal := finalResponseReason(pendingTools, exitReason)
 	if isFinal {
-		blocks = a.applyAfterResponseHook(ctx, blocks, finalReason)
+		blocks = a.applyAfterResponseHook(ctx, blocks, responseReason)
 	}
 
 	// Add assistant message with accumulated blocks

--- a/internal/agent/orphan_test.go
+++ b/internal/agent/orphan_test.go
@@ -493,3 +493,49 @@ func toolResultText(t *testing.T, a *Agent, toolUseID string) string {
 	t.Fatalf("no tool_result found for %q", toolUseID)
 	return ""
 }
+
+// TestTaskCompletePathLastToolCancelReportsCancellation covers the ordering the
+// sibling test does not: the cancelling tool runs *last*.
+//
+// Both executors check ctx.Err() only at the top of their loop, so cancellation
+// that happens while the final tool is running is never observed — the loop
+// simply ends. Reporting that as "not cancelled" let the task_complete path
+// fall through to ExitTaskComplete even though the turn died mid-batch. With
+// the cancelling tool first, the next iteration's check catches it and the bug
+// stays hidden; only a trailing cancel exposes it.
+func TestTaskCompletePathLastToolCancelReportsCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cancelTool := &cancelOnExecuteTool{cancel: cancel}
+
+	mp := &mockProvider{
+		events: []provider.StreamEvent{
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "t1", Name: tools.TaskCompleteName, Input: json.RawMessage(`{}`)}},
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{ID: "t2", Name: "cancel_tool", Input: json.RawMessage(`{}`)}},
+			{Type: "stop"},
+		},
+	}
+
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(cancelTool))
+
+	// No approvalChecker, so this takes the executePlannedToolsSequential path.
+	a := New(mp, reg, autoApprove, config.DefaultConfig())
+
+	ch, err := a.Turn(ctx, "finish up")
+	require.NoError(t, err)
+
+	var exitReason agentsdk.TurnExitReason
+	for ev := range ch {
+		if ev.Type == "done" {
+			exitReason = ev.ExitReason
+		}
+	}
+
+	require.True(t, cancelTool.invoked, "cancel tool was not invoked — test precondition failed")
+	require.Equal(t, agentsdk.ExitCancelled, exitReason,
+		"cancellation during the final tool of the batch must still be reported, not swallowed by the loop ending")
+}

--- a/internal/agent/orphan_test.go
+++ b/internal/agent/orphan_test.go
@@ -309,10 +309,16 @@ func TestTaskCompletePathToolCancelLeavesNoOrphans(t *testing.T) {
 	ch, err := a.Turn(ctx, "finish up")
 	require.NoError(t, err)
 
-	var exitReason agentsdk.TurnExitReason
+	var (
+		exitReason      agentsdk.TurnExitReason
+		cancellationErr error
+	)
 	for ev := range ch {
-		if ev.Type == "done" {
+		switch ev.Type {
+		case "done":
 			exitReason = ev.ExitReason
+		case "error":
+			cancellationErr = ev.Error
 		}
 	}
 
@@ -325,6 +331,12 @@ func TestTaskCompletePathToolCancelLeavesNoOrphans(t *testing.T) {
 	// different question and is resolved before execution.
 	require.Equal(t, agentsdk.ExitCancelled, exitReason,
 		"a batch cancelled before task_complete ran must report cancellation, not completion")
+
+	// The done event is only half of what this path emits. Consumers that
+	// surface the failure to the user read the error event, so assert it too
+	// or it could go missing without any test noticing.
+	require.ErrorIs(t, cancellationErr, context.Canceled,
+		"the cancelled task_complete path must emit the cancellation error alongside its done event")
 }
 
 // TestTaskCompletePathToolCancelPersistsSeal covers the persistence half of

--- a/internal/agent/orphan_test.go
+++ b/internal/agent/orphan_test.go
@@ -309,11 +309,22 @@ func TestTaskCompletePathToolCancelLeavesNoOrphans(t *testing.T) {
 	ch, err := a.Turn(ctx, "finish up")
 	require.NoError(t, err)
 
-	for range ch {
+	var exitReason agentsdk.TurnExitReason
+	for ev := range ch {
+		if ev.Type == "done" {
+			exitReason = ev.ExitReason
+		}
 	}
 
 	require.True(t, cancelTool.invoked, "cancel tool was not invoked — test precondition failed")
 	assertNoOrphanToolUses(t, a)
+
+	// task_complete never ran — the cancelling sibling preceded it — so
+	// reporting completion would tell every consumer the turn succeeded.
+	// The hook's response_reason still says task_complete; that answers a
+	// different question and is resolved before execution.
+	require.Equal(t, agentsdk.ExitCancelled, exitReason,
+		"a batch cancelled before task_complete ran must report cancellation, not completion")
 }
 
 // TestTaskCompletePathToolCancelPersistsSeal covers the persistence half of

--- a/internal/agent/tool_phase.go
+++ b/internal/agent/tool_phase.go
@@ -87,16 +87,21 @@ func (a *Agent) runToolPhase(ctx context.Context, ch chan<- TurnEvent, ls *loopS
 	for _, tc := range pendingTools {
 		if tc.Name == tools.TaskCompleteName {
 			// If the batch is cancelled part-way, task_complete itself may
-			// never run; seal the unanswered tool_use blocks so the
-			// conversation stays protocol-valid for resume.
+			// never run, so the turn did not complete the task — report the
+			// cancellation the way the main path below does. The sweeper
+			// inside the wrapper seals whatever tool_use blocks were left
+			// unanswered, keeping the conversation protocol-valid for resume.
 			//
-			// The exit reason stays ExitTaskComplete even when cancelled,
-			// matching what assembleAssistantTurn already handed the
-			// after-response hook (finalResponseReason resolves task_complete
-			// before execution). Reporting ExitCancelled here would make the
-			// hook's classification and the done event disagree for one turn;
-			// correcting both together is a separate change.
-			a.executeToolsSealingCancellation(ctx, ch, pendingTools, streamedResults)
+			// This does not contradict the after-response hook, which was
+			// handed task_complete by finalResponseReason before execution:
+			// that says why this response is the turn's last, while the done
+			// event says how the turn ended. Two questions, two values.
+			if cancelled := a.executeToolsSealingCancellation(ctx, ch, pendingTools, streamedResults); cancelled {
+				joinBackgroundTasks()
+				a.emit(ctx, ch, TurnEvent{Type: "error", Error: ctx.Err()})
+				a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitCancelled))
+				return stepEnded
+			}
 			joinBackgroundTasks()
 			a.emit(ctx, ch, a.makeDoneEvent(totalInputTokens, totalOutputTokens, agentsdk.ExitTaskComplete))
 			return stepEnded

--- a/internal/agent/tool_phase.go
+++ b/internal/agent/tool_phase.go
@@ -92,7 +92,7 @@ func (a *Agent) runToolPhase(ctx context.Context, ch chan<- TurnEvent, ls *loopS
 			//
 			// The exit reason stays ExitTaskComplete even when cancelled,
 			// matching what assembleAssistantTurn already handed the
-			// after-response hook (terminalExitReason resolves task_complete
+			// after-response hook (finalResponseReason resolves task_complete
 			// before execution). Reporting ExitCancelled here would make the
 			// hook's classification and the done event disagree for one turn;
 			// correcting both together is a separate change.

--- a/internal/skills/hook_data_keys.go
+++ b/internal/skills/hook_data_keys.go
@@ -10,8 +10,19 @@ package skills
 const (
 	HookDataUserMessage = "user_message"
 	HookDataResponse    = "response"
-	HookDataExitReason  = "exit_reason"
 	HookDataPromptBuild = "prompt_build"
+
+	// HookDataResponseReason carries why the current response is the turn's
+	// final one — no pending tools, an empty model response, or a batch
+	// containing task_complete.
+	//
+	// It is NOT the turn's outcome. HookOnAfterResponse fires before the
+	// pending tools execute (the hook rewrites the assistant text, which
+	// must be persisted before any tool_result can follow it), so nothing
+	// that happens during execution can be reflected here: a cancelled
+	// task_complete batch still reports task_complete. Handlers that need
+	// the outcome must read the done event's ExitReason instead.
+	HookDataResponseReason = "response_reason"
 )
 
 // Tool execution data keys.


### PR DESCRIPTION
Closes #323. The piece deliberately left out of #322, where both review bots converged on it from opposite directions.

## The defect

When a tool batch containing `task_complete` was cancelled part-way, `runToolPhase` still emitted `done{ExitReason: ExitTaskComplete}`. `task_complete` itself may never have run — a sibling tool cancelled first — so every consumer (TUI, headless runner, observability) was told the turn succeeded when the user had cancelled it. The main execution path already reported `ExitCancelled`; the `task_complete` path discarded the wrapper&#39;s `cancelled` return.

## Why the obvious fix didn&#39;t work, and what unblocked it

Changing just the `done` event was tried in #322 and reverted at [Codex&#39;s request](https://github.com/julianshen/rubichan/pull/322#discussion_r3651821953): it made the `done` event disagree with what `HookOnAfterResponse` had already been told for the same turn.

The hook cannot simply be moved. It rewrites the assistant text, so it must run before `AddAssistant` persists it, and that must precede tool execution because the protocol requires `tool_use` in history before any `tool_result`. The hook is structurally blind to the outcome.

The real problem was that one name, `exit_reason`, carried two different questions:

| Question | Known | Carried by |
|---|---|---|
| Why is this response the turn&#39;s last? | before execution | the hook |
| How did the turn end? | after execution | the `done` event |

Splitting them makes the fix trivial and non-contradictory — which is what [CodeRabbit asked for](https://github.com/julianshen/rubichan/pull/322#issuecomment-5082302067).

## A second defect found during review

Codex then found that the fix was incomplete ([P2](https://github.com/julianshen/rubichan/pull/324#discussion_r3652771183)): both executors test `ctx.Err()` at the top of their loop and never after it, so a cancellation landing while the **final** tool ran was invisible — the loop simply ended and the executor returned &#34;not cancelled&#34;. A batch like `[task_complete, cancelling_sibling]` therefore still reported `ExitTaskComplete`.

Fixed by having both executors return `ctx.Err() != nil` from their tails, so every caller gets an honest answer. The main execution path had the same blind spot with milder symptoms — it fell through and only noticed at the next turn&#39;s entry check.

This survived the existing coverage because both cancellation tests put the cancelling tool *first*, where the next iteration&#39;s check catches it. Only a trailing cancel exposes it.

## Changes

| | |
|---|---|
| `[STRUCTURAL]` | Rename `terminalExitReason` → `finalResponseReason` — names only, so the identifier says which question it answers |
| `[BEHAVIORAL]` | The after-response hook publishes `response_reason`, not `exit_reason`, with the constant&#39;s doc stating what it can and cannot know |
| `[BEHAVIORAL]` | The `task_complete` path branches on the cancellation return and emits error + `done{ExitCancelled}` |
| `[BEHAVIORAL]` | Pin the response reason exactly and assert the cancellation error event (CodeRabbit) |
| `[BEHAVIORAL]` | Report cancellation that lands during the last tool of a batch (Codex) |

## Compatibility

Skill-visible: a handler reading `event.Data["exit_reason"]` on `HookOnAfterResponse` now reads nothing. The key had a single dispatch site, no documentation outside it, and carried a value that was wrong precisely when it mattered — so it is removed rather than aliased to a name that would keep inviting the same misreading. Handlers needing the outcome read the `done` event&#39;s `ExitReason`.

## Tests

Each behavioral change went red first.

| Test | Red output |
|---|---|
| `TestAgentAfterResponseHookFiresOnTaskComplete` | `undefined: skills.HookDataResponseReason` — then asserts handlers see `response_reason` **and** that the hook publishes no `exit_reason` at all |
| `TestTaskCompletePathToolCancelLeavesNoOrphans` | regains the exit-reason assertion dropped in #322 — expected `cancelled(3)`, got `task_complete(7)`; now also asserts the error event carries `context.Canceled` |
| `TestTaskCompletePathLastToolCancelReportsCancellation` | cancelling tool runs **last** — expected `cancelled(3)`, got `task_complete(7)` |

## Verification

`internal/agent` (26.7s), `internal/skills/...`, `internal/toolexec`, `internal/modes/...`, `test/e2e`, `pkg/...` all green. `gofmt`/`go vet`/`go build` clean.

Two pre-existing failures in `cmd/rubichan` (`TestOpenSessionStore_Works`, `TestSessionListCmd_Execute`) are environmental — `unable to open database file: out of memory (14)` from sqlite in this sandbox. Confirmed identical before any commit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK