### PR TITLE
Fix Ollama stream hangs and provider/model-default resolution

### DIFF
--- a/cmd/rubichan/coverage_test.go
+++ b/cmd/rubichan/coverage_test.go
@@ -2227,6 +2227,75 @@ func TestWireExtendedTools_AllEnabled(t *testing.T) {
 // loadConfig with custom config path
 // ---------------------------------------------------------------------------
 
+func TestLoadConfig_AnthropicDefaultModel(t *testing.T) {
+	oldConfigPath := configPath
+	oldModelFlag := modelFlag
+	oldProviderFlag := providerFlag
+	defer func() {
+		configPath = oldConfigPath
+		modelFlag = oldModelFlag
+		providerFlag = oldProviderFlag
+	}()
+
+	configPath = filepath.Join(t.TempDir(), "nonexistent-config.toml")
+	modelFlag = ""
+	// Explicit, not "" — an empty providerFlag would run autoDetectProvider,
+	// which probes a real local Ollama server if one happens to be running
+	// on this machine (see autoDetectProvider), making the test environment-
+	// dependent. Being explicit keeps this deterministic.
+	providerFlag = "anthropic"
+
+	cfg, err := loadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "anthropic", cfg.Provider.Default)
+	assert.Equal(t, "claude-sonnet-4-5", cfg.Provider.Model)
+}
+
+func TestLoadConfig_ZaiDefaultModel_FallsBackWhenUnset(t *testing.T) {
+	oldConfigPath := configPath
+	oldModelFlag := modelFlag
+	oldProviderFlag := providerFlag
+	defer func() {
+		configPath = oldConfigPath
+		modelFlag = oldModelFlag
+		providerFlag = oldProviderFlag
+	}()
+
+	configPath = filepath.Join(t.TempDir(), "nonexistent-config.toml")
+	modelFlag = ""
+	providerFlag = "zai"
+
+	cfg, err := loadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "glm-5", cfg.Provider.Model)
+}
+
+func TestLoadConfig_ZaiDefaultModel_UsesConfiguredZaiModel(t *testing.T) {
+	oldConfigPath := configPath
+	oldModelFlag := modelFlag
+	oldProviderFlag := providerFlag
+	defer func() {
+		configPath = oldConfigPath
+		modelFlag = oldModelFlag
+		providerFlag = oldProviderFlag
+	}()
+
+	toml := `
+[provider.zai]
+model = "custom-glm"
+`
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(toml), 0o600))
+
+	configPath = path
+	modelFlag = ""
+	providerFlag = "zai"
+
+	cfg, err := loadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "custom-glm", cfg.Provider.Model)
+}
+
 func TestLoadConfig_WithCustomConfigPath(t *testing.T) {
 	oldConfigPath := configPath
 	oldModelFlag := modelFlag

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1344,6 +1344,16 @@ func loadConfig() (*config.Config, error) {
 		fmt.Fprintln(os.Stderr, "Using local Ollama (no API key configured)")
 	}
 
+	// Resolve Z.ai's default model if provider is zai and no model specified
+	// via --model. [provider.zai].model wins over the built-in fallback.
+	if cfg.Provider.Default == "zai" && cfg.Provider.Model == "" {
+		if cfg.Provider.Zai.Model != "" {
+			cfg.Provider.Model = cfg.Provider.Zai.Model
+		} else {
+			cfg.Provider.Model = "glm-5"
+		}
+	}
+
 	// Resolve Ollama model if provider is ollama and no model specified.
 	if cfg.Provider.Default == "ollama" && cfg.Provider.Model == "" {
 		model, err := resolveOllamaModel(ollamaURL)
@@ -1352,6 +1362,13 @@ func loadConfig() (*config.Config, error) {
 		}
 		cfg.Provider.Model = model
 		fmt.Fprintf(os.Stderr, "Using Ollama model: %s\n", model)
+	}
+
+	// Resolve Anthropic's default model if it's the (possibly auto-detected)
+	// provider and no model was specified. This runs last so it only ever
+	// fills in what the provider-specific resolutions above left empty.
+	if cfg.Provider.Default == "anthropic" && cfg.Provider.Model == "" {
+		cfg.Provider.Model = "claude-sonnet-4-5"
 	}
 
 	return cfg, nil

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1659,6 +1659,7 @@ func TestSetModel(t *testing.T) {
 	mp := &mockProvider{}
 	reg := tools.NewRegistry()
 	cfg := config.DefaultConfig()
+	cfg.Provider.Model = "claude-sonnet-4-5"
 	agent := New(mp, reg, autoApprove, cfg)
 
 	assert.Equal(t, "claude-sonnet-4-5", agent.model)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -399,11 +399,19 @@ func Save(path string, cfg *Config) error {
 }
 
 // DefaultConfig returns a Config populated with sensible default values.
+//
+// Provider.Model is intentionally left empty here rather than baked to an
+// Anthropic-specific default: the correct default model depends on which
+// provider ends up selected (via flag, auto-detection, or this default's own
+// Provider.Default), which isn't known until cmd/rubichan's loadConfig() has
+// finished resolving the provider. Defaulting the model here unconditionally
+// previously caused every non-anthropic provider's own default-model
+// resolution (Ollama auto-detection, Z.ai's built-in fallback) to see a
+// non-empty Model and skip resolving anything provider-appropriate.
 func DefaultConfig() *Config {
 	return &Config{
 		Provider: ProviderConfig{
 			Default: "anthropic",
-			Model:   "claude-sonnet-4-5",
 			Anthropic: AnthropicProviderConfig{
 				APIKeySource: "env",
 			},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,7 +14,9 @@ func TestDefaultConfig(t *testing.T) {
 
 	cfg := DefaultConfig()
 	assert.Equal(t, "anthropic", cfg.Provider.Default)
-	assert.Equal(t, "claude-sonnet-4-5", cfg.Provider.Model)
+	// Model defaulting is provider-dependent and resolved by
+	// cmd/rubichan's loadConfig() after the provider is finalized, not here.
+	assert.Empty(t, cfg.Provider.Model)
 	assert.Equal(t, 50, cfg.Agent.MaxTurns)
 	assert.Equal(t, "prompt", cfg.Agent.ApprovalMode)
 	assert.Equal(t, 100000, cfg.Agent.ContextBudget)

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -123,11 +123,6 @@ func newZaiProvider(cfg *config.Config) (LLMProvider, error) {
 		baseURL = "https://api.z.ai/api/coding/paas/v4"
 	}
 
-	model := cfg.Provider.Zai.Model
-	if model == "" {
-		model = "glm-5"
-	}
-
 	return constructor(baseURL, apiKey, nil), nil
 }
 

--- a/internal/provider/ollama/provider.go
+++ b/internal/provider/ollama/provider.go
@@ -27,6 +27,7 @@ type Provider struct {
 	nextToolID  atomic.Int64
 	keepAlive   string
 	debugLogger provider.DebugLogger
+	watchdogCfg provider.WatchdogConfig
 }
 
 // SetDebugLogger enables debug logging for API requests and responses.
@@ -52,6 +53,13 @@ func (p *Provider) SetHTTPClient(c *http.Client) {
 // An empty string means the provider default ("5m") will be used.
 func (p *Provider) SetKeepAlive(d string) {
 	p.keepAlive = d
+}
+
+// SetWatchdogConfig overrides the stream idle-watchdog thresholds. Intended
+// for tests; production code relies on the zero value (provider.WatchBody's
+// 45s/90s defaults).
+func (p *Provider) SetWatchdogConfig(cfg provider.WatchdogConfig) {
+	p.watchdogCfg = cfg
 }
 
 // KeepAlive returns the configured keep_alive duration, or empty if unset.
@@ -308,13 +316,31 @@ func (p *Provider) convertUserMessages(msg provider.Message) []apiMessage {
 }
 
 // processStream reads NDJSON lines from the response body and sends StreamEvents.
+// The body is wrapped in an idle watchdog: Ollama can stall mid-stream
+// (stuck model load, keep_alive swap, GPU busy) without closing the
+// connection, and the shared HTTP client has no top-level timeout for
+// exactly this reason — long streams are expected to run for minutes.
+// Without the watchdog, a stall here blocks forever with no way out short
+// of the caller cancelling ctx, which foreground turns don't do.
 func (p *Provider) processStream(ctx context.Context, body io.ReadCloser, ch chan<- provider.StreamEvent) {
 	defer close(ch)
-	defer body.Close()
+
+	onWarn := func() {
+		if p.debugLogger != nil {
+			p.debugLogger("[DEBUG] ollama: stream idle for 45s, still waiting")
+		}
+	}
+	onKill := func() {
+		if p.debugLogger != nil {
+			p.debugLogger("[DEBUG] ollama: stream killed after idle timeout")
+		}
+	}
+	watched := provider.WatchBody(body, p.watchdogCfg, onWarn, onKill)
+	defer watched.Close()
 
 	gotDone := false
 
-	scanner := bufio.NewScanner(body)
+	scanner := bufio.NewScanner(watched)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
 	for scanner.Scan() {
 		if ctx.Err() != nil {

--- a/internal/provider/ollama/provider_test.go
+++ b/internal/provider/ollama/provider_test.go
@@ -173,6 +173,66 @@ func TestStreamContextCancellation(t *testing.T) {
 done:
 }
 
+func TestStreamStalledConnectionIsKilledByWatchdog(t *testing.T) {
+	// Server sends one chunk, then goes silent forever without closing the
+	// connection and without the client ever cancelling its context. This
+	// simulates a stuck local model (stalled GPU, keep_alive swap, etc.).
+	// Only the idle watchdog can unblock the reader in this scenario.
+	server := testutil.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok, "expected http.Flusher")
+
+		fmt.Fprintf(w, `{"model":"llama3","message":{"role":"assistant","content":"Hello"},"done":false}`+"\n")
+		flusher.Flush()
+
+		// Go silent. Block until the test's http.Client gives up (via
+		// request cancellation on test cleanup) rather than closing here,
+		// so the only thing that can end the client-side read is the
+		// watchdog closing the body.
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	p := New(server.URL)
+	p.SetHTTPClient(&http.Client{})
+	p.SetWatchdogConfig(provider.WatchdogConfig{
+		WarnAfter: 20 * time.Millisecond,
+		KillAfter: 50 * time.Millisecond,
+	})
+
+	req := provider.CompletionRequest{
+		Model:     "llama3",
+		Messages:  []provider.Message{provider.NewUserMessage("Hi")},
+		MaxTokens: 1024,
+	}
+
+	// No cancellation — a real foreground turn context has no deadline.
+	ch, err := p.Stream(context.Background(), req)
+	require.NoError(t, err)
+
+	var sawError bool
+	timeout := time.After(2 * time.Second)
+	for done := false; !done; {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				done = true
+				break
+			}
+			if evt.Type == "error" {
+				sawError = true
+			}
+		case <-timeout:
+			t.Fatal("stream did not close after idle watchdog kill window — hang not detected")
+		}
+	}
+
+	assert.True(t, sawError, "expected an error event once the watchdog killed the stalled stream")
+}
+
 func TestStreamToolCallResponse(t *testing.T) {
 	ndjsonBody := `{"model":"llama3","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"read_file","arguments":{"path":"/tmp/test.txt"}}}]},"done":false}
 {"model":"llama3","message":{"role":"assistant","content":""},"done":true}


### PR DESCRIPTION
## Summary

Investigated "CLI sometimes stuck" per the debugging skill's root-cause process. Found and fixed the actual hang cause, plus a deeper pre-existing bug it led to in provider/model defaulting.

- **Ollama stream hang (the reported issue):** `internal/provider/ollama/provider.go`'s `processStream` scanned the raw HTTP response body directly, unlike Anthropic and the shared OpenAI-compatible SSE processor, which both wrap the body in `provider.WatchBody` (45s warn / 90s kill idle watchdog). Since the shared HTTP client intentionally has no top-level timeout (streaming needs to run for minutes) and foreground turns have no context deadline, a stalled local Ollama connection (stuck model load, `keep_alive` swap, busy GPU) blocked the stream reader forever with no error — indistinguishable from the CLI just being stuck. Now wired through the same watchdog as the other three providers.

- **Provider/model-default resolution (found while reviewing "provider and model setup"):** `config.DefaultConfig()` unconditionally baked `Provider.Model = "claude-sonnet-4-5"`, before the actual provider is known. This silently defeated every provider-specific model default downstream: confirmed by test that `--provider ollama` alone (no `--model`) never triggers Ollama's own auto-model-detection and instead sends the literal string `"claude-sonnet-4-5"` to the local Ollama server; the same issue meant Z.ai's built-in `"glm-5"` fallback could never apply either. It also meant the TUI first-run bootstrap wizard's model field started pre-filled with the Anthropic model name even when Z.ai or a custom OpenAI-compatible endpoint was selected. Model defaulting now happens once, in `loadConfig()`, after the provider is finalized (flag, auto-detection, or the anthropic default) — matching the existing per-provider resolution pattern instead of undermining it.

- Removed Z.ai's now-fully-dead `"glm-5"` fallback in `factory.go` (its value was never actually used — the real resolution lives in `loadConfig()` now).

## Test plan

- [x] New test proves the stalled-stream hang and the fix (`TestStreamStalledConnectionIsKilledByWatchdog`)
- [x] New tests prove the Z.ai and Anthropic model-default resolution (`TestLoadConfig_ZaiDefaultModel_*`, `TestLoadConfig_AnthropicDefaultModel`)
- [x] `go build ./...`, `gofmt -l .`, `go vet ./...` all clean
- [x] Full suite: `go test ./...` — 7057 passed
- [x] `go test -race ./internal/provider/...` — 321 passed
- [x] Confirmed pre-existing, unrelated flaky races (`TestRunReplayFollow*`, `TestStartAgentSummarization`, `TestAgentContextBudget`) reproduce identically on `main` before these changes — not introduced by this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)