### PR TITLE
Fix the portable loop's cancellation defects and share the sealing primitive

### DIFF
--- a/internal/agent/orphan.go
+++ b/internal/agent/orphan.go
@@ -1,6 +1,6 @@
 package agent
 
-import "fmt"
+import "github.com/julianshen/rubichan/pkg/agentsdk"
 
 // Reason strings passed to synthesizeMissingToolResults. Embedded in
 // the synthesized tool_result content so the model (and anyone
@@ -18,78 +18,12 @@ const (
 // of truth makes the ExitEmptyResponse classification unambiguous.
 const emptyModelResponseText = "[empty response from model]"
 
-// synthesizeMissingToolResults walks the conversation and, for every
-// tool_use block in the most recent assistant message that does not have
-// a matching tool_result in a subsequent message, appends an error
-// tool_result. Returns the number of orphans sealed.
+// synthesizeMissingToolResults seals unanswered tool_use blocks in the most
+// recent assistant message. Returns the number of orphans sealed.
 //
-// This exists because the Anthropic/OpenAI wire protocol requires every
-// tool_use block to be followed by a tool_result. If the stream dies
-// between tool_use emission and tool execution — or if execution is
-// cancelled after the assistant message has been committed — the next
-// API call fails with a 400 protocol error. Sealing orphans with a
-// synthetic error result keeps the conversation valid for retry and
-// for resume from a persisted snapshot.
-//
-// Called from every agent-loop exit path that follows a stream which
-// may have emitted tool_use blocks: provider stream error, mid-stream
-// error event, tool execution cancel, and the deferred panic handler.
+// The walk itself lives in pkg/agentsdk so this loop and the portable one
+// share a single implementation — a fix to either reaches both. See
+// agentsdk.SealOrphanedToolUses for why the protocol requires this.
 func synthesizeMissingToolResults(conv *Conversation, reason string) int {
-	msgs := conv.Messages()
-	if len(msgs) == 0 {
-		return 0
-	}
-
-	// Find the last assistant message.
-	assistantIdx := -1
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if msgs[i].Role == "assistant" {
-			assistantIdx = i
-			break
-		}
-	}
-	if assistantIdx == -1 {
-		return 0
-	}
-
-	// Collect tool_use IDs and names in that assistant message.
-	type pendingToolUse struct {
-		id, name string
-	}
-	var pending []pendingToolUse
-	for _, block := range msgs[assistantIdx].Content {
-		if block.Type == "tool_use" && block.ID != "" {
-			pending = append(pending, pendingToolUse{id: block.ID, name: block.Name})
-		}
-	}
-	if len(pending) == 0 {
-		return 0
-	}
-
-	// Collect tool_result IDs that appear after the assistant message.
-	answered := map[string]bool{}
-	for i := assistantIdx + 1; i < len(msgs); i++ {
-		for _, block := range msgs[i].Content {
-			if block.Type == "tool_result" && block.ToolUseID != "" {
-				answered[block.ToolUseID] = true
-			}
-		}
-	}
-
-	sealed := 0
-	for _, p := range pending {
-		if answered[p.id] {
-			continue
-		}
-		toolName := p.name
-		if toolName == "" {
-			toolName = "<unknown>"
-		}
-		conv.AddToolResult(p.id,
-			fmt.Sprintf("tool %s did not complete: %s", toolName, reason),
-			true,
-		)
-		sealed++
-	}
-	return sealed
+	return agentsdk.SealOrphanedToolUses(conv, reason)
 }

--- a/internal/agent/orphan.go
+++ b/internal/agent/orphan.go
@@ -8,9 +8,13 @@ import "github.com/julianshen/rubichan/pkg/agentsdk"
 // was sealed.
 const (
 	orphanReasonStreamError = "stream error"
-	orphanReasonToolCancel  = "cancelled during tool execution"
 	orphanReasonPanic       = "agent panic"
 	orphanReasonLoad        = "loaded from persisted session"
+
+	// orphanReasonToolCancel is shared with the portable loop, which seals
+	// the same condition — two spellings of one reason would show up as
+	// inconsistent history between the two cores.
+	orphanReasonToolCancel = agentsdk.OrphanReasonToolCancel
 )
 
 // emptyModelResponseText is the placeholder inserted when the model

--- a/internal/agent/orphan.go
+++ b/internal/agent/orphan.go
@@ -8,13 +8,13 @@ import "github.com/julianshen/rubichan/pkg/agentsdk"
 // was sealed.
 const (
 	orphanReasonStreamError = "stream error"
-	orphanReasonPanic       = "agent panic"
 	orphanReasonLoad        = "loaded from persisted session"
 
-	// orphanReasonToolCancel is shared with the portable loop, which seals
-	// the same condition — two spellings of one reason would show up as
-	// inconsistent history between the two cores.
+	// Shared with the portable loop, which seals the same two conditions —
+	// two spellings of one reason would show up as inconsistent history
+	// between the two cores.
 	orphanReasonToolCancel = agentsdk.OrphanReasonToolCancel
+	orphanReasonPanic      = agentsdk.OrphanReasonPanic
 )
 
 // emptyModelResponseText is the placeholder inserted when the model

--- a/pkg/agentsdk/agent.go
+++ b/pkg/agentsdk/agent.go
@@ -121,6 +121,13 @@ func (a *Agent) Turn(ctx context.Context, userMessage string) (<-chan TurnEvent,
 		defer func() {
 			if r := recover(); r != nil {
 				a.logger.Error("agent panic recovered: %v\n%s", r, debug.Stack())
+				// runLoop commits the assistant message before executing
+				// tools, and the approval flow calls embedder-supplied
+				// callbacks with no boundary of its own, so a panic can land
+				// here with tool_use blocks already in history. The
+				// conversation outlives this turn — leaving them unanswered
+				// would break the next one.
+				SealOrphanedToolUses(a.conversation, OrphanReasonPanic)
 				sendEvent(ctx, ch, TurnEvent{Type: "error", Error: fmt.Errorf("agent panic: %v", r)})
 				// Consumers treat "done" as the turn's terminator; without it
 				// a caller waiting on it would hang.

--- a/pkg/agentsdk/agent.go
+++ b/pkg/agentsdk/agent.go
@@ -214,6 +214,11 @@ func (a *Agent) runLoop(ctx context.Context, ch chan<- TurnEvent, turnCount int,
 		cancelled := a.executeTools(ctx, ch, sr.pendingTools)
 		joinBackgroundTasks()
 		if cancelled {
+			// A cancelled batch leaves the tools that never ran without a
+			// tool_result. The conversation outlives this turn, so leaving
+			// them unanswered would make the *next* Turn fail a protocol
+			// check rather than failing here.
+			SealOrphanedToolUses(a.conversation, OrphanReasonToolCancel)
 			ch <- TurnEvent{Type: "error", Error: ctx.Err()}
 			ch <- a.makeDoneEvent(totalInputTokens, totalOutputTokens)
 			return

--- a/pkg/agentsdk/agent.go
+++ b/pkg/agentsdk/agent.go
@@ -310,7 +310,10 @@ func (a *Agent) executeTools(ctx context.Context, ch chan<- TurnEvent, pendingTo
 		a.conversation.AddToolResult(tc.ID, result.content, result.isError)
 		ch <- result.event
 	}
-	return false
+	// The loop tests ctx.Err() before each call and never after the last one,
+	// so a cancellation landing during the final tool would otherwise be
+	// reported as a clean batch. Ask once more on the way out.
+	return ctx.Err() != nil
 }
 
 // toolResult holds the result of a single tool execution.

--- a/pkg/agentsdk/agent_test.go
+++ b/pkg/agentsdk/agent_test.go
@@ -1114,3 +1114,71 @@ func TestAgent_ConsumeStream_MessageStart(t *testing.T) {
 	assert.Equal(t, "gpt-4o", messageStarts[0].Model)
 	assert.Equal(t, "msg_123", messageStarts[0].MessageID)
 }
+
+// TestAgentCancelledBatchLeavesConversationProtocolValid covers the defect
+// that made the portable loop unsafe to embed: a cancelled tool batch left
+// trailing tool_use blocks with no matching tool_result.
+//
+// The damage is only observable across turns. Agent keeps one Conversation
+// for its lifetime and Turn appends to it, so the malformed history survives
+// the cancelled turn and is sent to the provider on the next one, where the
+// wire protocol rejects it. TestAgentContextCancelledMidToolBatch asserts the
+// second tool is skipped — the precondition for this — without checking that
+// the conversation was repaired.
+func TestAgentCancelledBatchLeavesConversationProtocolValid(t *testing.T) {
+	twoToolStream := []StreamEvent{
+		{Type: "tool_use", ToolUse: &ToolUseBlock{ID: "tc_1", Name: "cancel_tool"}},
+		{Type: "text_delta", Text: `{}`},
+		{Type: "tool_use", ToolUse: &ToolUseBlock{ID: "tc_2", Name: "echo"}},
+		{Type: "text_delta", Text: `{}`},
+		{Type: "stop"},
+	}
+	p := &mockProvider{responses: [][]StreamEvent{twoToolStream}}
+	r := NewRegistry()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, r.Register(&contextCancelTool{cancel: cancel}))
+	require.NoError(t, r.Register(&echoTool{}))
+
+	a := NewAgent(p, WithTools(r))
+	ch, err := a.Turn(ctx, "test")
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	assertNoUnansweredToolUses(t, a.Conversation())
+}
+
+// assertNoUnansweredToolUses fails if any tool_use in the conversation lacks a
+// matching tool_result later on — the shape the next provider call rejects.
+func assertNoUnansweredToolUses(t *testing.T, conv *Conversation) {
+	t.Helper()
+	msgs := conv.Messages()
+
+	answered := map[string]bool{}
+	for _, m := range msgs {
+		for _, b := range m.Content {
+			if b.Type == "tool_result" && b.ToolUseID != "" {
+				answered[b.ToolUseID] = true
+			}
+		}
+	}
+
+	var seen int
+	for _, m := range msgs {
+		for _, b := range m.Content {
+			if b.Type != "tool_use" || b.ID == "" {
+				continue
+			}
+			seen++
+			if !answered[b.ID] {
+				t.Fatalf("tool_use %q (%s) has no matching tool_result; "+
+					"the next Turn would send this conversation and fail a protocol check", b.ID, b.Name)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatalf("expected tool_use blocks in the conversation; got none — test precondition failed")
+	}
+}

--- a/pkg/agentsdk/agent_test.go
+++ b/pkg/agentsdk/agent_test.go
@@ -1182,3 +1182,43 @@ func assertNoUnansweredToolUses(t *testing.T, conv *Conversation) {
 		t.Fatalf("expected tool_use blocks in the conversation; got none — test precondition failed")
 	}
 }
+
+// TestAgentTrailingCancelIsReportedAsCancelled covers the ordering the other
+// cancellation tests miss: the cancelling tool runs *last*.
+//
+// executeTools tests ctx.Err() only at the top of its loop, so a cancellation
+// landing while the final tool runs ends the loop and is reported as a clean
+// batch. Today the loop's next-iteration check masks that — it emits the same
+// events one beat later — so the misclassification has no observable effect
+// here. It is still wrong, and internal/agent shows what it costs once a
+// caller acts on the return value: its task_complete path reported success for
+// a cancelled turn until ccea1cb.
+//
+// Asserting the return value directly rather than the event stream keeps this
+// honest about what is being fixed.
+func TestAgentTrailingCancelIsReportedAsCancelled(t *testing.T) {
+	r := NewRegistry()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, r.Register(&contextCancelTool{cancel: cancel}))
+	require.NoError(t, r.Register(&echoTool{}))
+
+	a := NewAgent(&mockProvider{}, WithTools(r))
+	a.conversation.AddAssistant([]ContentBlock{
+		{Type: "tool_use", ID: "tc_1", Name: "echo"},
+		{Type: "tool_use", ID: "tc_2", Name: "cancel_tool"},
+	})
+
+	ch := make(chan TurnEvent, 32)
+	// echo runs first and completes; cancel_tool runs last and cancels while
+	// it is the tool in flight, so no later iteration observes ctx.Err().
+	cancelled := a.executeTools(ctx, ch, []ToolUseBlock{
+		{ID: "tc_1", Name: "echo", Input: json.RawMessage(`{}`)},
+		{ID: "tc_2", Name: "cancel_tool", Input: json.RawMessage(`{}`)},
+	})
+	close(ch)
+
+	require.Error(t, ctx.Err(), "cancel tool did not cancel — test precondition failed")
+	require.True(t, cancelled,
+		"cancellation during the final tool must be reported, not swallowed by the loop ending")
+}

--- a/pkg/agentsdk/agent_test.go
+++ b/pkg/agentsdk/agent_test.go
@@ -1222,3 +1222,55 @@ func TestAgentTrailingCancelIsReportedAsCancelled(t *testing.T) {
 	require.True(t, cancelled,
 		"cancellation during the final tool must be reported, not swallowed by the loop ending")
 }
+
+// panickingApprovalTool is a plain tool; the panic in this scenario comes from
+// the embedder's approval callback, not from the tool itself.
+type panickingApprovalTool struct{}
+
+func (panickingApprovalTool) Name() string                 { return "needs_approval" }
+func (panickingApprovalTool) Description() string          { return "requires approval" }
+func (panickingApprovalTool) InputSchema() json.RawMessage { return json.RawMessage(`{}`) }
+func (panickingApprovalTool) Execute(context.Context, json.RawMessage) (ToolResult, error) {
+	return ToolResult{Content: "ran"}, nil
+}
+
+// TestAgentApprovalPanicLeavesConversationProtocolValid covers the panic exit
+// path. runLoop commits the assistant message before executeTools, and
+// ApprovalFlow.Decide then calls embedder-supplied callbacks — ApprovalFunc
+// here — with no recovery boundary of its own. dispatchTool's recover sits
+// further in and never sees it, so the panic reaches Turn's handler with
+// tool_use blocks already in history.
+//
+// Without sealing there, those blocks stay unanswered for the rest of the
+// Agent's life and the next Turn fails a protocol check, exactly as an
+// unsealed cancellation did.
+func TestAgentApprovalPanicLeavesConversationProtocolValid(t *testing.T) {
+	twoToolStream := []StreamEvent{
+		{Type: "tool_use", ToolUse: &ToolUseBlock{ID: "tc_1", Name: "needs_approval"}},
+		{Type: "text_delta", Text: `{}`},
+		{Type: "tool_use", ToolUse: &ToolUseBlock{ID: "tc_2", Name: "needs_approval"}},
+		{Type: "text_delta", Text: `{}`},
+		{Type: "stop"},
+	}
+	p := &mockProvider{responses: [][]StreamEvent{twoToolStream}}
+	r := NewRegistry()
+	require.NoError(t, r.Register(panickingApprovalTool{}))
+
+	panicking := func(context.Context, string, json.RawMessage) (bool, error) {
+		panic("approval callback exploded")
+	}
+
+	a := NewAgent(p, WithTools(r), WithApproval(panicking))
+	ch, err := a.Turn(context.Background(), "test")
+	require.NoError(t, err)
+
+	var sawError bool
+	for ev := range ch {
+		if ev.Type == "error" {
+			sawError = true
+		}
+	}
+	require.True(t, sawError, "the recovered panic should surface as an error event")
+
+	assertNoUnansweredToolUses(t, a.Conversation())
+}

--- a/pkg/agentsdk/orphan.go
+++ b/pkg/agentsdk/orphan.go
@@ -2,6 +2,15 @@ package agentsdk
 
 import "fmt"
 
+// Reason strings for SealOrphanedToolUses, embedded in the synthesized
+// tool_result content so the model — and anyone reading a captured
+// conversation — can tell why each orphan was sealed.
+const (
+	// OrphanReasonToolCancel marks tools that never ran because the batch
+	// was cancelled part-way.
+	OrphanReasonToolCancel = "cancelled during tool execution"
+)
+
 // ToolResultConversation is the slice of conversation behaviour orphan
 // sealing needs. Both this package's Conversation and internal/agent's
 // satisfy it, which is what lets the two agent loops share one sealing

--- a/pkg/agentsdk/orphan.go
+++ b/pkg/agentsdk/orphan.go
@@ -1,0 +1,90 @@
+package agentsdk
+
+import "fmt"
+
+// ToolResultConversation is the slice of conversation behaviour orphan
+// sealing needs. Both this package's Conversation and internal/agent's
+// satisfy it, which is what lets the two agent loops share one sealing
+// implementation instead of maintaining a copy each.
+type ToolResultConversation interface {
+	Messages() []Message
+	AddToolResult(toolUseID, content string, isError bool)
+}
+
+// SealOrphanedToolUses walks conv and, for every tool_use block in the most
+// recent assistant message that has no matching tool_result in a subsequent
+// message, appends an error tool_result. It returns the number of orphans
+// sealed.
+//
+// This exists because the Anthropic/OpenAI wire protocol requires every
+// tool_use block to be followed by a tool_result. If a stream dies between
+// tool_use emission and tool execution — or execution is cancelled after the
+// assistant message has been committed — the next API call fails with a 400
+// protocol error. Sealing orphans with a synthetic error result keeps the
+// conversation valid for retry and for resume from a persisted snapshot.
+//
+// reason is embedded in the synthesized content so the model, and anyone
+// reading a captured conversation, can tell why each orphan was sealed.
+//
+// Callers must invoke this on every exit path that follows a stream which may
+// have emitted tool_use blocks: provider stream error, mid-stream error event,
+// tool execution cancel, and panic recovery.
+func SealOrphanedToolUses(conv ToolResultConversation, reason string) int {
+	msgs := conv.Messages()
+	if len(msgs) == 0 {
+		return 0
+	}
+
+	// Find the last assistant message.
+	assistantIdx := -1
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == "assistant" {
+			assistantIdx = i
+			break
+		}
+	}
+	if assistantIdx == -1 {
+		return 0
+	}
+
+	// Collect tool_use IDs and names in that assistant message.
+	type pendingToolUse struct {
+		id, name string
+	}
+	var pending []pendingToolUse
+	for _, block := range msgs[assistantIdx].Content {
+		if block.Type == "tool_use" && block.ID != "" {
+			pending = append(pending, pendingToolUse{id: block.ID, name: block.Name})
+		}
+	}
+	if len(pending) == 0 {
+		return 0
+	}
+
+	// Collect tool_result IDs that appear after the assistant message.
+	answered := map[string]bool{}
+	for i := assistantIdx + 1; i < len(msgs); i++ {
+		for _, block := range msgs[i].Content {
+			if block.Type == "tool_result" && block.ToolUseID != "" {
+				answered[block.ToolUseID] = true
+			}
+		}
+	}
+
+	sealed := 0
+	for _, p := range pending {
+		if answered[p.id] {
+			continue
+		}
+		toolName := p.name
+		if toolName == "" {
+			toolName = "<unknown>"
+		}
+		conv.AddToolResult(p.id,
+			fmt.Sprintf("tool %s did not complete: %s", toolName, reason),
+			true,
+		)
+		sealed++
+	}
+	return sealed
+}

--- a/pkg/agentsdk/orphan.go
+++ b/pkg/agentsdk/orphan.go
@@ -9,6 +9,10 @@ const (
 	// OrphanReasonToolCancel marks tools that never ran because the batch
 	// was cancelled part-way.
 	OrphanReasonToolCancel = "cancelled during tool execution"
+
+	// OrphanReasonPanic marks tools left unanswered because the turn
+	// goroutine panicked after the assistant message was committed.
+	OrphanReasonPanic = "agent panic"
 )
 
 // ToolResultConversation is the slice of conversation behaviour orphan

--- a/pkg/agentsdk/orphan_test.go
+++ b/pkg/agentsdk/orphan_test.go
@@ -1,0 +1,159 @@
+package agentsdk
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSealOrphanedToolUses covers the branches that decide whether a
+// conversation needs repair at all. Both agent cores call this, so the
+// shape of a conversation it declines to touch is part of the contract:
+// sealing something already answered would duplicate a tool_result, and
+// sealing when there is no assistant turn would attach a result to nothing.
+func TestSealOrphanedToolUses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		build      func(*Conversation)
+		wantSealed int
+	}{
+		{
+			name:       "empty conversation has nothing to seal",
+			build:      func(*Conversation) {},
+			wantSealed: 0,
+		},
+		{
+			name: "no assistant message means no tool_use can exist",
+			build: func(c *Conversation) {
+				c.AddUser("hi")
+			},
+			wantSealed: 0,
+		},
+		{
+			name: "assistant message without tool calls needs no repair",
+			build: func(c *Conversation) {
+				c.AddUser("hi")
+				c.AddAssistant([]ContentBlock{{Type: "text", Text: "just talking"}})
+			},
+			wantSealed: 0,
+		},
+		{
+			name: "a tool_use already answered is left alone",
+			build: func(c *Conversation) {
+				c.AddUser("hi")
+				c.AddAssistant([]ContentBlock{
+					{Type: "tool_use", ID: "call_1", Name: "read_file"},
+				})
+				c.AddToolResult("call_1", "contents", false)
+			},
+			wantSealed: 0,
+		},
+		{
+			name: "only the unanswered half of a batch is sealed",
+			build: func(c *Conversation) {
+				c.AddUser("hi")
+				c.AddAssistant([]ContentBlock{
+					{Type: "tool_use", ID: "call_1", Name: "read_file"},
+					{Type: "tool_use", ID: "call_2", Name: "read_file"},
+				})
+				c.AddToolResult("call_1", "contents", false)
+			},
+			wantSealed: 1,
+		},
+		{
+			name: "a tool_use with no ID cannot be answered and is skipped",
+			build: func(c *Conversation) {
+				c.AddUser("hi")
+				c.AddAssistant([]ContentBlock{
+					{Type: "tool_use", ID: "", Name: "read_file"},
+				})
+			},
+			wantSealed: 0,
+		},
+		{
+			name: "only the most recent assistant turn is considered",
+			build: func(c *Conversation) {
+				c.AddAssistant([]ContentBlock{
+					{Type: "tool_use", ID: "old_call", Name: "read_file"},
+				})
+				c.AddUser("next")
+				c.AddAssistant([]ContentBlock{{Type: "text", Text: "done"}})
+			},
+			wantSealed: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			conv := NewConversation("sys")
+			tt.build(conv)
+			before := len(conv.Messages())
+
+			got := SealOrphanedToolUses(conv, "test reason")
+
+			assert.Equal(t, tt.wantSealed, got)
+			assert.Len(t, conv.Messages(), before+tt.wantSealed,
+				"sealed count and appended messages must agree")
+		})
+	}
+}
+
+// TestSealOrphanedToolUsesSynthesizedResult pins what a sealed result says.
+// The text reaches the model on the next turn and lands in captured
+// conversations, so both the tool name and the reason have to survive.
+func TestSealOrphanedToolUsesSynthesizedResult(t *testing.T) {
+	t.Parallel()
+
+	conv := NewConversation("sys")
+	conv.AddUser("hi")
+	conv.AddAssistant([]ContentBlock{
+		{Type: "tool_use", ID: "call_1", Name: "read_file"},
+	})
+
+	require.Equal(t, 1, SealOrphanedToolUses(conv, OrphanReasonToolCancel))
+
+	block := lastToolResult(t, conv)
+	assert.Equal(t, "call_1", block.ToolUseID)
+	assert.True(t, block.IsError, "a tool that never ran is not a success")
+	assert.Contains(t, block.Text, "read_file", "the model needs to know which tool failed")
+	assert.Contains(t, block.Text, OrphanReasonToolCancel)
+}
+
+// TestSealOrphanedToolUsesUnnamedTool covers the fallback for a tool_use whose
+// name never arrived — possible when a stream dies mid-block. The result still
+// has to be emitted, since the protocol cares about the ID, not the name.
+func TestSealOrphanedToolUsesUnnamedTool(t *testing.T) {
+	t.Parallel()
+
+	conv := NewConversation("sys")
+	conv.AddAssistant([]ContentBlock{
+		{Type: "tool_use", ID: "call_1", Name: ""},
+	})
+
+	require.Equal(t, 1, SealOrphanedToolUses(conv, "stream died"))
+
+	text := lastToolResult(t, conv).Text
+	assert.Contains(t, text, "<unknown>",
+		"an unnamed tool should read as unknown rather than leaving a gap in the sentence")
+	assert.False(t, strings.Contains(text, "tool  did not"),
+		"the name placeholder should not collapse into a double space")
+}
+
+func lastToolResult(t *testing.T, conv *Conversation) ContentBlock {
+	t.Helper()
+	msgs := conv.Messages()
+	for i := len(msgs) - 1; i >= 0; i-- {
+		for _, b := range msgs[i].Content {
+			if b.Type == "tool_result" {
+				return b
+			}
+		}
+	}
+	t.Fatalf("no tool_result found in conversation")
+	return ContentBlock{}
+}


### PR DESCRIPTION
Closes #325 — the concrete next step named by the convergence record (#326).

`pkg/agentsdk.executeTools` was the one step never unified with `internal/agent`&#39;s, and the cancellation fixes from #322/#324 had never reached it. Rather than porting patches, the sealing walk itself is now shared, so a fix to either core reaches both by construction.

## Three defects

**1. No orphan sealing on cancellation — live.** `pkg/agentsdk` had no `synthesizeMissingToolResults` equivalent anywhere. A cancelled batch left the tools that never ran without a `tool_result`, which the wire protocol forbids.

Only observable **across turns**: `Agent` keeps one `Conversation` for its lifetime and `Turn` appends, so the malformed history survived the cancelled turn and would be sent to the provider on the next one. `TestAgentContextCancelledMidToolBatch` already asserted the second tool is skipped — the precondition — without checking the conversation was repaired.

**2. No orphan sealing on panic — live, found in review.** `runLoop` commits the assistant message before `executeTools`, and `ApprovalFlow.Decide` then calls embedder-supplied callbacks (`ApprovalChecker.CheckApproval`, `ApprovalFunc`, `UIRequestHandler.Request`) with no recovery boundary of its own — `dispatchTool`&#39;s recover sits further in and never sees them. So a panicking approval callback reaches `Turn`&#39;s handler with `tool_use` blocks already in history.

I had argued on this PR that this path needed no sealing, on the grounds that no assistant message was committed yet. That was wrong: I enumerated the tool, middleware, background-task and strategy boundaries and overlooked the approval callbacks. `internal/agent` has sealed this path since `orphanReasonPanic`; the portable loop had not. Caught by CodeRabbit.

**3. Trailing-cancel blindness — latent.** `ctx.Err()` tested only at the loop top, so a cancellation landing during the **final** tool was reported as a clean batch. No observable effect today — the loop&#39;s next-iteration check emits the same events one beat later — but `internal/agent` shows what it costs once a caller consumes the value, where the `task_complete` path reported success for a cancelled turn until `ccea1cb`.

## Changes

| | |
|---|---|
| `[STRUCTURAL]` | Move Method: orphan sealing → `agentsdk.SealOrphanedToolUses`, over a two-method `ToolResultConversation` interface both `Conversation` types already satisfy. `internal/agent` delegates; call sites and reason constants unchanged |
| `[BEHAVIORAL]` | Portable loop&#39;s cancel path calls the shared sealer |
| `[STRUCTURAL]` | `internal`&#39;s tool-cancel reason aliases `agentsdk.OrphanReasonToolCancel` |
| `[BEHAVIORAL]` | `executeTools` returns `ctx.Err() != nil` from its tail |
| `[BEHAVIORAL]` | Portable loop&#39;s panic path calls the shared sealer |
| `[STRUCTURAL]` | `internal`&#39;s panic reason aliases `agentsdk.OrphanReasonPanic` |
| `[BEHAVIORAL]` | Contract tests for the shared sealer |

The interface works because `internal/provider.Message` is an alias of `agentsdk.Message`, so `internal/agent.Conversation.Messages() []provider.Message` matches exactly — no adapter, and no `internal/` import in `pkg/` (guard still green).

## Tests

Each behavioral change red first.

| Test | Red output |
|---|---|
| `TestAgentCancelledBatchLeavesConversationProtocolValid` | `tool_use "tc_2" (echo) has no matching tool_result; the next Turn would send this conversation and fail a protocol check` |
| `TestAgentApprovalPanicLeavesConversationProtocolValid` | same, for `tc_1` via a panicking approval callback |
| `TestAgentTrailingCancelIsReportedAsCancelled` | `cancellation during the final tool must be reported, not swallowed by the loop ending` |

The trailing-cancel test asserts the **return value** rather than the event stream, since the events are identical either way — the honest way to cover a latent defect.

`SealOrphanedToolUses` also gained table-driven contract tests for the branches deciding when *not* to repair (already-answered, no assistant turn, no `tool_use`, missing ID, stale earlier turn) plus the synthesized result&#39;s shape and the `<unknown>` name fallback. Coverage of the function: 90.6% → **100%**.

## Scope

This shares the cancellation *contract*, not batch execution. `internal/agent.executeTools` still carries approval partitioning, parallel policy, the batch executor, and result budgets with no SDK counterpart; unifying those is the larger convergence work #326 keeps as the target. What&#39;s closed is the fork that produced these defects.

## Verification

`internal/agent` (27.0s), `pkg/...`, `internal/skills/...`, `internal/toolexec`, `internal/modes/...`, `test/e2e`, `examples/...` green. `gofmt`/`go vet`/`go build` clean. Import-boundary guards pass.

Pre-existing environmental failures, verified identical on `main`: `cmd/rubichan` sqlite (`out of memory (14)`), `internal/checkpoint` and `internal/config` unreadable-path tests (they chmod a path unwritable, which no-ops as root).

Note: Codex hit its review usage limit partway through, so CodeRabbit is the only bot reviewer on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK