### PR TITLE
Share the seam dispatch and message constructors between the two cores

### DIFF
--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -21,44 +21,17 @@ func WithBackgroundTasks(tasks ...agentsdk.BackgroundTask) AgentOption {
 	}
 }
 
-// startBackgroundTurn starts every registered background task for the
-// current turn and returns the join functions to invoke after tool
-// execution. StartTurn and the joins run on the main turn goroutine, so
-// panics are recovered per task: a bad background optimization must not
-// abort the foreground turn (the outer Turn recover would grade it
-// ExitPanic) or starve sibling tasks.
+// startBackgroundTurn dispatches to the shared seam runtime in
+// pkg/agentsdk, which both loops call so the per-task recover boundaries
+// exist once rather than in two copies.
 func (a *Agent) startBackgroundTurn(ctx context.Context, info agentsdk.BackgroundTurnInfo) []func(context.Context) {
-	var joins []func(context.Context)
-	for _, task := range a.backgroundTasks {
-		if join := a.startTaskRecovering(ctx, task, info); join != nil {
-			joins = append(joins, a.recoveringJoin(join))
-		}
-	}
-	return joins
+	return agentsdk.StartBackgroundTurn(ctx, a.backgroundTasks, info, a.logger)
 }
 
-// startTaskRecovering invokes one task's StartTurn behind a recover
-// boundary; on panic the task contributes no join for this turn.
-func (a *Agent) startTaskRecovering(ctx context.Context, task agentsdk.BackgroundTask, info agentsdk.BackgroundTurnInfo) (join func(context.Context)) {
-	defer func() {
-		if r := recover(); r != nil {
-			a.logger.Warn("background task StartTurn panicked: %v", r)
-		}
-	}()
-	return task.StartTurn(ctx, info)
-}
-
-// recoveringJoin wraps a task's join so a panic in it is contained and
-// logged instead of aborting the turn.
-func (a *Agent) recoveringJoin(join func(context.Context)) func(context.Context) {
-	return func(ctx context.Context) {
-		defer func() {
-			if r := recover(); r != nil {
-				a.logger.Warn("background task join panicked: %v", r)
-			}
-		}()
-		join(ctx)
-	}
+// endBackgroundSession dispatches to the shared seam runtime; see
+// agentsdk.EndBackgroundSession.
+func (a *Agent) endBackgroundSession() {
+	agentsdk.EndBackgroundSession(a.backgroundTasks, a.logger)
 }
 
 // sessionMemoryExtractionTimeout bounds one extraction pass. The
@@ -97,22 +70,3 @@ func (t sessionMemoryBackgroundTask) StartTurn(context.Context, agentsdk.Backgro
 }
 
 func (sessionMemoryBackgroundTask) EndSession(context.Context) {}
-
-// endBackgroundSession signals session end to every registered background
-// task. Each task runs on its own goroutine with a fresh context so
-// session-end work is not bound to the (likely finished) turn context and
-// never blocks the loop's caller. Panics are recovered per task — this is
-// a public seam running third-party code on unsupervised goroutines, where
-// an unrecovered panic would take down the whole process.
-func (a *Agent) endBackgroundSession() {
-	for _, task := range a.backgroundTasks {
-		go func(t agentsdk.BackgroundTask) {
-			defer func() {
-				if r := recover(); r != nil {
-					a.logger.Warn("background task EndSession panicked: %v", r)
-				}
-			}()
-			t.EndSession(context.Background())
-		}(task)
-	}
-}

--- a/internal/agent/context_strategy.go
+++ b/internal/agent/context_strategy.go
@@ -74,25 +74,12 @@ func (a *Agent) staticSectionsRecovering(source agentsdk.StaticPromptSource) (se
 // running on the turn goroutine, where an unrecovered panic would abort
 // the user turn and starve sibling strategies.
 func (a *Agent) contributeStrategySections(ctx context.Context, pb *PromptBuilder, info agentsdk.PromptContext) {
-	for _, strategy := range a.contextStrategies {
-		for _, section := range a.strategySectionsRecovering(ctx, strategy, info) {
-			if strings.TrimSpace(section.Content) == "" {
-				continue
-			}
-			pb.AddDynamicSection_UNCACHED(section.Title, section.Content, section.Reason)
-		}
+	// The iteration, blank-skip and per-strategy recover boundary are shared
+	// with the portable loop; only the sink differs — this core feeds a
+	// PromptBuilder, the SDK returns the slice to its caller.
+	for _, section := range agentsdk.ContributeSections(ctx, a.contextStrategies, info, a.logger) {
+		pb.AddDynamicSection_UNCACHED(section.Title, section.Content, section.Reason)
 	}
-}
-
-// strategySectionsRecovering invokes one strategy behind a recover
-// boundary; on panic the strategy contributes nothing this turn.
-func (a *Agent) strategySectionsRecovering(ctx context.Context, strategy agentsdk.ContextStrategy, info agentsdk.PromptContext) (sections []agentsdk.PromptSection) {
-	defer func() {
-		if r := recover(); r != nil {
-			a.logger.Warn("context strategy ContributePromptSections panicked: %v", r)
-		}
-	}()
-	return strategy.ContributePromptSections(ctx, info)
 }
 
 // builtinContextStrategies returns the agent's built-in prompt

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -16,29 +16,14 @@ type ToolUseBlock = agentsdk.ToolUseBlock
 type StreamEvent = agentsdk.StreamEvent
 
 // NewUserMessage creates a new user message with a single text content block.
+// Delegates to the canonical constructor so this core and the portable one
+// cannot build different shapes for the same message.
 func NewUserMessage(text string) Message {
-	return Message{
-		Role: "user",
-		Content: []ContentBlock{
-			{
-				Type: "text",
-				Text: text,
-			},
-		},
-	}
+	return agentsdk.NewUserMessage(text)
 }
 
-// NewToolResultMessage creates a new tool result message.
+// NewToolResultMessage creates a new tool result message. Delegates to the
+// canonical constructor; see agentsdk.NewToolResultMessage.
 func NewToolResultMessage(toolUseID, content string, isError bool) Message {
-	return Message{
-		Role: "user",
-		Content: []ContentBlock{
-			{
-				Type:      "tool_result",
-				ToolUseID: toolUseID,
-				Text:      content,
-				IsError:   isError,
-			},
-		},
-	}
+	return agentsdk.NewToolResultMessage(toolUseID, content, isError)
 }

--- a/pkg/agentsdk/agent_background.go
+++ b/pkg/agentsdk/agent_background.go
@@ -20,60 +20,14 @@ func WithBackgroundTasks(tasks ...BackgroundTask) Option {
 	}
 }
 
-// startBackgroundTurn starts every registered background task for the
-// current turn and returns the join functions to invoke after tool
-// execution. StartTurn and the joins run on the main turn goroutine, so
-// panics are recovered per task: a bad background optimization must not
-// abort the foreground turn or starve sibling tasks.
+// startBackgroundTurn dispatches to the shared seam runtime; see
+// StartBackgroundTurn for the recover-boundary rationale.
 func (a *Agent) startBackgroundTurn(ctx context.Context, info BackgroundTurnInfo) []func(context.Context) {
-	var joins []func(context.Context)
-	for _, task := range a.backgroundTasks {
-		if join := a.startTaskRecovering(ctx, task, info); join != nil {
-			joins = append(joins, a.recoveringJoin(join))
-		}
-	}
-	return joins
+	return StartBackgroundTurn(ctx, a.backgroundTasks, info, a.logger)
 }
 
-// startTaskRecovering invokes one task's StartTurn behind a recover
-// boundary; on panic the task contributes no join for this turn.
-func (a *Agent) startTaskRecovering(ctx context.Context, task BackgroundTask, info BackgroundTurnInfo) (join func(context.Context)) {
-	defer func() {
-		if r := recover(); r != nil {
-			a.logger.Warn("background task StartTurn panicked: %v", r)
-		}
-	}()
-	return task.StartTurn(ctx, info)
-}
-
-// recoveringJoin wraps a task's join so a panic in it is contained and
-// logged instead of aborting the turn.
-func (a *Agent) recoveringJoin(join func(context.Context)) func(context.Context) {
-	return func(ctx context.Context) {
-		defer func() {
-			if r := recover(); r != nil {
-				a.logger.Warn("background task join panicked: %v", r)
-			}
-		}()
-		join(ctx)
-	}
-}
-
-// endBackgroundSession signals session end to every registered background
-// task. Each task runs on its own goroutine with a fresh context so
-// session-end work is not bound to the (likely finished) turn context and
-// never blocks the loop's caller. Panics are recovered per task — this is a
-// public seam running third-party code on unsupervised goroutines, where an
-// unrecovered panic would take down the whole process.
+// endBackgroundSession dispatches to the shared seam runtime; see
+// EndBackgroundSession.
 func (a *Agent) endBackgroundSession() {
-	for _, task := range a.backgroundTasks {
-		go func(t BackgroundTask) {
-			defer func() {
-				if r := recover(); r != nil {
-					a.logger.Warn("background task EndSession panicked: %v", r)
-				}
-			}()
-			t.EndSession(context.Background())
-		}(task)
-	}
+	EndBackgroundSession(a.backgroundTasks, a.logger)
 }

--- a/pkg/agentsdk/agent_context_strategy.go
+++ b/pkg/agentsdk/agent_context_strategy.go
@@ -54,27 +54,5 @@ func (a *Agent) effectiveSystemPrompt(ctx context.Context, userMessage string) s
 // its non-empty sections. Sections whose content is empty or whitespace-only
 // are skipped, so a strategy whose gate is not met contributes nothing.
 func (a *Agent) contributeStrategySections(ctx context.Context, info PromptContext) []PromptSection {
-	var out []PromptSection
-	for _, strategy := range a.contextStrategies {
-		for _, section := range a.strategySectionsRecovering(ctx, strategy, info) {
-			if strings.TrimSpace(section.Content) == "" {
-				continue
-			}
-			out = append(out, section)
-		}
-	}
-	return out
-}
-
-// strategySectionsRecovering invokes one strategy behind a recover boundary;
-// on panic the strategy contributes nothing this turn. This is a public seam
-// running on the turn goroutine, where an unrecovered panic would abort the
-// user's turn and starve sibling strategies.
-func (a *Agent) strategySectionsRecovering(ctx context.Context, strategy ContextStrategy, info PromptContext) (sections []PromptSection) {
-	defer func() {
-		if r := recover(); r != nil {
-			a.logger.Warn("context strategy ContributePromptSections panicked: %v", r)
-		}
-	}()
-	return strategy.ContributePromptSections(ctx, info)
+	return ContributeSections(ctx, a.contextStrategies, info, a.logger)
 }

--- a/pkg/agentsdk/background.go
+++ b/pkg/agentsdk/background.go
@@ -30,3 +30,67 @@ type BackgroundTask interface {
 	StartTurn(ctx context.Context, info BackgroundTurnInfo) (join func(context.Context))
 	EndSession(ctx context.Context)
 }
+
+// StartBackgroundTurn starts every task for the current turn and returns the
+// join functions to invoke after tool execution.
+//
+// StartTurn and the joins run on the caller's turn goroutine, so panics are
+// recovered per task: a bad background optimization must not abort the
+// foreground turn or starve sibling tasks. A task whose StartTurn panics
+// contributes no join for this turn.
+//
+// This is the seam's dispatch, shared by both agent loops rather than
+// reimplemented in each. The recover boundaries are the reason: defensive
+// code that exists in two copies gains fixes in one, which is how the
+// cancellation handling in tool execution came to differ between the cores.
+func StartBackgroundTurn(ctx context.Context, tasks []BackgroundTask, info BackgroundTurnInfo, logger Logger) []func(context.Context) {
+	var joins []func(context.Context)
+	for _, task := range tasks {
+		if join := startTaskRecovering(ctx, task, info, logger); join != nil {
+			joins = append(joins, recoveringJoin(join, logger))
+		}
+	}
+	return joins
+}
+
+// startTaskRecovering invokes one task's StartTurn behind a recover boundary.
+func startTaskRecovering(ctx context.Context, task BackgroundTask, info BackgroundTurnInfo, logger Logger) (join func(context.Context)) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Warn("background task StartTurn panicked: %v", r)
+		}
+	}()
+	return task.StartTurn(ctx, info)
+}
+
+// recoveringJoin wraps a task's join so a panic in it is contained and logged
+// instead of aborting the turn.
+func recoveringJoin(join func(context.Context), logger Logger) func(context.Context) {
+	return func(ctx context.Context) {
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Warn("background task join panicked: %v", r)
+			}
+		}()
+		join(ctx)
+	}
+}
+
+// EndBackgroundSession signals session end to every task. Each runs on its own
+// goroutine with a fresh context, so session-end work is not bound to the
+// (likely finished) turn context and never blocks the loop's caller. Panics
+// are recovered per task — this is a public seam running third-party code on
+// unsupervised goroutines, where an unrecovered panic would take down the
+// whole process.
+func EndBackgroundSession(tasks []BackgroundTask, logger Logger) {
+	for _, task := range tasks {
+		go func(t BackgroundTask) {
+			defer func() {
+				if r := recover(); r != nil {
+					logger.Warn("background task EndSession panicked: %v", r)
+				}
+			}()
+			t.EndSession(context.Background())
+		}(task)
+	}
+}

--- a/pkg/agentsdk/context_strategy.go
+++ b/pkg/agentsdk/context_strategy.go
@@ -1,6 +1,9 @@
 package agentsdk
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 // PromptContext carries the per-turn inputs the agent loop offers to
 // context strategies at prompt-build time.
@@ -47,4 +50,39 @@ type StaticSection struct {
 // empty or whitespace-only are skipped.
 type StaticPromptSource interface {
 	ContributeStaticSections() []StaticSection
+}
+
+// ContributeSections runs every strategy for one prompt build and returns
+// the sections they produced, skipping any whose content is empty or
+// whitespace-only.
+//
+// Each strategy is invoked behind its own recover boundary: strategies are
+// third-party code running on the turn goroutine, and a panicking one must
+// contribute nothing rather than abort the turn or starve its siblings.
+//
+// Shared by both agent loops. They differ in what they do with the result —
+// one appends to a prompt builder, the other returns the slice — but the
+// iteration and the recover boundary are the part worth having once.
+func ContributeSections(ctx context.Context, strategies []ContextStrategy, info PromptContext, logger Logger) []PromptSection {
+	var out []PromptSection
+	for _, strategy := range strategies {
+		for _, section := range sectionsRecovering(ctx, strategy, info, logger) {
+			if strings.TrimSpace(section.Content) == "" {
+				continue
+			}
+			out = append(out, section)
+		}
+	}
+	return out
+}
+
+// sectionsRecovering invokes one strategy behind a recover boundary; on
+// panic it contributes nothing for this prompt build.
+func sectionsRecovering(ctx context.Context, strategy ContextStrategy, info PromptContext, logger Logger) (sections []PromptSection) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Warn("context strategy ContributePromptSections panicked: %v", r)
+		}
+	}()
+	return strategy.ContributePromptSections(ctx, info)
 }

--- a/pkg/agentsdk/conversation.go
+++ b/pkg/agentsdk/conversation.go
@@ -23,12 +23,7 @@ func (c *Conversation) Messages() []Message {
 
 // AddUser appends a user text message.
 func (c *Conversation) AddUser(text string) {
-	c.messages = append(c.messages, Message{
-		Role: "user",
-		Content: []ContentBlock{
-			{Type: "text", Text: text},
-		},
-	})
+	c.messages = append(c.messages, NewUserMessage(text))
 }
 
 // AddAssistant appends an assistant message with the given content blocks.
@@ -41,17 +36,7 @@ func (c *Conversation) AddAssistant(blocks []ContentBlock) {
 
 // AddToolResult appends a tool result message.
 func (c *Conversation) AddToolResult(toolUseID, content string, isError bool) {
-	c.messages = append(c.messages, Message{
-		Role: "user",
-		Content: []ContentBlock{
-			{
-				Type:      "tool_result",
-				ToolUseID: toolUseID,
-				Text:      content,
-				IsError:   isError,
-			},
-		},
-	})
+	c.messages = append(c.messages, NewToolResultMessage(toolUseID, content, isError))
 }
 
 // Clear removes all messages, preserving the system prompt.

--- a/pkg/agentsdk/types.go
+++ b/pkg/agentsdk/types.go
@@ -199,3 +199,36 @@ func marshalSafeRawJSON(raw json.RawMessage) json.RawMessage {
 	}
 	return json.RawMessage(fallback)
 }
+
+// NewUserMessage builds a user message carrying a single text block.
+//
+// Canonical constructor for the wire shape: both agent cores and
+// internal/provider build user messages through this, so the shape cannot
+// drift between them the way two matching struct literals silently can.
+func NewUserMessage(text string) Message {
+	return Message{
+		Role: "user",
+		Content: []ContentBlock{
+			{Type: "text", Text: text},
+		},
+	}
+}
+
+// NewToolResultMessage builds the user-role message that answers a tool_use
+// block. Every tool_use must be followed by one of these — see
+// SealOrphanedToolUses for what happens when one is missing.
+//
+// Canonical constructor, for the same reason as NewUserMessage.
+func NewToolResultMessage(toolUseID, content string, isError bool) Message {
+	return Message{
+		Role: "user",
+		Content: []ContentBlock{
+			{
+				Type:      "tool_result",
+				ToolUseID: toolUseID,
+				Text:      content,
+				IsError:   isError,
+			},
+		},
+	}
+}


### PR DESCRIPTION
Closes the follow-ups the drift audit (#328) named. All three commits are `[STRUCTURAL]` — **no behavior change, and no bug fixed today.** This is prevention: collapsing duplication that has not drifted yet, because the one place it did drift (`executeTools`) cost two defects and five review findings.

## What was duplicated

**Background-task dispatch** — `startBackgroundTurn`, `startTaskRecovering`, `recoveringJoin`, `endBackgroundSession` existed twice, line-for-line identical down to the log messages. #328&#39;s same-filename comparison missed the pair because the SDK splits the interface (`background.go`) from the dispatch (`agent_background.go`).

**Strategy contribution** — `strategySectionsRecovering` identical; `contributeStrategySections` differed only in its *sink*: `internal/agent` feeds a `PromptBuilder`, the SDK returns a slice.

**Message construction** — `Conversation.AddUser` / `AddToolResult` built messages via `provider.NewUserMessage`/`NewToolResultMessage` in one core and inline struct literals in the other. #328 verified they produce byte-identical shapes, but only by coincidence of two literals that happen to match.

These are all per-task recover boundaries and wire-shape constructors — defensive code, which is exactly the category that gains a fix on one side only.

## What changed

| | |
|---|---|
| `agentsdk.StartBackgroundTurn` / `EndBackgroundSession` | take `[]BackgroundTask` and `Logger` rather than an `Agent`; both cores already hold those types, so no adapter was needed. Private methods stay as one-line delegates, leaving call sites and `background_test.go` untouched |
| `agentsdk.ContributeSections` | owns the iteration, blank-content skip and per-strategy recover boundary, and returns the sections. The SDK&#39;s method delegates; internal&#39;s keeps its `PromptBuilder` sink as a loop over the shared result |
| `agentsdk.NewUserMessage` / `NewToolResultMessage` | canonical constructors. `internal/provider`&#39;s delegate to them; the SDK&#39;s `Conversation` calls them instead of inlining literals |

The `tool_result` constructor&#39;s doc points at `SealOrphanedToolUses` — the two describe opposite halves of the same protocol rule.

## Why now rather than the bigger items

Review capacity is thin: Codex is out of budget entirely and CodeRabbit is rate-limiting to roughly hourly. Structural work whose correctness is settled by existing tests is the right thing to spend that window on. `agent.go`&#39;s two loops and Phase 3&#39;s `main.go` reduction both need more judgment review than is available.

## Verification

`internal/agent` (27.9s), `pkg/agentsdk`, `internal/provider`, `internal/modes/...`, `internal/skills/...`, `test/e2e`, `examples/...` green. `gofmt`/`go vet`/`go build` clean. Import-boundary guards pass — the shared functions live in `pkg` and take only `pkg` types.

Pre-existing environmental failures, verified identical on `main`: `internal/checkpoint` and `internal/config` chmod-unwritable tests (no-op as root), and `cmd/rubichan` sqlite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_