### PR TITLE
Extract process diagnostics out of main.go into internal/diag

### DIFF
--- a/cmd/rubichan/coverage_test.go
+++ b/cmd/rubichan/coverage_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -839,20 +838,6 @@ func TestConfigDir_ReturnsExpectedPath(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getActiveSessionLogPath / setActiveSessionLogPath
-// ---------------------------------------------------------------------------
-
-func TestActiveSessionLogPath_RoundTrip(t *testing.T) {
-	// Save and restore since this modifies global state.
-	prev := getActiveSessionLogPath()
-	defer setActiveSessionLogPath(prev)
-
-	setActiveSessionLogPath("/tmp/test-session.log")
-	assert.Equal(t, "/tmp/test-session.log", getActiveSessionLogPath())
-}
-
-// ---------------------------------------------------------------------------
-// storeMemoryAdapter
 // ---------------------------------------------------------------------------
 
 func TestStoreMemoryAdapter_SaveAndLoad(t *testing.T) {
@@ -1042,120 +1027,6 @@ func TestIndexProjectFiles_NonGitDir(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// captureAllStacks
-// ---------------------------------------------------------------------------
-
-func TestCaptureAllStacks_ReturnsNonEmpty(t *testing.T) {
-	t.Parallel()
-	stacks := captureAllStacks()
-	assert.NotEmpty(t, stacks)
-	assert.Contains(t, string(stacks), "goroutine")
-}
-
-// ---------------------------------------------------------------------------
-// writeStackDump
-// ---------------------------------------------------------------------------
-
-func TestWriteStackDump_CreatesFile(t *testing.T) {
-	t.Parallel()
-	cfgDir := t.TempDir()
-	path, err := writeStackDump(cfgDir, "test-dump.log", "header: test\n\n")
-	require.NoError(t, err)
-	require.FileExists(t, path)
-
-	data, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.Contains(t, string(data), "header: test")
-	assert.Contains(t, string(data), "goroutine")
-}
-
-func TestWriteStackDump_InvalidDir(t *testing.T) {
-	t.Parallel()
-	// Using a file path as the config dir should fail.
-	tmpFile := filepath.Join(t.TempDir(), "not-a-dir")
-	require.NoError(t, os.WriteFile(tmpFile, []byte("x"), 0o644))
-
-	_, err := writeStackDump(tmpFile, "dump.log", "header\n")
-	assert.Error(t, err)
-}
-
-// ---------------------------------------------------------------------------
-// writeDiagnosticDump
-// ---------------------------------------------------------------------------
-
-func TestWriteDiagnosticDump_CreatesFile(t *testing.T) {
-	t.Parallel()
-	cfgDir := t.TempDir()
-	path, err := writeDiagnosticDump(cfgDir, os.Interrupt, "/tmp/session.log")
-	require.NoError(t, err)
-	require.FileExists(t, path)
-
-	data, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.Contains(t, string(data), "signal: interrupt")
-	assert.Contains(t, string(data), "session_log: /tmp/session.log")
-}
-
-// ---------------------------------------------------------------------------
-// buildEventSink — additional cases
-// ---------------------------------------------------------------------------
-
-func TestBuildEventSink_DebugOnly(t *testing.T) {
-	t.Parallel()
-	sink := buildEventSink(nil, true)
-	require.Len(t, sink, 1) // log sink only
-}
-
-func TestBuildEventSink_DebugWithStructuredLog(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "events.jsonl")
-	logger, err := startEventLogger(path)
-	require.NoError(t, err)
-	defer logger.Close()
-
-	sink := buildEventSink(logger, true)
-	require.Len(t, sink, 2) // log sink + JSONL sink
-}
-
-// ---------------------------------------------------------------------------
-// eventLogger.Close — nil safety
-// ---------------------------------------------------------------------------
-
-func TestEventLoggerClose_Nil(t *testing.T) {
-	t.Parallel()
-	var el *eventLogger
-	assert.NoError(t, el.Close())
-}
-
-// ---------------------------------------------------------------------------
-// sessionLogger.Close — nil safety
-// ---------------------------------------------------------------------------
-
-func TestSessionLoggerClose_Nil(t *testing.T) {
-	t.Parallel()
-	var sl *sessionLogger
-	assert.NoError(t, sl.Close())
-}
-
-// ---------------------------------------------------------------------------
-// startEventLogger
-// ---------------------------------------------------------------------------
-
-func TestStartEventLogger_EmptyPath(t *testing.T) {
-	t.Parallel()
-	logger, err := startEventLogger("")
-	assert.NoError(t, err)
-	assert.Nil(t, logger)
-}
-
-func TestStartEventLogger_WhitespacePath(t *testing.T) {
-	t.Parallel()
-	logger, err := startEventLogger("   ")
-	assert.NoError(t, err)
-	assert.Nil(t, logger)
-}
-
-// ---------------------------------------------------------------------------
-// buildPipeline
 // ---------------------------------------------------------------------------
 
 func TestBuildPipeline_NilRuntime(t *testing.T) {
@@ -1903,18 +1774,6 @@ func TestSingleLinePlainPreview(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// logFileSuffix — additional check
-// ---------------------------------------------------------------------------
-
-func TestLogFileSuffix_ContainsPID(t *testing.T) {
-	t.Parallel()
-	now := time.Now()
-	suffix := logFileSuffix(now)
-	assert.Contains(t, suffix, fmt.Sprintf("%d", os.Getpid()))
-}
-
-// ---------------------------------------------------------------------------
-// loadConfig — basic test with default config
 // ---------------------------------------------------------------------------
 
 func TestLoadConfig_Default(t *testing.T) {

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -12,9 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"sync"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -31,6 +29,7 @@ import (
 	"github.com/julianshen/rubichan/internal/cmux"
 	"github.com/julianshen/rubichan/internal/commands"
 	"github.com/julianshen/rubichan/internal/config"
+	"github.com/julianshen/rubichan/internal/diag"
 	"github.com/julianshen/rubichan/internal/hooks"
 	"github.com/julianshen/rubichan/internal/integrations"
 	"github.com/julianshen/rubichan/internal/knowledgegraph"
@@ -46,7 +45,6 @@ import (
 	"github.com/julianshen/rubichan/internal/security/analyzer"
 	secoutput "github.com/julianshen/rubichan/internal/security/output"
 	"github.com/julianshen/rubichan/internal/security/scanner"
-	"github.com/julianshen/rubichan/internal/session"
 	"github.com/julianshen/rubichan/internal/skills"
 	"github.com/julianshen/rubichan/internal/skills/builtin"
 	"github.com/julianshen/rubichan/internal/skills/builtin/appledev"
@@ -132,9 +130,6 @@ var (
 	wikiOutFlag         string
 	wikiFormatFlag      string
 	wikiConcurrencyFlag int
-
-	activeSessionLogMu   sync.RWMutex
-	activeSessionLogPath string
 
 	newProviderWithDebug = provider.NewProviderWithDebug
 )
@@ -250,167 +245,6 @@ func handleInteractiveProgramError(err error, runCtx context.Context, phase stri
 	return fmt.Errorf("%s: %w", phase, err)
 }
 
-func setActiveSessionLogPath(path string) {
-	activeSessionLogMu.Lock()
-	defer activeSessionLogMu.Unlock()
-	activeSessionLogPath = path
-}
-
-func getActiveSessionLogPath() string {
-	activeSessionLogMu.RLock()
-	defer activeSessionLogMu.RUnlock()
-	return activeSessionLogPath
-}
-
-type sessionLogger struct {
-	file       *os.File
-	path       string
-	prevWriter io.Writer
-	prevFlags  int
-}
-
-type eventLogger struct {
-	file *os.File
-	path string
-}
-
-func logFileSuffix(now time.Time) string {
-	return fmt.Sprintf("%s-%d", now.UTC().Format("20060102-150405.000000000"), os.Getpid())
-}
-
-func captureAllStacks() []byte {
-	buf := make([]byte, 1<<20)
-	for len(buf) <= 16<<20 {
-		n := runtime.Stack(buf, true)
-		if n < len(buf) {
-			return buf[:n]
-		}
-		buf = make([]byte, len(buf)*2)
-	}
-	n := runtime.Stack(buf, true)
-	return buf[:n]
-}
-
-func writeStackDump(cfgDir, fileName, header string) (string, error) {
-	logDir := filepath.Join(cfgDir, "logs")
-	if err := os.MkdirAll(logDir, 0o700); err != nil {
-		return "", fmt.Errorf("creating log directory: %w", err)
-	}
-
-	path := filepath.Join(logDir, fileName)
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return "", fmt.Errorf("opening dump file: %w", err)
-	}
-	defer f.Close()
-
-	if _, err := io.WriteString(f, header); err != nil {
-		return "", fmt.Errorf("writing dump header: %w", err)
-	}
-	if _, err := f.Write(captureAllStacks()); err != nil {
-		return "", fmt.Errorf("writing dump stack: %w", err)
-	}
-
-	return path, nil
-}
-
-func startSessionLogger(cfgDir string, mirrorToStderr bool) (*sessionLogger, error) {
-	logDir := filepath.Join(cfgDir, "logs")
-	if err := os.MkdirAll(logDir, 0o700); err != nil {
-		return nil, fmt.Errorf("creating log directory: %w", err)
-	}
-
-	path := filepath.Join(logDir, fmt.Sprintf("rubichan-%s.log", logFileSuffix(time.Now())))
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("opening session log: %w", err)
-	}
-
-	sl := &sessionLogger{
-		file:       f,
-		path:       path,
-		prevWriter: log.Writer(),
-		prevFlags:  log.Flags(),
-	}
-	setActiveSessionLogPath(path)
-	logWriter := io.Writer(f)
-	if mirrorToStderr {
-		logWriter = io.MultiWriter(os.Stderr, f)
-	}
-	log.SetOutput(logWriter)
-	log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.LUTC)
-	log.Printf("rubichan session log started: %s", path)
-	return sl, nil
-}
-
-func (sl *sessionLogger) Close() error {
-	if sl == nil {
-		return nil
-	}
-	log.Printf("rubichan session log finished")
-	log.SetOutput(sl.prevWriter)
-	log.SetFlags(sl.prevFlags)
-	return sl.file.Close()
-}
-
-func startEventLogger(path string) (*eventLogger, error) {
-	if strings.TrimSpace(path) == "" {
-		return nil, nil
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return nil, fmt.Errorf("creating event log directory: %w", err)
-	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("opening event log: %w", err)
-	}
-	return &eventLogger{file: f, path: path}, nil
-}
-
-func (el *eventLogger) Close() error {
-	if el == nil {
-		return nil
-	}
-	return el.file.Close()
-}
-
-// buildEventSink centralizes interactive/headless session event wiring.
-// Human-readable log mirroring is intentionally debug-only; when callers
-// request only --event-log, events are written to JSONL without also being
-// mirrored through the standard logger.
-func buildEventSink(structuredEventLog *eventLogger, debug bool) session.MultiSink {
-	var sink session.MultiSink
-	if debug {
-		sink = append(sink, session.NewLogSink(log.Printf))
-	}
-	if structuredEventLog != nil {
-		sink = append(sink, session.NewJSONLSink(structuredEventLog.file))
-	}
-	return sink
-}
-
-func writeDiagnosticDump(cfgDir string, sig os.Signal, sessionLogPath string) (string, error) {
-	now := time.Now()
-	header := fmt.Sprintf(
-		"timestamp: %s\nsignal: %s\nsession_log: %s\n\n",
-		now.UTC().Format(time.RFC3339Nano),
-		sig.String(),
-		sessionLogPath,
-	)
-	return writeStackDump(cfgDir, fmt.Sprintf("diagnostic-%s-%s.log", strings.ToLower(sig.String()), logFileSuffix(now)), header)
-}
-
-func writePanicDump(cfgDir string, recovered any, sessionLogPath string) (string, error) {
-	now := time.Now()
-	header := fmt.Sprintf(
-		"timestamp: %s\npanic: %v\nsession_log: %s\n\n",
-		now.UTC().Format(time.RFC3339Nano),
-		recovered,
-		sessionLogPath,
-	)
-	return writeStackDump(cfgDir, fmt.Sprintf("panic-%s.log", logFileSuffix(now)), header)
-}
-
 // setupWorkingDir determines the effective working directory. When --worktree
 // is specified, it creates/reuses a worktree and returns a cleanup function
 // that auto-removes the worktree if it has no changes. The returned manager
@@ -478,9 +312,9 @@ func main() {
 	cfgDir, cfgDirErr := configDir()
 	defer func() {
 		if r := recover(); r != nil {
-			sessionLogPath := getActiveSessionLogPath()
+			sessionLogPath := diag.ActiveSessionLogPath()
 			if cfgDirErr == nil {
-				if path, err := writePanicDump(cfgDir, r, sessionLogPath); err != nil {
+				if path, err := diag.WritePanicDump(cfgDir, r, sessionLogPath); err != nil {
 					fmt.Fprintf(os.Stderr, "warning: failed to write panic dump: %v\n", err)
 				} else {
 					fmt.Fprintf(os.Stderr, "panic dump written to %s\n", path)
@@ -1460,18 +1294,18 @@ func runInteractive() error {
 	}
 	runCtx, cancelRun := context.WithCancelCause(context.Background())
 	defer cancelRun(nil)
-	sessionLog, err := startSessionLogger(cfgDir, debugMode)
+	sessionLog, err := diag.StartSessionLogger(cfgDir, debugMode)
 	if err != nil {
 		return err
 	}
-	structuredEventLog, err := startEventLogger(eventLogPath)
+	structuredEventLog, err := diag.StartEventLogger(eventLogPath)
 	if err != nil {
 		if closeErr := sessionLog.Close(); closeErr != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to close session log: %v\n", closeErr)
 		}
 		return err
 	}
-	stopSignals := startInteractiveSignalHandler(cfgDir, sessionLog.path, cancelRun)
+	stopSignals := startInteractiveSignalHandler(cfgDir, sessionLog.Path(), cancelRun)
 	defer stopSignals()
 	defer func() {
 		if closeErr := sessionLog.Close(); closeErr != nil {
@@ -1788,7 +1622,7 @@ func runInteractive() error {
 	if rt != nil {
 		model.SetSkillSummaryProvider(rt)
 	}
-	sink := buildEventSink(structuredEventLog, debugMode)
+	sink := diag.BuildEventSink(structuredEventLog, debugMode)
 	model.SetEventSink(sink)
 	if plainHost != nil {
 		plainHost.SetEventSink(sink)
@@ -2157,7 +1991,7 @@ func runHeadless() error {
 	if err != nil {
 		return err
 	}
-	structuredEventLog, err := startEventLogger(eventLogPath)
+	structuredEventLog, err := diag.StartEventLogger(eventLogPath)
 	if err != nil {
 		return err
 	}
@@ -2352,7 +2186,7 @@ func runHeadless() error {
 	// Run LLM review and security scan concurrently for code-review mode.
 	hr := runner.NewHeadlessRunner(a.Turn)
 	hr.SetModelName(cfg.Provider.Model)
-	if sink := buildEventSink(structuredEventLog, debugMode); len(sink) > 0 {
+	if sink := diag.BuildEventSink(structuredEventLog, debugMode); len(sink) > 0 {
 		hr.SetEventSink(sink)
 	}
 	promptText = applyHeadlessBootstrapProbePrompt(promptText, headlessToolsCfg.ShouldEnable("shell"))

--- a/cmd/rubichan/main_test.go
+++ b/cmd/rubichan/main_test.go
@@ -4,15 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/julianshen/rubichan/internal/agent"
@@ -21,7 +17,6 @@ import (
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/runner"
 	"github.com/julianshen/rubichan/internal/security"
-	"github.com/julianshen/rubichan/internal/session"
 	"github.com/julianshen/rubichan/internal/store"
 	"github.com/julianshen/rubichan/internal/testutil"
 	"github.com/julianshen/rubichan/internal/tools/xcode"
@@ -80,127 +75,6 @@ func TestInteractiveExitErrorReturnsExitErrorForSignalAbort(t *testing.T) {
 	var exitErr *runner.ExitError
 	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, 131, exitErr.Code)
-}
-
-func TestStartSessionLoggerWritesFileAndRestoresLogger(t *testing.T) {
-	origWriter := log.Writer()
-	origFlags := log.Flags()
-	var sentinel bytes.Buffer
-	log.SetOutput(&sentinel)
-	log.SetFlags(123)
-	defer log.SetOutput(origWriter)
-	defer log.SetFlags(origFlags)
-
-	logger, err := startSessionLogger(t.TempDir(), false)
-	require.NoError(t, err)
-	require.FileExists(t, logger.path)
-
-	log.Printf("captured line")
-
-	require.NoError(t, logger.Close())
-
-	data, err := os.ReadFile(logger.path)
-	require.NoError(t, err)
-	assert.Contains(t, string(data), "rubichan session log started")
-	assert.Contains(t, string(data), "captured line")
-	assert.Contains(t, string(data), "rubichan session log finished")
-	info, err := os.Stat(logger.path)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
-	assert.Contains(t, filepath.Base(logger.path), strconv.Itoa(os.Getpid()))
-	dirInfo, err := os.Stat(filepath.Dir(logger.path))
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm())
-	assert.NotContains(t, sentinel.String(), "captured line")
-	log.Print("restored line")
-	assert.Contains(t, sentinel.String(), "restored line")
-	assert.Equal(t, 123, log.Flags())
-}
-
-func TestStartSessionLoggerMirrorsToStderrInDebugMode(t *testing.T) {
-	origWriter := log.Writer()
-	origFlags := log.Flags()
-	origStderr := os.Stderr
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	defer func() { _ = r.Close() }()
-	os.Stderr = w
-	log.SetFlags(123)
-	defer log.SetOutput(origWriter)
-	defer log.SetFlags(origFlags)
-	defer func() { os.Stderr = origStderr }()
-
-	logger, err := startSessionLogger(t.TempDir(), true)
-	require.NoError(t, err)
-
-	log.Printf("debug line")
-
-	require.NoError(t, logger.Close())
-	require.NoError(t, w.Close())
-	data, err := io.ReadAll(r)
-	require.NoError(t, err)
-	assert.Contains(t, string(data), "debug line")
-}
-
-func TestStartEventLoggerWritesJSONLFile(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "events", "session.jsonl")
-	logger, err := startEventLogger(path)
-	require.NoError(t, err)
-	require.NotNil(t, logger)
-	require.Equal(t, path, logger.path)
-
-	_, err = logger.file.WriteString("{\"type\":\"command_result\"}\n")
-	require.NoError(t, err)
-	require.NoError(t, logger.Close())
-
-	data, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.Contains(t, string(data), `"type":"command_result"`)
-	info, err := os.Stat(path)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
-}
-
-func TestBuildEventSinkWithoutDebugAndEventLogIsNoOp(t *testing.T) {
-	sink := buildEventSink(nil, false)
-	require.Len(t, sink, 0)
-	assert.NotPanics(t, func() {
-		sink.Emit(session.NewTurnStartedEvent("prompt", "model"))
-	})
-}
-
-func TestBuildEventSinkIncludesJSONLWithoutDebug(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "events", "session.jsonl")
-	logger, err := startEventLogger(path)
-	require.NoError(t, err)
-	require.NoError(t, logger.Close())
-
-	sink := buildEventSink(logger, false)
-	require.Len(t, sink, 1)
-}
-
-func TestWritePanicDumpIncludesPanicAndSessionLog(t *testing.T) {
-	cfgDir := t.TempDir()
-	dumpPath, err := writePanicDump(cfgDir, "boom", "/tmp/session.log")
-	require.NoError(t, err)
-	require.FileExists(t, dumpPath)
-
-	data, err := os.ReadFile(dumpPath)
-	require.NoError(t, err)
-	text := string(data)
-	assert.Contains(t, text, "panic: boom")
-	assert.Contains(t, text, "session_log: /tmp/session.log")
-	assert.Contains(t, text, "goroutine")
-	info, err := os.Stat(dumpPath)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
-	assert.Contains(t, filepath.Base(dumpPath), strconv.Itoa(os.Getpid()))
-}
-
-func TestLogFileSuffixIncludesTimestampAndPID(t *testing.T) {
-	now := time.Date(2026, time.March, 11, 21, 15, 30, 123456789, time.FixedZone("UTC+8", 8*3600))
-	suffix := logFileSuffix(now)
-	assert.Equal(t, fmt.Sprintf("20260311-131530.123456789-%d", os.Getpid()), suffix)
 }
 
 func TestStartInteractiveSignalHandlerStopIsIdempotent(t *testing.T) {

--- a/cmd/rubichan/main_unix.go
+++ b/cmd/rubichan/main_unix.go
@@ -9,6 +9,8 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+
+	"github.com/julianshen/rubichan/internal/diag"
 )
 
 func startInteractiveSignalHandler(cfgDir, sessionLogPath string, cancel context.CancelCauseFunc) func() {
@@ -32,7 +34,7 @@ func startInteractiveSignalHandler(cfgDir, sessionLogPath string, cancel context
 		select {
 		case sig := <-sigCh:
 			stop()
-			path, err := writeDiagnosticDump(cfgDir, sig, sessionLogPath)
+			path, err := diag.WriteDiagnosticDump(cfgDir, sig, sessionLogPath)
 			if err != nil {
 				log.Printf("failed to write %s diagnostic dump: %v", sig.String(), err)
 			} else {

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -1,0 +1,228 @@
+// Package diag owns the CLI's process-level diagnostics: the session log,
+// the structured event log, and the stack dumps written on signal or panic.
+//
+// It is infrastructure rather than agent behaviour, which is why it lives
+// outside cmd/: main.go's job is composition, and file layout, permissions
+// and log-writer swapping are none of its business. Extracted from
+// cmd/rubichan/main.go as the first slice of the redesign's Phase 3.
+package diag
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/julianshen/rubichan/internal/session"
+)
+
+var (
+	activeSessionLogMu   sync.RWMutex
+	activeSessionLogPath string
+)
+
+// SetActiveSessionLogPath records the session log's location so dumps
+// written later — including from a signal handler on another goroutine —
+// can point an operator at it.
+func SetActiveSessionLogPath(path string) {
+	activeSessionLogMu.Lock()
+	defer activeSessionLogMu.Unlock()
+	activeSessionLogPath = path
+}
+
+// ActiveSessionLogPath returns the path recorded by SetActiveSessionLogPath,
+// or the empty string when no session log is open.
+func ActiveSessionLogPath() string {
+	activeSessionLogMu.RLock()
+	defer activeSessionLogMu.RUnlock()
+	return activeSessionLogPath
+}
+
+// SessionLogger redirects the standard logger to a per-session file and
+// restores the previous writer on Close.
+type SessionLogger struct {
+	file       *os.File
+	path       string
+	prevWriter io.Writer
+	prevFlags  int
+}
+
+// Path returns the session log's location on disk.
+func (sl *SessionLogger) Path() string {
+	if sl == nil {
+		return ""
+	}
+	return sl.path
+}
+
+// EventLogger writes structured session events as JSONL.
+type EventLogger struct {
+	file *os.File
+	path string
+}
+
+// Path returns the event log's location on disk.
+func (el *EventLogger) Path() string {
+	if el == nil {
+		return ""
+	}
+	return el.path
+}
+
+// LogFileSuffix builds the timestamp+pid suffix that keeps concurrent
+// rubichan processes from colliding on a log filename.
+func LogFileSuffix(now time.Time) string {
+	return fmt.Sprintf("%s-%d", now.UTC().Format("20060102-150405.000000000"), os.Getpid())
+}
+
+// CaptureAllStacks returns a goroutine dump for every goroutine, growing the
+// buffer until the dump fits or 16MiB is reached — a truncated dump is worse
+// than a large one when diagnosing a deadlock.
+func CaptureAllStacks() []byte {
+	buf := make([]byte, 1<<20)
+	for len(buf) <= 16<<20 {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return buf[:n]
+		}
+		buf = make([]byte, len(buf)*2)
+	}
+	n := runtime.Stack(buf, true)
+	return buf[:n]
+}
+
+// WriteStackDump writes header followed by a full goroutine dump into
+// cfgDir/logs/fileName and returns the path written.
+func WriteStackDump(cfgDir, fileName, header string) (string, error) {
+	logDir := filepath.Join(cfgDir, "logs")
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		return "", fmt.Errorf("creating log directory: %w", err)
+	}
+
+	path := filepath.Join(logDir, fileName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("opening dump file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := io.WriteString(f, header); err != nil {
+		return "", fmt.Errorf("writing dump header: %w", err)
+	}
+	if _, err := f.Write(CaptureAllStacks()); err != nil {
+		return "", fmt.Errorf("writing dump stack: %w", err)
+	}
+
+	return path, nil
+}
+
+// StartSessionLogger opens a new session log under cfgDir/logs and points the
+// standard logger at it, mirroring to stderr when asked. The file is opened
+// O_EXCL so two processes cannot share one log.
+func StartSessionLogger(cfgDir string, mirrorToStderr bool) (*SessionLogger, error) {
+	logDir := filepath.Join(cfgDir, "logs")
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		return nil, fmt.Errorf("creating log directory: %w", err)
+	}
+
+	path := filepath.Join(logDir, fmt.Sprintf("rubichan-%s.log", LogFileSuffix(time.Now())))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("opening session log: %w", err)
+	}
+
+	sl := &SessionLogger{
+		file:       f,
+		path:       path,
+		prevWriter: log.Writer(),
+		prevFlags:  log.Flags(),
+	}
+	SetActiveSessionLogPath(path)
+	logWriter := io.Writer(f)
+	if mirrorToStderr {
+		logWriter = io.MultiWriter(os.Stderr, f)
+	}
+	log.SetOutput(logWriter)
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.LUTC)
+	log.Printf("rubichan session log started: %s", path)
+	return sl, nil
+}
+
+// Close restores the previous log writer and flags, then closes the file.
+func (sl *SessionLogger) Close() error {
+	if sl == nil {
+		return nil
+	}
+	log.Printf("rubichan session log finished")
+	log.SetOutput(sl.prevWriter)
+	log.SetFlags(sl.prevFlags)
+	return sl.file.Close()
+}
+
+// StartEventLogger opens the JSONL event log at path. A blank path means the
+// caller did not ask for one, and yields a nil logger rather than an error.
+func StartEventLogger(path string) (*EventLogger, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("creating event log directory: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("opening event log: %w", err)
+	}
+	return &EventLogger{file: f, path: path}, nil
+}
+
+// Close closes the event log file.
+func (el *EventLogger) Close() error {
+	if el == nil {
+		return nil
+	}
+	return el.file.Close()
+}
+
+// BuildEventSink centralizes interactive/headless session event wiring.
+// Human-readable log mirroring is intentionally debug-only; when callers
+// request only --event-log, events are written to JSONL without also being
+// mirrored through the standard logger.
+func BuildEventSink(structuredEventLog *EventLogger, debug bool) session.MultiSink {
+	var sink session.MultiSink
+	if debug {
+		sink = append(sink, session.NewLogSink(log.Printf))
+	}
+	if structuredEventLog != nil {
+		sink = append(sink, session.NewJSONLSink(structuredEventLog.file))
+	}
+	return sink
+}
+
+// WriteDiagnosticDump records a goroutine dump taken in response to a signal.
+func WriteDiagnosticDump(cfgDir string, sig os.Signal, sessionLogPath string) (string, error) {
+	now := time.Now()
+	header := fmt.Sprintf(
+		"timestamp: %s\nsignal: %s\nsession_log: %s\n\n",
+		now.UTC().Format(time.RFC3339Nano),
+		sig.String(),
+		sessionLogPath,
+	)
+	return WriteStackDump(cfgDir, fmt.Sprintf("diagnostic-%s-%s.log", strings.ToLower(sig.String()), LogFileSuffix(now)), header)
+}
+
+// WritePanicDump records a goroutine dump taken while unwinding a panic.
+func WritePanicDump(cfgDir string, recovered any, sessionLogPath string) (string, error) {
+	now := time.Now()
+	header := fmt.Sprintf(
+		"timestamp: %s\npanic: %v\nsession_log: %s\n\n",
+		now.UTC().Format(time.RFC3339Nano),
+		recovered,
+		sessionLogPath,
+	)
+	return WriteStackDump(cfgDir, fmt.Sprintf("panic-%s.log", LogFileSuffix(now)), header)
+}

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -66,14 +66,6 @@ type EventLogger struct {
 	path string
 }
 
-// Path returns the event log's location on disk.
-func (el *EventLogger) Path() string {
-	if el == nil {
-		return ""
-	}
-	return el.path
-}
-
 // LogFileSuffix builds the timestamp+pid suffix that keeps concurrent
 // rubichan processes from colliding on a log filename.
 func LogFileSuffix(now time.Time) string {

--- a/internal/diag/diag_test.go
+++ b/internal/diag/diag_test.go
@@ -1,0 +1,257 @@
+package diag
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/julianshen/rubichan/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActiveSessionLogPath_RoundTrip(t *testing.T) {
+	// Save and restore since this modifies global state.
+	prev := ActiveSessionLogPath()
+	defer SetActiveSessionLogPath(prev)
+
+	SetActiveSessionLogPath("/tmp/test-session.log")
+	assert.Equal(t, "/tmp/test-session.log", ActiveSessionLogPath())
+}
+
+// storeMemoryAdapter
+
+func TestCaptureAllStacks_ReturnsNonEmpty(t *testing.T) {
+	t.Parallel()
+	stacks := CaptureAllStacks()
+	assert.NotEmpty(t, stacks)
+	assert.Contains(t, string(stacks), "goroutine")
+}
+
+// writeStackDump
+
+func TestWriteStackDump_CreatesFile(t *testing.T) {
+	t.Parallel()
+	cfgDir := t.TempDir()
+	path, err := WriteStackDump(cfgDir, "test-dump.log", "header: test\n\n")
+	require.NoError(t, err)
+	require.FileExists(t, path)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "header: test")
+	assert.Contains(t, string(data), "goroutine")
+}
+
+func TestWriteStackDump_InvalidDir(t *testing.T) {
+	t.Parallel()
+	// Using a file path as the config dir should fail.
+	tmpFile := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("x"), 0o644))
+
+	_, err := WriteStackDump(tmpFile, "dump.log", "header\n")
+	assert.Error(t, err)
+}
+
+// writeDiagnosticDump
+
+func TestWriteDiagnosticDump_CreatesFile(t *testing.T) {
+	t.Parallel()
+	cfgDir := t.TempDir()
+	path, err := WriteDiagnosticDump(cfgDir, os.Interrupt, "/tmp/session.log")
+	require.NoError(t, err)
+	require.FileExists(t, path)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "signal: interrupt")
+	assert.Contains(t, string(data), "session_log: /tmp/session.log")
+}
+
+// buildEventSink — additional cases
+
+func TestBuildEventSink_DebugOnly(t *testing.T) {
+	t.Parallel()
+	sink := BuildEventSink(nil, true)
+	require.Len(t, sink, 1) // log sink only
+}
+
+func TestBuildEventSink_DebugWithStructuredLog(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	logger, err := StartEventLogger(path)
+	require.NoError(t, err)
+	defer logger.Close()
+
+	sink := BuildEventSink(logger, true)
+	require.Len(t, sink, 2) // log sink + JSONL sink
+}
+
+// eventLogger.Close — nil safety
+
+func TestEventLoggerClose_Nil(t *testing.T) {
+	t.Parallel()
+	var el *EventLogger
+	assert.NoError(t, el.Close())
+}
+
+// sessionLogger.Close — nil safety
+
+func TestSessionLoggerClose_Nil(t *testing.T) {
+	t.Parallel()
+	var sl *SessionLogger
+	assert.NoError(t, sl.Close())
+}
+
+// startEventLogger
+
+func TestStartEventLogger_EmptyPath(t *testing.T) {
+	t.Parallel()
+	logger, err := StartEventLogger("")
+	assert.NoError(t, err)
+	assert.Nil(t, logger)
+}
+
+func TestStartEventLogger_WhitespacePath(t *testing.T) {
+	t.Parallel()
+	logger, err := StartEventLogger("   ")
+	assert.NoError(t, err)
+	assert.Nil(t, logger)
+}
+
+// buildPipeline
+
+func TestLogFileSuffix_ContainsPID(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	suffix := LogFileSuffix(now)
+	assert.Contains(t, suffix, fmt.Sprintf("%d", os.Getpid()))
+}
+
+// loadConfig — basic test with default config
+
+func TestStartSessionLoggerWritesFileAndRestoresLogger(t *testing.T) {
+	origWriter := log.Writer()
+	origFlags := log.Flags()
+	var sentinel bytes.Buffer
+	log.SetOutput(&sentinel)
+	log.SetFlags(123)
+	defer log.SetOutput(origWriter)
+	defer log.SetFlags(origFlags)
+
+	logger, err := StartSessionLogger(t.TempDir(), false)
+	require.NoError(t, err)
+	require.FileExists(t, logger.Path())
+
+	log.Printf("captured line")
+
+	require.NoError(t, logger.Close())
+
+	data, err := os.ReadFile(logger.Path())
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "rubichan session log started")
+	assert.Contains(t, string(data), "captured line")
+	assert.Contains(t, string(data), "rubichan session log finished")
+	info, err := os.Stat(logger.Path())
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	assert.Contains(t, filepath.Base(logger.Path()), strconv.Itoa(os.Getpid()))
+	dirInfo, err := os.Stat(filepath.Dir(logger.Path()))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm())
+	assert.NotContains(t, sentinel.String(), "captured line")
+	log.Print("restored line")
+	assert.Contains(t, sentinel.String(), "restored line")
+	assert.Equal(t, 123, log.Flags())
+}
+
+func TestStartSessionLoggerMirrorsToStderrInDebugMode(t *testing.T) {
+	origWriter := log.Writer()
+	origFlags := log.Flags()
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+	os.Stderr = w
+	log.SetFlags(123)
+	defer log.SetOutput(origWriter)
+	defer log.SetFlags(origFlags)
+	defer func() { os.Stderr = origStderr }()
+
+	logger, err := StartSessionLogger(t.TempDir(), true)
+	require.NoError(t, err)
+
+	log.Printf("debug line")
+
+	require.NoError(t, logger.Close())
+	require.NoError(t, w.Close())
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "debug line")
+}
+
+func TestStartEventLoggerWritesJSONLFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events", "session.jsonl")
+	logger, err := StartEventLogger(path)
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+	require.Equal(t, path, logger.Path())
+
+	_, err = logger.file.WriteString("{\"type\":\"command_result\"}\n")
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"type":"command_result"`)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestBuildEventSinkWithoutDebugAndEventLogIsNoOp(t *testing.T) {
+	sink := BuildEventSink(nil, false)
+	require.Len(t, sink, 0)
+	assert.NotPanics(t, func() {
+		sink.Emit(session.NewTurnStartedEvent("prompt", "model"))
+	})
+}
+
+func TestBuildEventSinkIncludesJSONLWithoutDebug(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events", "session.jsonl")
+	logger, err := StartEventLogger(path)
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+
+	sink := BuildEventSink(logger, false)
+	require.Len(t, sink, 1)
+}
+
+func TestWritePanicDumpIncludesPanicAndSessionLog(t *testing.T) {
+	cfgDir := t.TempDir()
+	dumpPath, err := WritePanicDump(cfgDir, "boom", "/tmp/session.log")
+	require.NoError(t, err)
+	require.FileExists(t, dumpPath)
+
+	data, err := os.ReadFile(dumpPath)
+	require.NoError(t, err)
+	text := string(data)
+	assert.Contains(t, text, "panic: boom")
+	assert.Contains(t, text, "session_log: /tmp/session.log")
+	assert.Contains(t, text, "goroutine")
+	info, err := os.Stat(dumpPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	assert.Contains(t, filepath.Base(dumpPath), strconv.Itoa(os.Getpid()))
+}
+
+func TestLogFileSuffixIncludesTimestampAndPID(t *testing.T) {
+	now := time.Date(2026, time.March, 11, 21, 15, 30, 123456789, time.FixedZone("UTC+8", 8*3600))
+	suffix := LogFileSuffix(now)
+	assert.Equal(t, fmt.Sprintf("20260311-131530.123456789-%d", os.Getpid()), suffix)
+}

--- a/internal/diag/diag_test.go
+++ b/internal/diag/diag_test.go
@@ -108,8 +108,6 @@ func TestSessionLoggerClose_Nil(t *testing.T) {
 	assert.NoError(t, sl.Close())
 }
 
-// startEventLogger
-
 func TestStartEventLogger_EmptyPath(t *testing.T) {
 	t.Parallel()
 	logger, err := StartEventLogger("")
@@ -200,7 +198,7 @@ func TestStartEventLoggerWritesJSONLFile(t *testing.T) {
 	logger, err := StartEventLogger(path)
 	require.NoError(t, err)
 	require.NotNil(t, logger)
-	require.Equal(t, path, logger.Path())
+	require.Equal(t, path, logger.path)
 
 	_, err = logger.file.WriteString("{\"type\":\"command_result\"}\n")
 	require.NoError(t, err)

--- a/internal/diag/diag_unix_test.go
+++ b/internal/diag/diag_unix_test.go
@@ -1,6 +1,6 @@
 //go:build unix
 
-package main
+package diag
 
 import (
 	"os"
@@ -15,7 +15,7 @@ import (
 
 func TestWriteDiagnosticDumpIncludesSignalAndSessionLog(t *testing.T) {
 	cfgDir := t.TempDir()
-	dumpPath, err := writeDiagnosticDump(cfgDir, syscall.SIGQUIT, "/tmp/session.log")
+	dumpPath, err := WriteDiagnosticDump(cfgDir, syscall.SIGQUIT, "/tmp/session.log")
 	require.NoError(t, err)
 	require.FileExists(t, dumpPath)
 


### PR DESCRIPTION
First slice of **Phase 3**, which the redesign doc targets as reducing `cmd/rubichan/main.go` to composition only — 3,383 lines against a stated goal of a few hundred.

Two `[STRUCTURAL]` commits. No behavior change.

## Why this cluster first

`main.go` has 102 functions. The diagnostics group is the cleanest boundary in it: twelve declarations with no agent coupling, no mode coupling, and real existing test coverage. Session logging, the JSONL event log, and the stack dumps written on signal or panic are process infrastructure — file layout, permissions, and swapping the standard logger&#39;s writer are none of a composition root&#39;s business.

## What moved

`StartSessionLogger`, `StartEventLogger`, `BuildEventSink`, `WriteStackDump`, `WriteDiagnosticDump`, `WritePanicDump`, `CaptureAllStacks`, `LogFileSuffix`, the `SessionLogger` / `EventLogger` types, and the active-session-log accessors — those last exist because a signal handler on another goroutine needs to name the log in its dump.

Seven call sites in `main.go` and `main_unix.go` repointed.

`SessionLogger` gained a `Path()` accessor because `main.go` read the unexported field. `EventLogger` briefly gained one too; CodeRabbit pointed out it had no production consumer, so it was removed and its same-package test reads the field directly — the new package&#39;s exported surface is only what callers actually need.

## Verification approach

**The twenty tests covering these functions moved with the code**, adapted only for the exported names. That&#39;s deliberate: the extraction is verified by the same assertions that guarded the behavior before, not by new ones written afterward.

To confirm nothing was silently dropped, I extracted every moved test body from the pre-move sources, applied the identifier renames, and diffed against the new file. Nine of twenty differed — **every difference a stripped `// ---` divider comment, zero assertion changes.** CodeRabbit verified the same independently.

Retained assertions cover file permissions (`0o600`), the `O_EXCL` open, logger writer *and* flags restored on `Close`, nil-receiver `Close` on both types, blank/whitespace event-log paths, dump headers containing the signal or panic value plus the session-log path, and the timestamp+PID suffix format.

`cmd/rubichan/main_unix_test.go` is deleted — its single test was the signal-dump case, now at `internal/diag/diag_unix_test.go` behind the same `//go:build unix` tag.

`main.go`: **3,383 → 3,217 lines.**

## Known gap, not introduced here

There is no test for the `O_EXCL` collision case on the session log. It was absent before the move and remains absent. A deterministic test needs two processes racing on the same timestamp-plus-PID filename; if that&#39;s worth having it belongs in its own change with the cost weighed openly, rather than tacked onto a move.

## Verification

`internal/diag` (20 tests), `internal/agent`, `pkg/...`, `internal/modes/...`, `test/e2e`, `examples/...` green. `gofmt`/`go vet`/`go build` clean.

Pre-existing environmental failures, each verified identical on `main` and unrelated: `cmd/rubichan` sqlite (`out of memory (14)`), and the chmod-unwritable tests in `internal/checkpoint`, `internal/config` and `internal/hooks` — they make a path unwritable, which no-ops as root.

## Scope

One slice, not Phase 3. Remaining clusters in `main.go` worth the same treatment: folder-access approval (4 funcs), model-capability testing (3), skill-runtime construction, and the agent-option wiring helpers. Each independently shippable, and `internal/diag` is now a settled destination for process-level infrastructure.

Codex is out of review budget; CodeRabbit was the only bot reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK