### PR TITLE
Provider registry: declarative construction + default-model resolution

### DIFF
--- a/cmd/rubichan/coverage_test.go
+++ b/cmd/rubichan/coverage_test.go
@@ -1791,13 +1791,21 @@ func TestLoadConfig_WithProviderOverride(t *testing.T) {
 		providerFlag = oldProviderFlag
 	}()
 
-	configPath = ""
+	// A temp, nonexistent path — not "" — so this test doesn't pick up a
+	// real ~/.config/rubichan/config.toml on the machine running it (which
+	// would set Provider.Model from the file, masking the assertion below).
+	configPath = filepath.Join(t.TempDir(), "nonexistent-config.toml")
 	modelFlag = ""
 	providerFlag = "openrouter"
 
 	cfg, err := loadConfig()
 	require.NoError(t, err)
 	assert.Equal(t, "openrouter", cfg.Provider.Default)
+	// "openrouter" isn't a registered provider ID, so ResolveDefaultModel
+	// resolves through the fallback (no DefaultModel resolver) and returns
+	// ErrNoDefaultModel, which loadConfig treats as "leave unset" rather
+	// than a fatal error.
+	assert.Empty(t, cfg.Provider.Model)
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -943,31 +943,6 @@ func autoDetectProvider(cfg *config.Config, providerFlagValue, ollamaURL string)
 	return false
 }
 
-// resolveOllamaModel queries Ollama for available models and resolves which
-// model to use. With a single model it auto-selects; with zero models it
-// returns an error. The ollamaURL parameter allows testing with httptest.
-func resolveOllamaModel(ollamaURL string) (string, error) {
-	client := ollama.NewClient(ollamaURL)
-	models, err := client.ListModels(context.Background())
-	if err != nil {
-		return "", fmt.Errorf("listing Ollama models: %w", err)
-	}
-
-	if len(models) == 0 {
-		return "", fmt.Errorf("no models found; run 'rubichan ollama pull <model>' first")
-	}
-
-	if len(models) == 1 {
-		return models[0].Name, nil
-	}
-
-	// Multiple models — in interactive mode, we'd show a picker.
-	// For now, return the first model. The TUI picker integration
-	// requires running a Bubble Tea program which is complex to wire here.
-	// TODO: integrate tui.ModelPicker when running interactively.
-	return models[0].Name, nil
-}
-
 // loadConfig resolves the config path, loads the config, and applies any
 // flag overrides. This eliminates duplication between runInteractive and
 // runHeadless.
@@ -1024,7 +999,7 @@ func loadConfig() (*config.Config, error) {
 
 	// Resolve Ollama model if provider is ollama and no model specified.
 	if cfg.Provider.Default == "ollama" && cfg.Provider.Model == "" {
-		model, err := resolveOllamaModel(ollamaURL)
+		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -1035,9 +1010,8 @@ func loadConfig() (*config.Config, error) {
 	// Resolve Anthropic's default model if it's the (possibly auto-detected)
 	// provider and no model was specified. This runs last so it only ever
 	// fills in what the provider-specific resolutions above left empty.
-	// (Ollama above still resolves its own default inline until Task 4
-	// migrates it the same way; Task 5 collapses all three into one
-	// generic call once every provider is registered.)
+	// (Task 5 collapses all three into one generic call now that every
+	// provider is registered.)
 	if cfg.Provider.Default == "anthropic" && cfg.Provider.Model == "" {
 		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
 		if err != nil {

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1006,7 +1006,7 @@ func loadConfig() (*config.Config, error) {
 			// No default-model resolution for this provider — leave Model
 			// empty, same as before this provider had a Registry entry.
 		default:
-			return nil, err
+			return nil, fmt.Errorf("resolving default model: %w", err)
 		}
 	}
 

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1013,14 +1013,13 @@ func loadConfig() (*config.Config, error) {
 		fmt.Fprintln(os.Stderr, "Using local Ollama (no API key configured)")
 	}
 
-	// Resolve Z.ai's default model if provider is zai and no model specified
-	// via --model. [provider.zai].model wins over the built-in fallback.
+	// Resolve Z.ai's default model if provider is zai and no model specified.
 	if cfg.Provider.Default == "zai" && cfg.Provider.Model == "" {
-		if cfg.Provider.Zai.Model != "" {
-			cfg.Provider.Model = cfg.Provider.Zai.Model
-		} else {
-			cfg.Provider.Model = "glm-5"
+		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
+		if err != nil {
+			return nil, err
 		}
+		cfg.Provider.Model = model
 	}
 
 	// Resolve Ollama model if provider is ollama and no model specified.
@@ -1036,8 +1035,8 @@ func loadConfig() (*config.Config, error) {
 	// Resolve Anthropic's default model if it's the (possibly auto-detected)
 	// provider and no model was specified. This runs last so it only ever
 	// fills in what the provider-specific resolutions above left empty.
-	// (Zai/Ollama above still resolve their own default inline until Tasks
-	// 3-4 migrate them the same way; Task 5 collapses all three into one
+	// (Ollama above still resolves its own default inline until Task 4
+	// migrates it the same way; Task 5 collapses all three into one
 	// generic call once every provider is registered.)
 	if cfg.Provider.Default == "anthropic" && cfg.Provider.Model == "" {
 		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -988,36 +988,26 @@ func loadConfig() (*config.Config, error) {
 		fmt.Fprintln(os.Stderr, "Using local Ollama (no API key configured)")
 	}
 
-	// Resolve Z.ai's default model if provider is zai and no model specified.
-	if cfg.Provider.Default == "zai" && cfg.Provider.Model == "" {
+	// Resolve the provider's default model if none was specified via
+	// --model or config. Each provider's own resolution logic (constant,
+	// config-driven fallback, or dynamic lookup) lives in its ProviderDef
+	// (internal/provider/{anthropic,zai,ollama}). Providers with no
+	// DefaultModel resolver (e.g. custom OpenAI-compatible endpoints) leave
+	// cfg.Provider.Model unset, matching prior behavior.
+	if cfg.Provider.Model == "" {
 		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
-		if err != nil {
+		switch {
+		case err == nil:
+			cfg.Provider.Model = model
+			if cfg.Provider.Default == "ollama" {
+				fmt.Fprintf(os.Stderr, "Using Ollama model: %s\n", model)
+			}
+		case errors.Is(err, provider.ErrNoDefaultModel):
+			// No default-model resolution for this provider — leave Model
+			// empty, same as before this provider had a Registry entry.
+		default:
 			return nil, err
 		}
-		cfg.Provider.Model = model
-	}
-
-	// Resolve Ollama model if provider is ollama and no model specified.
-	if cfg.Provider.Default == "ollama" && cfg.Provider.Model == "" {
-		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
-		if err != nil {
-			return nil, err
-		}
-		cfg.Provider.Model = model
-		fmt.Fprintf(os.Stderr, "Using Ollama model: %s\n", model)
-	}
-
-	// Resolve Anthropic's default model if it's the (possibly auto-detected)
-	// provider and no model was specified. This runs last so it only ever
-	// fills in what the provider-specific resolutions above left empty.
-	// (Task 5 collapses all three into one generic call now that every
-	// provider is registered.)
-	if cfg.Provider.Default == "anthropic" && cfg.Provider.Model == "" {
-		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
-		if err != nil {
-			return nil, err
-		}
-		cfg.Provider.Model = model
 	}
 
 	return cfg, nil

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -1036,8 +1036,15 @@ func loadConfig() (*config.Config, error) {
 	// Resolve Anthropic's default model if it's the (possibly auto-detected)
 	// provider and no model was specified. This runs last so it only ever
 	// fills in what the provider-specific resolutions above left empty.
+	// (Zai/Ollama above still resolve their own default inline until Tasks
+	// 3-4 migrate them the same way; Task 5 collapses all three into one
+	// generic call once every provider is registered.)
 	if cfg.Provider.Default == "anthropic" && cfg.Provider.Model == "" {
-		cfg.Provider.Model = "claude-sonnet-4-5"
+		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Provider.Model = model
 	}
 
 	return cfg, nil

--- a/cmd/rubichan/main_test.go
+++ b/cmd/rubichan/main_test.go
@@ -281,48 +281,6 @@ func TestAutoDetectProvider_APIKeyExists(t *testing.T) {
 	assert.False(t, detected)
 }
 
-func TestResolveOllamaModel_SingleModel(t *testing.T) {
-	srv := testutil.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"models": [{"name": "llama3.2:latest", "size": 4294967296}]}`))
-	}))
-	defer srv.Close()
-
-	model, err := resolveOllamaModel(srv.URL)
-	require.NoError(t, err)
-	assert.Equal(t, "llama3.2:latest", model)
-}
-
-func TestResolveOllamaModel_NoModels(t *testing.T) {
-	srv := testutil.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"models": []}`))
-	}))
-	defer srv.Close()
-
-	_, err := resolveOllamaModel(srv.URL)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no models found")
-}
-
-func TestResolveOllamaModel_MultipleModels(t *testing.T) {
-	srv := testutil.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"models": [
-			{"name": "llama3.2:latest", "size": 4294967296},
-			{"name": "codellama:7b", "size": 3758096384}
-		]}`))
-	}))
-	defer srv.Close()
-
-	model, err := resolveOllamaModel(srv.URL)
-	require.NoError(t, err)
-	assert.Equal(t, "llama3.2:latest", model) // returns first model
-}
-
-func TestResolveOllamaModel_ConnectionError(t *testing.T) {
-	_, err := resolveOllamaModel("http://localhost:1")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "listing Ollama models")
-}
-
 // saveFlags saves the current apiBaseFlag and apiKeyFlag values and registers
 // a t.Cleanup to restore them after the test completes.
 func saveFlags(t *testing.T) {

--- a/docs/superpowers/plans/2026-07-28-provider-registry.md
+++ b/docs/superpowers/plans/2026-07-28-provider-registry.md
@@ -12,7 +12,7 @@
 
 - TDD strictly: one test at a time, Red → Green → Refactor → Commit. Never write implementation before the test.
 - Commit prefixes: `[STRUCTURAL]` (no behavior change) or `[BEHAVIORAL]` (new/changed behavior). Never mix both in one commit.
-- Run `go build ./...`, `go test ./...`, `gofmt -l .`, `go vet ./...` after every task; all must be clean before moving on.
+- Run `go build ./...`, `go test ./...`, `go test -cover ./...` (>90% on new code), `gofmt -l .`, `go vet ./...` and `golangci-lint run ./...` after every task; all must be clean before moving on, and the full set repeats at final verification.
 - **Zero duplication, zero dead-code windows.** Every task that adds new provider logic must, in the same commit, delete whichever old logic it supersedes (old switch-case body, old `if`-block, old standalone function). No task may leave the same logic implemented in two places, or leave code nothing calls, for a later task to remove.
 - No behavior change anywhere is a hard requirement, verified at every task boundary — except the one explicitly-flagged, intentional fix in Task 5 (see that task).
 - Never push to `main`. Work happens on `feature/provider-registry` (already created; design spec and a prior draft of this plan are already committed there — this version supersedes that draft, see note below).
@@ -1204,8 +1204,9 @@ func init() {
 // because this provider handles any name found in cfg.Provider.OpenAI —
 // "openai", "openrouter", a custom proxy name, etc. — not one fixed ID.
 // DefaultModel is left nil: this provider has never had default-model
-// resolution (users must pass --model), and Registry.ResolveDefaultModel's
-// ErrNoDefaultModel preserves that — see main.go's loadConfig().
+// resolution, so the model is simply left unset rather than the user being
+// obliged to pass --model. Registry.ResolveDefaultModel's ErrNoDefaultModel
+// preserves that — see main.go's loadConfig().
 func providerDef() provider.ProviderDef {
 	return provider.ProviderDef{
 		ID: "openai",

--- a/docs/superpowers/plans/2026-07-28-provider-registry.md
+++ b/docs/superpowers/plans/2026-07-28-provider-registry.md
@@ -1,0 +1,1486 @@
+# Provider Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `internal/provider/factory.go`'s switch-statement and `cmd/rubichan/main.go`'s three copy-pasted default-model `if`-blocks with one declarative per-provider registration (`ProviderDef`), so construction, auth, base URL, and default-model resolution for a provider are described once instead of as parallel logic in two files.
+
+**Architecture:** A new `Registry` type in `internal/provider/registry.go` holds `ProviderDef` values (one per provider: anthropic, zai, ollama, openai-compatible), each supplying `Constructor`/`BaseURL`/`Auth` (required) and `DefaultModel`/`ListModels` (optional — nil means unsupported). `factory.go`'s public `NewProvider`/`NewProviderWithDebug` become thin delegates to the registry; `main.go`'s `loadConfig()` calls `Registry.ResolveDefaultModel` once instead of three separate blocks.
+
+**Tech Stack:** Go, existing `internal/provider`/`internal/config` packages, `testify` (assert/require), `testutil.NewServer` for HTTP-backed provider tests.
+
+## Global Constraints
+
+- TDD strictly: one test at a time, Red → Green → Refactor → Commit. Never write implementation before the test.
+- Commit prefixes: `[STRUCTURAL]` (no behavior change) or `[BEHAVIORAL]` (new/changed behavior). Never mix both in one commit.
+- Run `go build ./...`, `go test ./...`, `gofmt -l .`, `go vet ./...` after every task; all must be clean before moving on.
+- No behavior change anywhere is a hard requirement until Task 6 (the cutover). Tasks 1–5 are pure *additions* — nothing in `cmd/rubichan` or the existing `factory.go` switch-statement changes or is removed until Task 6/7. This is what makes every intermediate commit safely shippable.
+- Never push to `main`. Work happens on `feature/provider-registry` (already created, spec already committed there).
+
+---
+
+## Prerequisite (read before starting)
+
+PR #329 (branch `fix/ollama-stream-watchdog`, not yet merged as of this plan's writing) changed two files this plan also touches:
+- `internal/config/config.go`: `DefaultConfig()` no longer bakes `Provider.Model = "claude-sonnet-4-5"`.
+- `cmd/rubichan/main.go`: `loadConfig()` gained three `if cfg.Provider.Model == ""` blocks (zai, ollama, anthropic) that this plan's Task 8 replaces.
+
+**Before starting Task 8 or Task 9**, confirm `main.go`'s `loadConfig()` has these three blocks (run `grep -n "Provider.Zai.Model\|Resolve.*default model" cmd/rubichan/main.go`). If they're missing, PR #329 hasn't merged yet — merge it first, or `git rebase main` after it merges, then re-check. Tasks 1–7 have no dependency on PR #329 and can proceed regardless.
+
+---
+
+## Task 1: Registry core types
+
+**Files:**
+- Create: `internal/provider/registry.go`
+- Create: `internal/provider/registry_test.go`
+
+**Interfaces:**
+- Produces: `provider.Model{ID, Name string}`, `provider.ProviderDef{ID string; Constructor ProviderConstructor; BaseURL func(*config.Config) string; Auth func(*config.Config) (string, map[string]string, error); DefaultModel func(context.Context, *config.Config) (string, error); ListModels func(context.Context, *config.Config) ([]Model, error)}`, `provider.Registry` with `NewRegistry() *Registry`, package var `Default *Registry`, methods `Register(def ProviderDef)`, `RegisterFallback(def ProviderDef)`, `New(cfg *config.Config) (LLMProvider, error)`, `ResolveDefaultModel(ctx, cfg) (string, error)`, `ListModels(ctx, providerID string, cfg) ([]Model, error)`.
+- `KeepAliveConfigurer` and `ProviderConstructor` move here from `factory.go` (still exist, same names — Task 7 deletes the now-duplicate copies in `factory.go`; until then both files may declare them, so don't create this file's copy yet if it would collide. To avoid a duplicate-declaration compile error in the interim, this task **moves** them out of `factory.go` now rather than duplicating.)
+
+**Note on `KeepAliveConfigurer`/`ProviderConstructor` relocation:** moving these two type declarations from `factory.go` to `registry.go` in this task is a zero-behavior-change move (same package, same names, same call sites still compile) — do it as part of this task's commit since `registry.go` needs both types and Go doesn't allow duplicate declarations in one package. This is the one place this "pure addition" task also touches existing code, and it's mechanical (cut two type blocks from one file, paste into the new one).
+
+- [ ] **Step 1: Write the failing test for `Registry.New` with a registered provider**
+
+Create `internal/provider/registry_test.go`:
+
+```go
+package provider_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/config"
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeProvider struct {
+	baseURL, apiKey string
+	headers         map[string]string
+}
+
+func (f *fakeProvider) Stream(context.Context, provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
+	return nil, nil
+}
+
+func fakeDef(id string) provider.ProviderDef {
+	return provider.ProviderDef{
+		ID: id,
+		Constructor: func(baseURL, apiKey string, headers map[string]string) provider.LLMProvider {
+			return &fakeProvider{baseURL: baseURL, apiKey: apiKey, headers: headers}
+		},
+		BaseURL: func(cfg *config.Config) string { return "https://" + id + ".example.com" },
+		Auth: func(cfg *config.Config) (string, map[string]string, error) {
+			return "key-" + id, map[string]string{"X-Test": id}, nil
+		},
+	}
+}
+
+func TestRegistry_New_BuildsRegisteredProvider(t *testing.T) {
+	r := provider.NewRegistry()
+	r.Register(fakeDef("acme"))
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "acme"
+
+	p, err := r.New(cfg)
+	require.NoError(t, err)
+	fp, ok := p.(*fakeProvider)
+	require.True(t, ok)
+	assert.Equal(t, "https://acme.example.com", fp.baseURL)
+	assert.Equal(t, "key-acme", fp.apiKey)
+	assert.Equal(t, map[string]string{"X-Test": "acme"}, fp.headers)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/provider/... -run TestRegistry_New_BuildsRegisteredProvider -v`
+Expected: FAIL — `undefined: provider.NewRegistry` (or similar compile error; `registry.go` doesn't exist yet).
+
+- [ ] **Step 3: Write `registry.go` with `Model`, `ProviderDef`, `Registry`, `Register`, `New`**
+
+First, remove these two blocks from `internal/provider/factory.go` (they move to `registry.go`):
+
+```go
+// ProviderConstructor is a function that creates a new LLMProvider.
+type ProviderConstructor func(baseURL, apiKey string, extraHeaders map[string]string) LLMProvider
+
+// KeepAliveConfigurer is implemented by providers that support configurable
+// model keep-alive duration (e.g., Ollama). Defined here so the factory can
+// type-assert without importing provider sub-packages.
+type KeepAliveConfigurer interface {
+	SetKeepAlive(duration string)
+	KeepAlive() string
+}
+```
+
+Create `internal/provider/registry.go`:
+
+```go
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/julianshen/rubichan/internal/config"
+)
+
+// ProviderConstructor is a function that creates a new LLMProvider.
+type ProviderConstructor func(baseURL, apiKey string, extraHeaders map[string]string) LLMProvider
+
+// KeepAliveConfigurer is implemented by providers that support configurable
+// model keep-alive duration (e.g., Ollama). Registry.New type-asserts
+// against it after construction, for any provider that happens to
+// implement it — no provider-specific wiring needed here.
+type KeepAliveConfigurer interface {
+	SetKeepAlive(duration string)
+	KeepAlive() string
+}
+
+// Model describes one entry in a provider's model catalog, whether static
+// or fetched dynamically via ProviderDef.ListModels.
+type Model struct {
+	ID   string
+	Name string
+}
+
+// ProviderDef is a declarative registration for one provider: how to build
+// it, how to authenticate it, and (optionally) how to resolve or list its
+// models. Registering a ProviderDef replaces registering a bare
+// ProviderConstructor — construction and default-model resolution are
+// described once, together, instead of as parallel switch-statements in
+// factory.go and cmd/rubichan/main.go.
+type ProviderDef struct {
+	ID          string
+	Constructor ProviderConstructor
+	BaseURL     func(cfg *config.Config) string
+	Auth        func(cfg *config.Config) (apiKey string, headers map[string]string, err error)
+
+	// DefaultModel resolves the model to use when the user hasn't specified
+	// one. nil means the provider has no default-model resolution (the
+	// caller must always specify a model explicitly).
+	DefaultModel func(ctx context.Context, cfg *config.Config) (string, error)
+
+	// ListModels returns the provider's available models. nil means the
+	// provider doesn't support dynamic listing.
+	ListModels func(ctx context.Context, cfg *config.Config) ([]Model, error)
+}
+
+// Registry holds ProviderDefs, registered by each provider package's init().
+type Registry struct {
+	defs        map[string]ProviderDef
+	fallback    ProviderDef
+	hasFallback bool
+}
+
+// NewRegistry returns an empty Registry. Most callers use Default; tests
+// that want isolation from global registration state use NewRegistry.
+func NewRegistry() *Registry {
+	return &Registry{defs: make(map[string]ProviderDef)}
+}
+
+// Default is the registry every provider package registers against via
+// init(). cmd/rubichan and factory.go use this one.
+var Default = NewRegistry()
+
+// Register adds or replaces a provider definition, looked up by ID.
+func (r *Registry) Register(def ProviderDef) {
+	r.defs[def.ID] = def
+}
+
+// RegisterFallback registers a definition used when cfg.Provider.Default
+// doesn't match any exact-ID registration — mirrors the OpenAI-compatible
+// provider's role of handling any provider name found in
+// cfg.Provider.OpenAI rather than one fixed ID.
+func (r *Registry) RegisterFallback(def ProviderDef) {
+	r.fallback = def
+	r.hasFallback = true
+}
+
+func (r *Registry) lookup(id string) (ProviderDef, error) {
+	if def, ok := r.defs[id]; ok {
+		return def, nil
+	}
+	if r.hasFallback {
+		return r.fallback, nil
+	}
+	return ProviderDef{}, fmt.Errorf("provider %q not registered", id)
+}
+
+// New builds the LLMProvider for cfg.Provider.Default.
+func (r *Registry) New(cfg *config.Config) (LLMProvider, error) {
+	def, err := r.lookup(cfg.Provider.Default)
+	if err != nil {
+		return nil, err
+	}
+	apiKey, headers, err := def.Auth(cfg)
+	if err != nil {
+		return nil, err
+	}
+	p := def.Constructor(def.BaseURL(cfg), apiKey, headers)
+	if ka := cfg.Agent.Cache.OllamaKeepAlive; ka != "" {
+		if kac, ok := p.(KeepAliveConfigurer); ok {
+			kac.SetKeepAlive(ka)
+		}
+	}
+	return p, nil
+}
+
+// ResolveDefaultModel returns the model to use for cfg.Provider.Default when
+// the user hasn't specified one. Returns an error if the provider has no
+// DefaultModel resolver.
+func (r *Registry) ResolveDefaultModel(ctx context.Context, cfg *config.Config) (string, error) {
+	def, err := r.lookup(cfg.Provider.Default)
+	if err != nil {
+		return "", err
+	}
+	if def.DefaultModel == nil {
+		return "", fmt.Errorf("provider %q has no default model; specify one explicitly", cfg.Provider.Default)
+	}
+	return def.DefaultModel(ctx, cfg)
+}
+
+// ListModels returns the available models for providerID. Returns an error
+// if the provider has no ListModels resolver.
+func (r *Registry) ListModels(ctx context.Context, providerID string, cfg *config.Config) ([]Model, error) {
+	def, err := r.lookup(providerID)
+	if err != nil {
+		return nil, err
+	}
+	if def.ListModels == nil {
+		return nil, fmt.Errorf("provider %q does not support model listing", providerID)
+	}
+	return def.ListModels(ctx, cfg)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/provider/... -run TestRegistry_New_BuildsRegisteredProvider -v`
+Expected: PASS
+
+- [ ] **Step 5: Add the remaining Registry tests (unknown provider, auth error, fallback, KeepAliveConfigurer, ResolveDefaultModel, ListModels)**
+
+Append to `internal/provider/registry_test.go`:
+
+```go
+func TestRegistry_New_UnknownProvider(t *testing.T) {
+	r := provider.NewRegistry()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "nope"
+
+	_, err := r.New(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"nope"`)
+}
+
+func TestRegistry_New_AuthError(t *testing.T) {
+	r := provider.NewRegistry()
+	def := fakeDef("acme")
+	def.Auth = func(cfg *config.Config) (string, map[string]string, error) {
+		return "", nil, fmt.Errorf("no key configured")
+	}
+	r.Register(def)
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "acme"
+
+	_, err := r.New(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no key configured")
+}
+
+func TestRegistry_New_FallsBackWhenNoExactMatch(t *testing.T) {
+	r := provider.NewRegistry()
+	r.RegisterFallback(fakeDef("compat"))
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "my-custom-endpoint"
+
+	p, err := r.New(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+}
+
+type keepAliveFakeProvider struct {
+	fakeProvider
+	keepAlive string
+}
+
+func (k *keepAliveFakeProvider) SetKeepAlive(d string) { k.keepAlive = d }
+func (k *keepAliveFakeProvider) KeepAlive() string     { return k.keepAlive }
+
+func TestRegistry_New_AppliesKeepAliveConfigurer(t *testing.T) {
+	r := provider.NewRegistry()
+	r.Register(provider.ProviderDef{
+		ID: "ka",
+		Constructor: func(baseURL, apiKey string, headers map[string]string) provider.LLMProvider {
+			return &keepAliveFakeProvider{}
+		},
+		BaseURL: func(cfg *config.Config) string { return "" },
+		Auth:    func(cfg *config.Config) (string, map[string]string, error) { return "", nil, nil },
+	})
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "ka"
+	cfg.Agent.Cache.OllamaKeepAlive = "10m"
+
+	p, err := r.New(cfg)
+	require.NoError(t, err)
+	kap, ok := p.(*keepAliveFakeProvider)
+	require.True(t, ok)
+	assert.Equal(t, "10m", kap.keepAlive)
+}
+
+func TestRegistry_ResolveDefaultModel(t *testing.T) {
+	r := provider.NewRegistry()
+	def := fakeDef("acme")
+	def.DefaultModel = func(ctx context.Context, cfg *config.Config) (string, error) {
+		return "acme-model-1", nil
+	}
+	r.Register(def)
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "acme"
+
+	model, err := r.ResolveDefaultModel(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "acme-model-1", model)
+}
+
+func TestRegistry_ResolveDefaultModel_NoResolver(t *testing.T) {
+	r := provider.NewRegistry()
+	r.Register(fakeDef("acme")) // DefaultModel left nil
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "acme"
+
+	_, err := r.ResolveDefaultModel(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no default model")
+}
+
+func TestRegistry_ListModels(t *testing.T) {
+	r := provider.NewRegistry()
+	def := fakeDef("acme")
+	def.ListModels = func(ctx context.Context, cfg *config.Config) ([]provider.Model, error) {
+		return []provider.Model{{ID: "m1", Name: "Model One"}}, nil
+	}
+	r.Register(def)
+
+	models, err := r.ListModels(context.Background(), "acme", config.DefaultConfig())
+	require.NoError(t, err)
+	assert.Equal(t, []provider.Model{{ID: "m1", Name: "Model One"}}, models)
+}
+
+func TestRegistry_ListModels_NoResolver(t *testing.T) {
+	r := provider.NewRegistry()
+	r.Register(fakeDef("acme")) // ListModels left nil
+
+	_, err := r.ListModels(context.Background(), "acme", config.DefaultConfig())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support model listing")
+}
+```
+
+- [ ] **Step 6: Run the full registry test file and the whole provider package**
+
+Run: `go test ./internal/provider/... -run TestRegistry -v`
+Expected: all `TestRegistry_*` PASS.
+
+Run: `go test ./internal/provider/... ./cmd/rubichan/...`
+Expected: all existing tests still PASS unchanged (this task didn't touch any provider construction logic, only moved two type declarations verbatim).
+
+- [ ] **Step 7: Format, vet, commit**
+
+Run: `gofmt -l internal/provider/registry.go internal/provider/registry_test.go internal/provider/factory.go` (expect no output) and `go vet ./internal/provider/...` (expect no issues).
+
+```bash
+git add internal/provider/registry.go internal/provider/registry_test.go internal/provider/factory.go
+git commit -m "$(cat <<'EOF'
+[BEHAVIORAL] Add the provider Registry/ProviderDef/Model types
+
+New declarative registration mechanism for providers: construction, auth,
+base URL, and optional default-model/model-listing resolvers described
+once per provider instead of as parallel switch-statement logic. Nothing
+uses it yet — factory.go's existing switch-statement is untouched.
+Moves KeepAliveConfigurer/ProviderConstructor out of factory.go since
+registry.go needs them and Go disallows duplicate declarations.
+EOF
+)"
+```
+
+---
+
+## Task 2: Migrate Anthropic to a ProviderDef
+
+**Files:**
+- Modify: `internal/provider/anthropic/provider.go` (its `init()`, currently lines 17-21)
+- Modify: `internal/provider/anthropic/provider_test.go`
+
+**Interfaces:**
+- Consumes: `provider.ProviderDef`, `provider.Default.Register` (Task 1).
+- Produces: `anthropic.providerDef() provider.ProviderDef` — an unexported function tests call directly, isolated from the shared `provider.Default` registry.
+
+**Note:** this task adds the new registration *alongside* the existing `provider.RegisterProvider("anthropic", ...)` call — both stay active. `factory.go`'s switch-statement still exclusively drives real provider construction until Task 6; this task's new path is exercised only by its own tests, matching Task 1's "pure addition" ethos.
+
+- [ ] **Step 1: Write the failing test for the new ProviderDef**
+
+Add to `internal/provider/anthropic/provider_test.go` (package `anthropic`, already imports `provider`, `testify/assert`, `testify/require` — add `"github.com/julianshen/rubichan/internal/config"`):
+
+```go
+func TestProviderDef_BaseURLAndAuth(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+
+	def := providerDef()
+	cfg := config.DefaultConfig()
+
+	assert.Equal(t, "https://api.anthropic.com", def.BaseURL(cfg))
+
+	apiKey, headers, err := def.Auth(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "test-anthropic-key", apiKey)
+	assert.Nil(t, headers)
+}
+
+func TestProviderDef_AuthMissingKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	def := providerDef()
+	cfg := config.DefaultConfig()
+
+	_, _, err := def.Auth(cfg)
+	require.Error(t, err)
+}
+
+func TestProviderDef_DefaultModel(t *testing.T) {
+	def := providerDef()
+
+	model, err := def.DefaultModel(context.Background(), config.DefaultConfig())
+	require.NoError(t, err)
+	assert.Equal(t, "claude-sonnet-4-5", model)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/provider/anthropic/... -run TestProviderDef -v`
+Expected: FAIL — `undefined: providerDef` (and `undefined: config` until the import is added — add `"github.com/julianshen/rubichan/internal/config"` to the test file's import block now).
+
+- [ ] **Step 3: Add `providerDef()` and register it in `init()`**
+
+In `internal/provider/anthropic/provider.go`, replace:
+
+```go
+func init() {
+	provider.RegisterProvider("anthropic", func(baseURL, apiKey string, _ map[string]string) provider.LLMProvider {
+		return New(baseURL, apiKey)
+	})
+}
+```
+
+with:
+
+```go
+const anthropicBaseURL = "https://api.anthropic.com"
+
+func init() {
+	provider.RegisterProvider("anthropic", func(baseURL, apiKey string, _ map[string]string) provider.LLMProvider {
+		return New(baseURL, apiKey)
+	})
+	provider.Default.Register(providerDef())
+}
+
+// providerDef describes this provider's construction, auth, and default
+// model for provider.Default. Exposed as a function (not inlined in init)
+// so tests can exercise it directly without depending on the shared
+// provider.Default registry's global state.
+func providerDef() provider.ProviderDef {
+	return provider.ProviderDef{
+		ID: "anthropic",
+		Constructor: func(baseURL, apiKey string, _ map[string]string) provider.LLMProvider {
+			return New(baseURL, apiKey)
+		},
+		BaseURL: func(cfg *config.Config) string {
+			return anthropicBaseURL
+		},
+		Auth: func(cfg *config.Config) (string, map[string]string, error) {
+			apiKey, err := config.ResolveAPIKey(
+				cfg.Provider.Anthropic.APIKeySource,
+				cfg.Provider.Anthropic.APIKey,
+				"ANTHROPIC_API_KEY",
+			)
+			if err != nil {
+				return "", nil, fmt.Errorf("resolving Anthropic API key: %w", err)
+			}
+			return apiKey, nil, nil
+		},
+		DefaultModel: func(_ context.Context, _ *config.Config) (string, error) {
+			return "claude-sonnet-4-5", nil
+		},
+	}
+}
+```
+
+Add `"github.com/julianshen/rubichan/internal/config"` to `internal/provider/anthropic/provider.go`'s import block (`context` and `fmt` are already imported there).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/provider/anthropic/... -run TestProviderDef -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full anthropic package and provider package (regression check)**
+
+Run: `go test ./internal/provider/anthropic/... ./internal/provider/... ./cmd/rubichan/...`
+Expected: all PASS unchanged — the old `RegisterProvider` call and `factory.go`'s switch-statement are untouched, so every existing code path behaves exactly as before.
+
+- [ ] **Step 6: Format, vet, commit**
+
+Run: `gofmt -l internal/provider/anthropic/provider.go internal/provider/anthropic/provider_test.go` and `go vet ./internal/provider/anthropic/...`.
+
+```bash
+git add internal/provider/anthropic/provider.go internal/provider/anthropic/provider_test.go
+git commit -m "$(cat <<'EOF'
+[BEHAVIORAL] Register Anthropic as a ProviderDef
+
+Adds the new declarative registration alongside the existing
+RegisterProvider call, which factory.go still exclusively uses until the
+Task 6 cutover. providerDef() is exposed so tests exercise Auth/BaseURL/
+DefaultModel directly, isolated from the shared provider.Default registry.
+EOF
+)"
+```
+
+---
+
+## Task 3: Migrate Z.ai to a ProviderDef
+
+**Files:**
+- Modify: `internal/provider/zai/provider.go` (its `init()`, currently lines 15-19)
+- Modify: `internal/provider/zai/provider_test.go`
+
+**Interfaces:**
+- Consumes: same as Task 2.
+- Produces: `zai.providerDef() provider.ProviderDef`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/provider/zai/provider_test.go` (package `zai`; add `"github.com/julianshen/rubichan/internal/config"` to imports):
+
+```go
+func TestProviderDef_BaseURLAndAuth(t *testing.T) {
+	t.Setenv("Z_AI_API_KEY", "test-zai-key")
+
+	def := providerDef()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "zai"
+
+	assert.Equal(t, "https://api.z.ai/api/coding/paas/v4", def.BaseURL(cfg))
+
+	apiKey, headers, err := def.Auth(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "test-zai-key", apiKey)
+	assert.Nil(t, headers)
+}
+
+func TestProviderDef_BaseURLOverride(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Zai.BaseURL = "https://custom.zai.example.com"
+
+	assert.Equal(t, "https://custom.zai.example.com", def.BaseURL(cfg))
+}
+
+func TestProviderDef_DefaultModel_FallsBackToGlm5(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+
+	model, err := def.DefaultModel(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "glm-5", model)
+}
+
+func TestProviderDef_DefaultModel_UsesConfiguredModel(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Zai.Model = "custom-glm"
+
+	model, err := def.DefaultModel(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "custom-glm", model)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/provider/zai/... -run TestProviderDef -v`
+Expected: FAIL — `undefined: providerDef`.
+
+- [ ] **Step 3: Add `providerDef()` and register it in `init()`**
+
+In `internal/provider/zai/provider.go`, replace:
+
+```go
+func init() {
+	provider.RegisterProvider("zai", func(baseURL, apiKey string, extraHeaders map[string]string) provider.LLMProvider {
+		return New(baseURL, apiKey, "glm-5", extraHeaders)
+	})
+}
+```
+
+with:
+
+```go
+func init() {
+	provider.RegisterProvider("zai", func(baseURL, apiKey string, extraHeaders map[string]string) provider.LLMProvider {
+		return New(baseURL, apiKey, "glm-5", extraHeaders)
+	})
+	provider.Default.Register(providerDef())
+}
+
+// providerDef describes this provider's construction, auth, and default
+// model for provider.Default. Exposed as a function so tests can exercise
+// it directly, isolated from the shared provider.Default registry.
+func providerDef() provider.ProviderDef {
+	return provider.ProviderDef{
+		ID: "zai",
+		Constructor: func(baseURL, apiKey string, extraHeaders map[string]string) provider.LLMProvider {
+			return New(baseURL, apiKey, "glm-5", extraHeaders)
+		},
+		BaseURL: func(cfg *config.Config) string {
+			if cfg.Provider.Zai.BaseURL != "" {
+				return cfg.Provider.Zai.BaseURL
+			}
+			return "https://api.z.ai/api/coding/paas/v4"
+		},
+		Auth: func(cfg *config.Config) (string, map[string]string, error) {
+			apiKey, err := config.ResolveAPIKey(
+				cfg.Provider.Zai.APIKeySource,
+				cfg.Provider.Zai.APIKey,
+				"Z_AI_API_KEY",
+			)
+			if err != nil {
+				return "", nil, fmt.Errorf("resolving Z.ai API key: %w", err)
+			}
+			return apiKey, nil, nil
+		},
+		DefaultModel: func(_ context.Context, cfg *config.Config) (string, error) {
+			if cfg.Provider.Zai.Model != "" {
+				return cfg.Provider.Zai.Model, nil
+			}
+			return "glm-5", nil
+		},
+	}
+}
+```
+
+Add `"context"` and `"github.com/julianshen/rubichan/internal/config"` to `internal/provider/zai/provider.go`'s import block (`fmt` is already imported).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/provider/zai/... -run TestProviderDef -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full zai package and provider package (regression check)**
+
+Run: `go test ./internal/provider/zai/... ./internal/provider/... ./cmd/rubichan/...`
+Expected: all PASS unchanged.
+
+- [ ] **Step 6: Format, vet, commit**
+
+Run: `gofmt -l internal/provider/zai/provider.go internal/provider/zai/provider_test.go` and `go vet ./internal/provider/zai/...`.
+
+```bash
+git add internal/provider/zai/provider.go internal/provider/zai/provider_test.go
+git commit -m "$(cat <<'EOF'
+[BEHAVIORAL] Register Z.ai as a ProviderDef
+
+Same pattern as Anthropic (Task 2). DefaultModel replicates the
+cfg.Provider.Zai.Model -> "glm-5" fallback exactly.
+EOF
+)"
+```
+
+This completes PR 1 (Tasks 1-3: registry core + Anthropic + Z.ai). Suggest opening/pushing here before continuing to Ollama.
+
+---
+
+## Task 4: Migrate Ollama to a ProviderDef (construction + default model + listing)
+
+**Files:**
+- Modify: `internal/provider/ollama/provider.go` (its `init()`, currently lines 17-21)
+- Modify: `internal/provider/ollama/provider_test.go`
+
+**Interfaces:**
+- Consumes: same as Task 2, plus `ollama.NewClient(baseURL string) *Client` and `Client.ListModels(ctx) ([]ModelInfo, error)` (existing, `internal/provider/ollama/client.go`), `ollama.DefaultBaseURL` (existing constant, `"http://localhost:11434"`).
+- Produces: `ollama.providerDef() provider.ProviderDef`, `ollama.resolveDefaultModel(ctx, cfg) (string, error)`, `ollama.listModels(ctx, cfg) ([]provider.Model, error)` — these two replicate `cmd/rubichan/main.go`'s current `resolveOllamaModel` behavior exactly (single model → auto-select; multiple → first-of-list; zero → error `"no models found; run 'rubichan ollama pull <model>' first"`).
+
+**Note:** this task does *not* touch `cmd/rubichan/main.go`'s existing `resolveOllamaModel` function — it stays, still used by the old path, until Task 9 deletes it. For this task's duration, the same model-resolution logic temporarily exists in two places; that's expected and resolved by Task 9, not a bug to fix now.
+
+- [ ] **Step 1: Write the failing tests for `resolveDefaultModel`/`listModels`**
+
+Add to `internal/provider/ollama/provider_test.go` (package `ollama`; add `"github.com/julianshen/rubichan/internal/config"` to imports — `context`, `net/http`, `testutil` already imported):
+
+```go
+func TestResolveDefaultModel_SingleModel(t *testing.T) {
+	srv := testutil.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"models": [{"name": "llama3.2:latest", "size": 4294967296}]}`))
+	}))
+	defer srv.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Ollama.BaseURL = srv.URL
+
+	model, err := resolveDefaultModel(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "llama3.2:latest", model)
+}
+
+func TestResolveDefaultModel_NoModels(t *testing.T) {
+	srv := testutil.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"models": []}`))
+	}))
+	defer srv.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Ollama.BaseURL = srv.URL
+
+	_, err := resolveDefaultModel(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no models found")
+}
+
+func TestResolveDefaultModel_MultipleModels(t *testing.T) {
+	srv := testutil.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"models": [
+			{"name": "llama3.2:latest", "size": 4294967296},
+			{"name": "codellama:7b", "size": 3758096384}
+		]}`))
+	}))
+	defer srv.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Ollama.BaseURL = srv.URL
+
+	model, err := resolveDefaultModel(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "llama3.2:latest", model) // returns first model
+}
+
+func TestResolveDefaultModel_ConnectionError(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Provider.Ollama.BaseURL = "http://localhost:1"
+
+	_, err := resolveDefaultModel(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing Ollama models")
+}
+
+func TestListModels(t *testing.T) {
+	srv := testutil.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"models": [{"name": "llama3.2:latest", "size": 1}]}`))
+	}))
+	defer srv.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Ollama.BaseURL = srv.URL
+
+	models, err := listModels(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, []provider.Model{{ID: "llama3.2:latest", Name: "llama3.2:latest"}}, models)
+}
+
+func TestProviderDef_BaseURLDefault(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+
+	assert.Equal(t, DefaultBaseURL, def.BaseURL(cfg))
+}
+
+func TestProviderDef_BaseURLOverride(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Ollama.BaseURL = "http://custom-ollama:1234"
+
+	assert.Equal(t, "http://custom-ollama:1234", def.BaseURL(cfg))
+}
+
+func TestProviderDef_AuthIsKeyless(t *testing.T) {
+	def := providerDef()
+
+	apiKey, headers, err := def.Auth(config.DefaultConfig())
+	require.NoError(t, err)
+	assert.Empty(t, apiKey)
+	assert.Nil(t, headers)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/provider/ollama/... -run 'TestResolveDefaultModel|TestListModels|TestProviderDef' -v`
+Expected: FAIL — `undefined: resolveDefaultModel` (and friends).
+
+- [ ] **Step 3: Add `resolveDefaultModel`, `listModels`, `providerDef()`, and register it in `init()`**
+
+In `internal/provider/ollama/provider.go`, replace:
+
+```go
+func init() {
+	provider.RegisterProvider("ollama", func(baseURL, _ string, _ map[string]string) provider.LLMProvider {
+		return New(baseURL)
+	})
+}
+```
+
+with:
+
+```go
+func init() {
+	provider.RegisterProvider("ollama", func(baseURL, _ string, _ map[string]string) provider.LLMProvider {
+		return New(baseURL)
+	})
+	provider.Default.Register(providerDef())
+}
+
+// providerDef describes this provider's construction, auth, default model,
+// and model listing for provider.Default. Exposed as a function so tests
+// can exercise it directly, isolated from the shared provider.Default
+// registry.
+func providerDef() provider.ProviderDef {
+	return provider.ProviderDef{
+		ID: "ollama",
+		Constructor: func(baseURL, _ string, _ map[string]string) provider.LLMProvider {
+			return New(baseURL)
+		},
+		BaseURL: func(cfg *config.Config) string {
+			return resolveBaseURL(cfg)
+		},
+		Auth: func(cfg *config.Config) (string, map[string]string, error) {
+			return "", nil, nil // local server, no credentials
+		},
+		DefaultModel: resolveDefaultModel,
+		ListModels:   listModels,
+	}
+}
+
+func resolveBaseURL(cfg *config.Config) string {
+	if cfg.Provider.Ollama.BaseURL != "" {
+		return cfg.Provider.Ollama.BaseURL
+	}
+	return DefaultBaseURL
+}
+
+// resolveDefaultModel queries Ollama for available models and resolves
+// which model to use. With a single model it auto-selects; with multiple,
+// it returns the first (a future TUI picker would use listModels/ListModels
+// directly instead of this auto-select).
+func resolveDefaultModel(ctx context.Context, cfg *config.Config) (string, error) {
+	models, err := listModels(ctx, cfg)
+	if err != nil {
+		return "", err
+	}
+	if len(models) == 0 {
+		return "", fmt.Errorf("no models found; run 'rubichan ollama pull <model>' first")
+	}
+	return models[0].ID, nil
+}
+
+func listModels(ctx context.Context, cfg *config.Config) ([]provider.Model, error) {
+	client := NewClient(resolveBaseURL(cfg))
+	infos, err := client.ListModels(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing Ollama models: %w", err)
+	}
+	models := make([]provider.Model, len(infos))
+	for i, info := range infos {
+		models[i] = provider.Model{ID: info.Name, Name: info.Name}
+	}
+	return models, nil
+}
+```
+
+Add `"github.com/julianshen/rubichan/internal/config"` to `internal/provider/ollama/provider.go`'s import block (`context` and `fmt` are already imported).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/provider/ollama/... -run 'TestResolveDefaultModel|TestListModels|TestProviderDef' -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full ollama package and provider package (regression check)**
+
+Run: `go test ./internal/provider/ollama/... ./internal/provider/... ./cmd/rubichan/...`
+Expected: all PASS unchanged — `cmd/rubichan/main.go`'s `resolveOllamaModel` and the old switch-statement path are both untouched.
+
+- [ ] **Step 6: Format, vet, commit**
+
+Run: `gofmt -l internal/provider/ollama/provider.go internal/provider/ollama/provider_test.go` and `go vet ./internal/provider/ollama/...`.
+
+```bash
+git add internal/provider/ollama/provider.go internal/provider/ollama/provider_test.go
+git commit -m "$(cat <<'EOF'
+[BEHAVIORAL] Register Ollama as a ProviderDef with model listing
+
+Adds resolveDefaultModel/listModels alongside the existing
+cmd/rubichan/main.go resolveOllamaModel (same behavior, temporarily
+duplicated — Task 9 removes the old copy once main.go is cut over).
+ListModels is the first real use of the ProviderDef.ListModels extension
+point; Anthropic/Z.ai don't have a listing API and leave it nil.
+EOF
+)"
+```
+
+This completes PR 2 (Task 4: Ollama). Suggest opening/pushing here before continuing.
+
+---
+
+## Task 5: Migrate the OpenAI-compatible provider to a ProviderDef (fallback registration)
+
+**Files:**
+- Modify: `internal/provider/openai/provider.go` (its `init()`, currently lines 14-18)
+- Modify: `internal/provider/openai/provider_test.go`
+
+**Interfaces:**
+- Consumes: `Registry.RegisterFallback` (Task 1) — this provider handles *any* `cfg.Provider.Default` name that doesn't match an exact registration (openrouter, custom proxies, etc.), matching `factory.go`'s current `switch { ...; default: newOpenAIProvider }`.
+- Produces: `openai.providerDef() provider.ProviderDef`, `openai.formatUnknownProviderError(name string, configured []config.OpenAICompatibleConfig) error` (moved here from `factory.go` — Task 7 deletes the `factory.go` copy).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/provider/openai/provider_test.go` (package `openai`; add `"github.com/julianshen/rubichan/internal/config"` to imports):
+
+```go
+func TestProviderDef_BaseURLAndAuth(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "openrouter"
+	cfg.Provider.OpenAI = []config.OpenAICompatibleConfig{
+		{Name: "openrouter", BaseURL: "https://openrouter.ai/api/v1", APIKeySource: "config", APIKey: "test-key", ExtraHeaders: map[string]string{"X-Test": "1"}},
+	}
+
+	assert.Equal(t, "https://openrouter.ai/api/v1", def.BaseURL(cfg))
+
+	apiKey, headers, err := def.Auth(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "test-key", apiKey)
+	assert.Equal(t, map[string]string{"X-Test": "1"}, headers)
+}
+
+func TestProviderDef_AuthUnknownProvider(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "does-not-exist"
+
+	_, _, err := def.Auth(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"does-not-exist"`)
+}
+
+func TestProviderDef_DefaultModelIsNil(t *testing.T) {
+	def := providerDef()
+	assert.Nil(t, def.DefaultModel)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/provider/openai/... -run TestProviderDef -v`
+Expected: FAIL — `undefined: providerDef`.
+
+- [ ] **Step 3: Add `providerDef()`, `formatUnknownProviderError`, register via `RegisterFallback`**
+
+In `internal/provider/openai/provider.go`, replace:
+
+```go
+func init() {
+	provider.RegisterProvider("openai", func(baseURL, apiKey string, extraHeaders map[string]string) provider.LLMProvider {
+		return New(baseURL, apiKey, extraHeaders)
+	})
+}
+```
+
+with:
+
+```go
+func init() {
+	provider.RegisterProvider("openai", func(baseURL, apiKey string, extraHeaders map[string]string) provider.LLMProvider {
+		return New(baseURL, apiKey, extraHeaders)
+	})
+	provider.Default.RegisterFallback(providerDef())
+}
+
+// providerDef describes this provider's construction, auth, and base URL
+// for provider.Default. Registered as the fallback (not an exact-ID match)
+// because this provider handles any name found in cfg.Provider.OpenAI —
+// "openai", "openrouter", a custom proxy name, etc. — not one fixed ID.
+// Exposed as a function so tests can exercise it directly.
+func providerDef() provider.ProviderDef {
+	return provider.ProviderDef{
+		ID: "openai",
+		Constructor: func(baseURL, apiKey string, extraHeaders map[string]string) provider.LLMProvider {
+			return New(baseURL, apiKey, extraHeaders)
+		},
+		BaseURL: func(cfg *config.Config) string {
+			oc, _ := lookupCompatEntry(cfg)
+			return oc.BaseURL
+		},
+		Auth: func(cfg *config.Config) (string, map[string]string, error) {
+			oc, ok := lookupCompatEntry(cfg)
+			if !ok {
+				return "", nil, formatUnknownProviderError(cfg.Provider.Default, cfg.Provider.OpenAI)
+			}
+			apiKey, err := config.ResolveOpenAICompatibleAPIKey(oc)
+			if err != nil {
+				return "", nil, fmt.Errorf("resolving %s API key: %w", cfg.Provider.Default, err)
+			}
+			return apiKey, oc.ExtraHeaders, nil
+		},
+	}
+}
+
+func lookupCompatEntry(cfg *config.Config) (config.OpenAICompatibleConfig, bool) {
+	for _, oc := range cfg.Provider.OpenAI {
+		if oc.Name == cfg.Provider.Default {
+			return oc, true
+		}
+	}
+	return config.OpenAICompatibleConfig{}, false
+}
+
+// formatUnknownProviderError builds a helpful error message when the
+// requested provider name doesn't match any configured
+// [[provider.openai_compatible]] entry. It lists what IS configured and
+// shows example config / CLI usage.
+func formatUnknownProviderError(name string, configured []config.OpenAICompatibleConfig) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "unknown provider: %q\n\n", name)
+
+	if len(configured) > 0 {
+		b.WriteString("Configured OpenAI-compatible providers:\n")
+		for _, oc := range configured {
+			fmt.Fprintf(&b, "  - %s (%s)\n", oc.Name, oc.BaseURL)
+		}
+		b.WriteString("\n")
+	} else {
+		b.WriteString("No OpenAI-compatible providers are configured.\n\n")
+	}
+
+	b.WriteString("Quick fix — use CLI flags:\n")
+	fmt.Fprintf(&b, "  rubichan --provider %s --api-base http://localhost:1234/v1 --model my-model\n\n", name)
+
+	b.WriteString("Or add to ~/.config/rubichan/config.toml:\n")
+	fmt.Fprintf(&b, "  [provider]\n")
+	fmt.Fprintf(&b, "  default = %q\n", name)
+	fmt.Fprintf(&b, "  model   = \"my-model\"\n\n")
+	fmt.Fprintf(&b, "  [[provider.openai_compatible]]\n")
+	fmt.Fprintf(&b, "  name     = %q\n", name)
+	fmt.Fprintf(&b, "  base_url = \"http://localhost:1234/v1\"\n")
+	fmt.Fprintf(&b, "  api_key  = \"none\"")
+
+	return fmt.Errorf("%s", b.String())
+}
+```
+
+Add `"strings"` and `"github.com/julianshen/rubichan/internal/config"` to `internal/provider/openai/provider.go`'s import block (`fmt` is already imported).
+
+**Note:** `Registry.New` calls `def.Auth(cfg)` before `def.BaseURL(cfg)` (see Task 1's `New` implementation) — this ordering is why `BaseURL` above can safely ignore the not-found case (`oc, _ := lookupCompatEntry(cfg)`) rather than duplicating the error: by the time `BaseURL` runs, `Auth` has already succeeded, which only happens when the entry exists.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/provider/openai/... -run TestProviderDef -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full openai package and provider package (regression check)**
+
+Run: `go test ./internal/provider/openai/... ./internal/provider/... ./cmd/rubichan/...`
+Expected: all PASS unchanged.
+
+- [ ] **Step 6: Format, vet, commit**
+
+Run: `gofmt -l internal/provider/openai/provider.go internal/provider/openai/provider_test.go` and `go vet ./internal/provider/openai/...`.
+
+```bash
+git add internal/provider/openai/provider.go internal/provider/openai/provider_test.go
+git commit -m "$(cat <<'EOF'
+[BEHAVIORAL] Register the OpenAI-compatible provider as a Registry fallback
+
+Uses RegisterFallback since this provider handles any name found in
+cfg.Provider.OpenAI, not one fixed ID — mirrors factory.go's switch
+default: case. formatUnknownProviderError moves here from factory.go
+(duplicated for now; Task 7 removes the factory.go copy).
+EOF
+)"
+```
+
+---
+
+## Task 6: Cut `factory.go` over to the registry
+
+**Files:**
+- Modify: `internal/provider/factory.go`
+
+**Interfaces:**
+- Consumes: `provider.Default.New(cfg)` (Task 1), fully populated by Tasks 2-5.
+- Produces: `NewProvider`/`NewProviderWithDebug` unchanged signatures, now delegating instead of switching.
+
+This is the actual behavioral cutover — the highest-risk single step in this plan. The old switch-statement (`newAnthropicProvider`, `newOllamaProvider`, `newZaiProvider`, `newOpenAIProvider`, the old `registry` map, `RegisterProvider`) is **not deleted yet** — it becomes unused dead code in this same file, removed cleanly in Task 7 (structural, separated per Tidy First since this task is the behavior change and Task 7 is pure deletion).
+
+- [ ] **Step 1: Run the full existing `factory_test.go` suite first, to have a known-green baseline**
+
+Run: `go test ./internal/provider/... -run TestNewProvider -v`
+Expected: all `TestNewProvider*` tests in `internal/provider/factory_test.go` PASS (11 tests — see file for names).
+
+- [ ] **Step 2: Change `NewProviderWithDebug` to delegate to `Default.New`**
+
+In `internal/provider/factory.go`, replace:
+
+```go
+// NewProviderWithDebug creates an LLMProvider and optionally enables debug
+// logging of HTTP request/response details to stderr via log.Printf.
+func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
+	var p LLMProvider
+	var err error
+
+	switch cfg.Provider.Default {
+	case "anthropic":
+		p, err = newAnthropicProvider(cfg)
+	case "ollama":
+		return newOllamaProvider(cfg)
+	case "zai":
+		return newZaiProvider(cfg)
+	default:
+		p, err = newOpenAIProvider(cfg)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if debug {
+		EnableDebugLogging(p)
+	}
+
+	return p, nil
+}
+```
+
+with:
+
+```go
+// NewProviderWithDebug creates an LLMProvider and optionally enables debug
+// logging of HTTP request/response details to stderr via log.Printf.
+func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
+	p, err := Default.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if debug {
+		EnableDebugLogging(p)
+	}
+
+	return p, nil
+}
+```
+
+Leave `newAnthropicProvider`, `newOllamaProvider`, `newZaiProvider`, `newOpenAIProvider`, `formatUnknownProviderError`, `anthropicBaseURL`, `registry`, and `RegisterProvider` exactly as they are in the file for now — they're unused by anything except each other after this change, but Task 7 removes them.
+
+- [ ] **Step 3: Run the same tests to verify they still pass, now via the new path**
+
+Run: `go test ./internal/provider/... -run TestNewProvider -v`
+Expected: all still PASS — same behavior, now produced by `Registry.New` instead of the switch-statement.
+
+- [ ] **Step 4: Run the full suite (regression check)**
+
+Run: `go test ./internal/provider/... ./cmd/rubichan/...`
+Expected: all PASS. This is the step that proves the cutover is behavior-preserving — if anything fails here, do not proceed to Task 7; investigate which `ProviderDef` doesn't match its old switch-statement counterpart.
+
+- [ ] **Step 5: Format, vet, commit**
+
+Run: `gofmt -l internal/provider/factory.go` and `go vet ./internal/provider/...`.
+
+```bash
+git add internal/provider/factory.go
+git commit -m "$(cat <<'EOF'
+[BEHAVIORAL] Cut NewProvider/NewProviderWithDebug over to the registry
+
+Delegates to Default.New instead of the switch-statement. The old
+switch-statement and per-provider newXxxProvider functions are now dead
+code, left in place for this commit and removed in the next
+(structural-only) commit so this behavioral change stays isolated and
+easy to revert on its own if something regresses.
+EOF
+)"
+```
+
+---
+
+## Task 7: Delete the old switch-statement machinery
+
+**Files:**
+- Modify: `internal/provider/factory.go`
+- Modify: `internal/provider/anthropic/provider.go`, `internal/provider/zai/provider.go`, `internal/provider/ollama/provider.go`, `internal/provider/openai/provider.go` (remove now-redundant `RegisterProvider` calls)
+- Modify: `internal/provider/factory_test.go` (remove/adapt tests that exercised deleted internals — the public-behavior tests calling `NewProvider`/`NewProviderWithDebug` don't need to change at all, since Task 6 proved they still pass)
+
+**Interfaces:** none — pure deletion, no new interfaces produced or consumed. Structural only; run tests before and after per CLAUDE.md's refactoring guideline, revert if anything breaks.
+
+- [ ] **Step 1: Delete the four per-provider constructor functions and `formatUnknownProviderError`/`anthropicBaseURL` from `factory.go`**
+
+Remove from `internal/provider/factory.go`: `newAnthropicProvider`, `newOllamaProvider`, `newZaiProvider`, `newOpenAIProvider`, `formatUnknownProviderError`, the `const anthropicBaseURL = "https://api.anthropic.com"` line, the `registry map[string]ProviderConstructor` var, and `RegisterProvider`. The file should end up containing only: package/imports, `NewProvider`, `NewProviderWithDebug` (from Task 6). Update imports — `strings` is no longer used in this file (it was only for `formatUnknownProviderError`), remove it if `goimports`/`gofmt` doesn't do so automatically.
+
+The resulting `internal/provider/factory.go`:
+
+```go
+package provider
+
+import (
+	"github.com/julianshen/rubichan/internal/config"
+)
+
+// NewProvider creates an LLMProvider based on the given configuration.
+// It routes to the appropriate provider based on the default provider name.
+// Use NewProviderWithDebug to enable debug logging of API requests/responses.
+func NewProvider(cfg *config.Config) (LLMProvider, error) {
+	return NewProviderWithDebug(cfg, false)
+}
+
+// NewProviderWithDebug creates an LLMProvider and optionally enables debug
+// logging of HTTP request/response details to stderr via log.Printf.
+func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
+	p, err := Default.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if debug {
+		EnableDebugLogging(p)
+	}
+
+	return p, nil
+}
+```
+
+- [ ] **Step 2: Remove the now-redundant `RegisterProvider` calls from each provider's `init()`**
+
+In each of `internal/provider/anthropic/provider.go`, `internal/provider/zai/provider.go`, `internal/provider/ollama/provider.go`, `internal/provider/openai/provider.go`, change `init()` to only call `Default.Register(providerDef())` (or `Default.RegisterFallback(providerDef())` for `openai`), removing the `provider.RegisterProvider(...)` call. Example for anthropic:
+
+```go
+func init() {
+	provider.Default.Register(providerDef())
+}
+```
+
+(Same shape for zai/ollama with `Register`, and openai with `RegisterFallback`.)
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `go test ./internal/provider/... ./cmd/rubichan/...`
+Expected: all PASS. `factory_test.go`'s existing `TestNewProvider*` tests should compile and pass unmodified — they call the public `NewProvider`/`NewProviderWithDebug` functions, whose behavior Task 6 already proved is unchanged.
+
+If any test fails: revert this task's changes (`git checkout -- <files>` for uncommitted changes) and investigate before retrying — per CLAUDE.md, a structural change that breaks tests gets reverted, not patched forward.
+
+- [ ] **Step 4: Format, vet, commit**
+
+Run: `gofmt -l internal/provider/factory.go internal/provider/anthropic/provider.go internal/provider/zai/provider.go internal/provider/ollama/provider.go internal/provider/openai/provider.go` and `go vet ./internal/provider/...`.
+
+```bash
+git add internal/provider/factory.go internal/provider/anthropic/provider.go internal/provider/zai/provider.go internal/provider/ollama/provider.go internal/provider/openai/provider.go
+git commit -m "$(cat <<'EOF'
+[STRUCTURAL] Remove the old provider switch-statement and RegisterProvider
+
+Dead since the previous commit cut NewProvider/NewProviderWithDebug over
+to the registry. Each provider's init() now registers only its
+ProviderDef. No behavior change — verified by the full test suite passing
+unmodified.
+EOF
+)"
+```
+
+This completes PR 3's first half (Tasks 5-7). Continue directly to Tasks 8-9, or pause here — Tasks 8-9 are independent of whether this is a separate PR.
+
+---
+
+## Task 8: Cut `main.go`'s `loadConfig()` over to `ResolveDefaultModel`
+
+**Files:**
+- Modify: `cmd/rubichan/main.go`
+
+**Interfaces:**
+- Consumes: `provider.Default.ResolveDefaultModel(ctx, cfg)` (Task 1, populated by Tasks 2-4; Task 5's OpenAI-compatible provider has no `DefaultModel`, matching today's behavior of never auto-resolving a model for it).
+
+**Reminder:** confirm the Prerequisite section at the top of this plan before starting — this task assumes `loadConfig()` currently has the three `if cfg.Provider.Model == ""` blocks (zai, ollama, anthropic) from PR #329.
+
+- [ ] **Step 1: Run the existing `loadConfig` tests first, to have a known-green baseline**
+
+Run: `go test ./cmd/rubichan/... -run TestLoadConfig -v`
+Expected: PASS (`TestLoadConfig_Default`, `TestLoadConfig_WithModelOverride`, `TestLoadConfig_WithProviderOverride`, `TestLoadConfig_ZaiDefaultModel_FallsBackWhenUnset`, `TestLoadConfig_ZaiDefaultModel_UsesConfiguredZaiModel`, `TestLoadConfig_AnthropicDefaultModel`, `TestLoadConfig_WithCustomConfigPath`).
+
+- [ ] **Step 2: Replace the three `if` blocks with one `ResolveDefaultModel` call**
+
+In `cmd/rubichan/main.go`'s `loadConfig()`, replace:
+
+```go
+	// Resolve Z.ai's default model if provider is zai and no model specified
+	// via --model. [provider.zai].model wins over the built-in fallback.
+	if cfg.Provider.Default == "zai" && cfg.Provider.Model == "" {
+		if cfg.Provider.Zai.Model != "" {
+			cfg.Provider.Model = cfg.Provider.Zai.Model
+		} else {
+			cfg.Provider.Model = "glm-5"
+		}
+	}
+
+	// Resolve Ollama model if provider is ollama and no model specified.
+	if cfg.Provider.Default == "ollama" && cfg.Provider.Model == "" {
+		model, err := resolveOllamaModel(ollamaURL)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Provider.Model = model
+		fmt.Fprintf(os.Stderr, "Using Ollama model: %s\n", model)
+	}
+
+	// Resolve Anthropic's default model if it's the (possibly auto-detected)
+	// provider and no model was specified. This runs last so it only ever
+	// fills in what the provider-specific resolutions above left empty.
+	if cfg.Provider.Default == "anthropic" && cfg.Provider.Model == "" {
+		cfg.Provider.Model = "claude-sonnet-4-5"
+	}
+```
+
+with:
+
+```go
+	// Resolve the provider's default model if none was specified via
+	// --model or config. Each provider's own resolution logic (constant,
+	// config-driven fallback, or dynamic lookup) lives in its ProviderDef
+	// (internal/provider/{anthropic,zai,ollama}) rather than here.
+	if cfg.Provider.Model == "" {
+		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Provider.Model = model
+		if cfg.Provider.Default == "ollama" {
+			fmt.Fprintf(os.Stderr, "Using Ollama model: %s\n", model)
+		}
+	}
+```
+
+`ollamaURL` (computed just above this block) is still used by `autoDetectProvider` a few lines earlier — leave that computation in place. `context` and `provider` are both already imported in `cmd/rubichan/main.go`.
+
+- [ ] **Step 3: Run the same tests to verify they still pass**
+
+Run: `go test ./cmd/rubichan/... -run TestLoadConfig -v`
+Expected: all still PASS — same resolved `cfg.Provider.Model` values, now produced by `ResolveDefaultModel` instead of three inline blocks.
+
+- [ ] **Step 4: Run the full suite (regression check)**
+
+Run: `go test ./cmd/rubichan/... ./internal/provider/...`
+Expected: all PASS.
+
+- [ ] **Step 5: Format, vet, commit**
+
+Run: `gofmt -l cmd/rubichan/main.go` and `go vet ./cmd/rubichan/...`.
+
+```bash
+git add cmd/rubichan/main.go
+git commit -m "$(cat <<'EOF'
+[BEHAVIORAL] Cut loadConfig()'s default-model resolution over to the registry
+
+Replaces the three provider-specific if-blocks (zai, ollama, anthropic)
+with one provider.Default.ResolveDefaultModel call. Same resolved values
+for every provider — verified by the existing TestLoadConfig_* suite
+passing unmodified.
+EOF
+)"
+```
+
+---
+
+## Task 9: Delete `resolveOllamaModel` from `main.go`
+
+**Files:**
+- Modify: `cmd/rubichan/main.go` (delete `resolveOllamaModel`, currently the function right before `loadConfig()`)
+- Modify: `cmd/rubichan/main_test.go` (delete `TestResolveOllamaModel_SingleModel`, `TestResolveOllamaModel_NoModels`, `TestResolveOllamaModel_MultipleModels`, `TestResolveOllamaModel_ConnectionError` — their behavior is now covered by Task 4's `TestResolveDefaultModel_*` tests in `internal/provider/ollama/provider_test.go`)
+
+**Interfaces:** none — pure deletion of now-fully-superseded code (Task 4's `ollama.resolveDefaultModel`/`listModels` replicate this function's exact behavior, and Task 8 stopped calling it).
+
+- [ ] **Step 1: Confirm nothing still calls `resolveOllamaModel`**
+
+Run: `grep -rn "resolveOllamaModel" cmd/rubichan/`
+Expected: only its own definition and its 4 tests — no call sites (Task 8 removed the only one).
+
+- [ ] **Step 2: Delete the function from `main.go`**
+
+Remove this function from `cmd/rubichan/main.go` (immediately precedes `loadConfig()`):
+
+```go
+// resolveOllamaModel queries Ollama for available models and resolves which
+// model to use. With a single model it auto-selects; with zero models it
+// returns an error. The ollamaURL parameter allows testing with httptest.
+func resolveOllamaModel(ollamaURL string) (string, error) {
+	client := ollama.NewClient(ollamaURL)
+	models, err := client.ListModels(context.Background())
+	if err != nil {
+		return "", fmt.Errorf("listing Ollama models: %w", err)
+	}
+
+	if len(models) == 0 {
+		return "", fmt.Errorf("no models found; run 'rubichan ollama pull <model>' first")
+	}
+
+	if len(models) == 1 {
+		return models[0].Name, nil
+	}
+
+	// Multiple models — in interactive mode, we'd show a picker.
+	// For now, return the first model. The TUI picker integration
+	// requires running a Bubble Tea program which is complex to wire here.
+	// TODO: integrate tui.ModelPicker when running interactively.
+	return models[0].Name, nil
+}
+```
+
+Leave the `ollama` package import in place — `autoDetectProvider` still uses `ollama.NewClient(...).IsRunning(...)`.
+
+- [ ] **Step 3: Delete its tests from `main_test.go`**
+
+Remove `TestResolveOllamaModel_SingleModel`, `TestResolveOllamaModel_NoModels`, `TestResolveOllamaModel_MultipleModels` (all three currently just before `capabilityTestProvider`), and `TestResolveOllamaModel_ConnectionError` (currently just before `// saveFlags saves...`) from `cmd/rubichan/main_test.go`.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `go test ./cmd/rubichan/... ./internal/provider/...`
+Expected: all PASS — Ollama default-model-resolution coverage now lives entirely in `internal/provider/ollama/provider_test.go` (Task 4).
+
+- [ ] **Step 5: Format, vet, commit**
+
+Run: `gofmt -l cmd/rubichan/main.go cmd/rubichan/main_test.go` and `go vet ./cmd/rubichan/...`.
+
+```bash
+git add cmd/rubichan/main.go cmd/rubichan/main_test.go
+git commit -m "$(cat <<'EOF'
+[STRUCTURAL] Remove resolveOllamaModel, now fully superseded
+
+ollama.resolveDefaultModel/listModels (internal/provider/ollama) replicate
+its exact behavior and have their own test coverage since Task 4; nothing
+has called this copy since Task 8. autoDetectProvider's ollama.NewClient
+usage is untouched.
+EOF
+)"
+```
+
+---
+
+## Final verification (after Task 9)
+
+- [ ] Run: `go build ./...` — expect success.
+- [ ] Run: `gofmt -l .` — expect no output.
+- [ ] Run: `go vet ./...` — expect no issues.
+- [ ] Run: `go test ./...` — expect all packages passing, same total test count as before this plan started minus the 4 deleted `TestResolveOllamaModel_*` tests plus every new test this plan added.
+- [ ] Run: `go test -race ./internal/provider/... ./cmd/rubichan/...` — expect all passing (matches the verification rigor used in PR #329).
+- [ ] Confirm `internal/provider/factory.go` is now ~20 lines (just `NewProvider`/`NewProviderWithDebug`) and every provider construction/default-model concern lives in exactly one place: that provider's own `providerDef()`.

--- a/docs/superpowers/plans/2026-07-28-provider-registry.md
+++ b/docs/superpowers/plans/2026-07-28-provider-registry.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace `internal/provider/factory.go`'s switch-statement and `cmd/rubichan/main.go`'s three copy-pasted default-model `if`-blocks with one declarative per-provider registration (`ProviderDef`), so construction, auth, base URL, and default-model resolution for a provider are described once instead of as parallel logic in two files.
 
-**Architecture:** A new `Registry` type in `internal/provider/registry.go` holds `ProviderDef` values (one per provider: anthropic, zai, ollama, openai-compatible), each supplying `Constructor`/`BaseURL`/`Auth` (required) and `DefaultModel`/`ListModels` (optional — nil means unsupported). `factory.go`'s public `NewProvider`/`NewProviderWithDebug` become thin delegates to the registry; `main.go`'s `loadConfig()` calls `Registry.ResolveDefaultModel` once instead of three separate blocks.
+**Architecture:** A new `Registry` type in `internal/provider/registry.go` holds `ProviderDef` values (one per provider: anthropic, zai, ollama, openai-compatible), each supplying `Constructor`/`BaseURL`/`Auth` (required) and `DefaultModel`/`ListModels` (optional — nil means unsupported). Each provider is migrated **fully atomically, one provider per task**: `factory.go`'s switch-case and `main.go`'s corresponding `if`-block are cut over and the old code deleted in the *same* commit as that provider's new `ProviderDef` — no task leaves duplicate logic or dead code for a later task to clean up.
 
 **Tech Stack:** Go, existing `internal/provider`/`internal/config` packages, `testify` (assert/require), `testutil.NewServer` for HTTP-backed provider tests.
 
@@ -13,8 +13,10 @@
 - TDD strictly: one test at a time, Red → Green → Refactor → Commit. Never write implementation before the test.
 - Commit prefixes: `[STRUCTURAL]` (no behavior change) or `[BEHAVIORAL]` (new/changed behavior). Never mix both in one commit.
 - Run `go build ./...`, `go test ./...`, `gofmt -l .`, `go vet ./...` after every task; all must be clean before moving on.
-- No behavior change anywhere is a hard requirement until Task 6 (the cutover). Tasks 1–5 are pure *additions* — nothing in `cmd/rubichan` or the existing `factory.go` switch-statement changes or is removed until Task 6/7. This is what makes every intermediate commit safely shippable.
-- Never push to `main`. Work happens on `feature/provider-registry` (already created, spec already committed there).
+- **Zero duplication, zero dead-code windows.** Every task that adds new provider logic must, in the same commit, delete whichever old logic it supersedes (old switch-case body, old `if`-block, old standalone function). No task may leave the same logic implemented in two places, or leave code nothing calls, for a later task to remove.
+- No behavior change anywhere is a hard requirement, verified at every task boundary — except the one explicitly-flagged, intentional fix in Task 5 (see that task).
+- Never push to `main`. Work happens on `feature/provider-registry` (already created; design spec and a prior draft of this plan are already committed there — this version supersedes that draft, see note below).
+- **Correctness note this plan corrects vs. an earlier draft:** a fully-generic `if cfg.Provider.Model == "" { ResolveDefaultModel(...) }` call is only safe once *every* provider is registered in the `Registry` (including the OpenAI-compatible fallback) — calling it while some providers are still unmigrated would hard-error for those. It is also only safe if a provider with no `DefaultModel` resolver (OpenAI-compatible, by design) is treated as "leave the model as-is," not as an error — otherwise users of custom OpenAI-compatible endpoints who don't pass `--model` would get a new hard failure at startup where previously the CLI proceeded (and would fail later, if at all, from the provider's own response). `Registry.ResolveDefaultModel` returns the sentinel `ErrNoDefaultModel` for this case specifically so callers can distinguish it from a real failure.
 
 ---
 
@@ -22,9 +24,9 @@
 
 PR #329 (branch `fix/ollama-stream-watchdog`, not yet merged as of this plan's writing) changed two files this plan also touches:
 - `internal/config/config.go`: `DefaultConfig()` no longer bakes `Provider.Model = "claude-sonnet-4-5"`.
-- `cmd/rubichan/main.go`: `loadConfig()` gained three `if cfg.Provider.Model == ""` blocks (zai, ollama, anthropic) that this plan's Task 8 replaces.
+- `cmd/rubichan/main.go`: `loadConfig()` gained three `if cfg.Provider.Model == ""` blocks (zai, ollama, anthropic) that Tasks 2-5 each replace one at a time.
 
-**Before starting Task 8 or Task 9**, confirm `main.go`'s `loadConfig()` has these three blocks (run `grep -n "Provider.Zai.Model\|Resolve.*default model" cmd/rubichan/main.go`). If they're missing, PR #329 hasn't merged yet — merge it first, or `git rebase main` after it merges, then re-check. Tasks 1–7 have no dependency on PR #329 and can proceed regardless.
+**Before starting Task 2**, confirm `main.go`'s `loadConfig()` has these three blocks (run `grep -n "Provider.Zai.Model\|Resolve.*default model" cmd/rubichan/main.go`). If they're missing, PR #329 hasn't merged yet — merge it first, or `git rebase main` after it merges, then re-check. Task 1 has no dependency on PR #329.
 
 ---
 
@@ -33,12 +35,12 @@ PR #329 (branch `fix/ollama-stream-watchdog`, not yet merged as of this plan's w
 **Files:**
 - Create: `internal/provider/registry.go`
 - Create: `internal/provider/registry_test.go`
+- Modify: `internal/provider/factory.go` (move two type declarations out — see below)
 
 **Interfaces:**
-- Produces: `provider.Model{ID, Name string}`, `provider.ProviderDef{ID string; Constructor ProviderConstructor; BaseURL func(*config.Config) string; Auth func(*config.Config) (string, map[string]string, error); DefaultModel func(context.Context, *config.Config) (string, error); ListModels func(context.Context, *config.Config) ([]Model, error)}`, `provider.Registry` with `NewRegistry() *Registry`, package var `Default *Registry`, methods `Register(def ProviderDef)`, `RegisterFallback(def ProviderDef)`, `New(cfg *config.Config) (LLMProvider, error)`, `ResolveDefaultModel(ctx, cfg) (string, error)`, `ListModels(ctx, providerID string, cfg) ([]Model, error)`.
-- `KeepAliveConfigurer` and `ProviderConstructor` move here from `factory.go` (still exist, same names — Task 7 deletes the now-duplicate copies in `factory.go`; until then both files may declare them, so don't create this file's copy yet if it would collide. To avoid a duplicate-declaration compile error in the interim, this task **moves** them out of `factory.go` now rather than duplicating.)
+- Produces: `provider.Model{ID, Name string}`, `provider.ProviderDef{ID string; Constructor ProviderConstructor; BaseURL func(*config.Config) string; Auth func(*config.Config) (string, map[string]string, error); DefaultModel func(context.Context, *config.Config) (string, error); ListModels func(context.Context, *config.Config) ([]Model, error)}`, `provider.ErrNoDefaultModel` (sentinel error), `provider.Registry` with `NewRegistry() *Registry`, package var `Default *Registry`, methods `Register(def ProviderDef)`, `RegisterFallback(def ProviderDef)`, `New(cfg *config.Config) (LLMProvider, error)`, `ResolveDefaultModel(ctx, cfg) (string, error)`, `ListModels(ctx, providerID string, cfg) ([]Model, error)`.
 
-**Note on `KeepAliveConfigurer`/`ProviderConstructor` relocation:** moving these two type declarations from `factory.go` to `registry.go` in this task is a zero-behavior-change move (same package, same names, same call sites still compile) — do it as part of this task's commit since `registry.go` needs both types and Go doesn't allow duplicate declarations in one package. This is the one place this "pure addition" task also touches existing code, and it's mechanical (cut two type blocks from one file, paste into the new one).
+This task is pure addition — nothing in `cmd/rubichan` or `factory.go`'s switch-statement is touched except moving `KeepAliveConfigurer`/`ProviderConstructor` (verbatim, same names, same package — a mechanical Move, not a duplication, since Go disallows declaring them twice in one package and `registry.go` needs both).
 
 - [ ] **Step 1: Write the failing test for `Registry.New` with a registered provider**
 
@@ -49,6 +51,7 @@ package provider_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -104,7 +107,7 @@ Expected: FAIL — `undefined: provider.NewRegistry` (or similar compile error; 
 
 - [ ] **Step 3: Write `registry.go` with `Model`, `ProviderDef`, `Registry`, `Register`, `New`**
 
-First, remove these two blocks from `internal/provider/factory.go` (they move to `registry.go`):
+First, remove these two blocks from `internal/provider/factory.go` (they move to `registry.go` — leave everything else in `factory.go` untouched):
 
 ```go
 // ProviderConstructor is a function that creates a new LLMProvider.
@@ -126,6 +129,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/julianshen/rubichan/internal/config"
@@ -142,6 +146,13 @@ type KeepAliveConfigurer interface {
 	SetKeepAlive(duration string)
 	KeepAlive() string
 }
+
+// ErrNoDefaultModel is returned by Registry.ResolveDefaultModel when the
+// resolved provider has no DefaultModel resolver (e.g. a custom
+// OpenAI-compatible endpoint). Callers should treat this as "leave the
+// model unset," not as a failure — the provider was found, it simply
+// doesn't offer default-model resolution.
+var ErrNoDefaultModel = errors.New("provider has no default model")
 
 // Model describes one entry in a provider's model catalog, whether static
 // or fetched dynamically via ProviderDef.ListModels.
@@ -164,7 +175,8 @@ type ProviderDef struct {
 
 	// DefaultModel resolves the model to use when the user hasn't specified
 	// one. nil means the provider has no default-model resolution (the
-	// caller must always specify a model explicitly).
+	// caller must always specify a model explicitly) — ResolveDefaultModel
+	// returns ErrNoDefaultModel in that case.
 	DefaultModel func(ctx context.Context, cfg *config.Config) (string, error)
 
 	// ListModels returns the provider's available models. nil means the
@@ -233,15 +245,16 @@ func (r *Registry) New(cfg *config.Config) (LLMProvider, error) {
 }
 
 // ResolveDefaultModel returns the model to use for cfg.Provider.Default when
-// the user hasn't specified one. Returns an error if the provider has no
-// DefaultModel resolver.
+// the user hasn't specified one. Returns ErrNoDefaultModel if the provider
+// has no DefaultModel resolver (distinct from any other error, which means
+// resolution was attempted and failed).
 func (r *Registry) ResolveDefaultModel(ctx context.Context, cfg *config.Config) (string, error) {
 	def, err := r.lookup(cfg.Provider.Default)
 	if err != nil {
 		return "", err
 	}
 	if def.DefaultModel == nil {
-		return "", fmt.Errorf("provider %q has no default model; specify one explicitly", cfg.Provider.Default)
+		return "", ErrNoDefaultModel
 	}
 	return def.DefaultModel(ctx, cfg)
 }
@@ -265,7 +278,7 @@ func (r *Registry) ListModels(ctx context.Context, providerID string, cfg *confi
 Run: `go test ./internal/provider/... -run TestRegistry_New_BuildsRegisteredProvider -v`
 Expected: PASS
 
-- [ ] **Step 5: Add the remaining Registry tests (unknown provider, auth error, fallback, KeepAliveConfigurer, ResolveDefaultModel, ListModels)**
+- [ ] **Step 5: Add the remaining Registry tests**
 
 Append to `internal/provider/registry_test.go`:
 
@@ -363,7 +376,7 @@ func TestRegistry_ResolveDefaultModel_NoResolver(t *testing.T) {
 
 	_, err := r.ResolveDefaultModel(context.Background(), cfg)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no default model")
+	assert.True(t, errors.Is(err, provider.ErrNoDefaultModel))
 }
 
 func TestRegistry_ListModels(t *testing.T) {
@@ -418,17 +431,19 @@ EOF
 
 ---
 
-## Task 2: Migrate Anthropic to a ProviderDef
+## Task 2: Migrate Anthropic (fully atomic — construction + default model)
 
 **Files:**
 - Modify: `internal/provider/anthropic/provider.go` (its `init()`, currently lines 17-21)
 - Modify: `internal/provider/anthropic/provider_test.go`
+- Modify: `internal/provider/factory.go` (the `"anthropic"` switch-case; delete `newAnthropicProvider` and `anthropicBaseURL`)
+- Modify: `cmd/rubichan/main.go` (the anthropic `if` block in `loadConfig()`)
 
 **Interfaces:**
-- Consumes: `provider.ProviderDef`, `provider.Default.Register` (Task 1).
-- Produces: `anthropic.providerDef() provider.ProviderDef` — an unexported function tests call directly, isolated from the shared `provider.Default` registry.
+- Consumes: `provider.ProviderDef`, `provider.Default.Register`, `provider.Default.New`, `provider.Default.ResolveDefaultModel` (Task 1).
+- Produces: `anthropic.providerDef() provider.ProviderDef` — an unexported function tests call directly, isolated from the shared `provider.Default` registry's global state.
 
-**Note:** this task adds the new registration *alongside* the existing `provider.RegisterProvider("anthropic", ...)` call — both stay active. `factory.go`'s switch-statement still exclusively drives real provider construction until Task 6; this task's new path is exercised only by its own tests, matching Task 1's "pure addition" ethos.
+**Why this task also touches `factory.go` and `main.go`:** per this plan's zero-duplication constraint, the new `ProviderDef` and the code it replaces cannot coexist past this one commit. `newAnthropicProvider` (factory.go) and the anthropic `if` block (main.go) are deleted in this same task, the moment the registry-based path takes over their job — not in a later cleanup task.
 
 - [ ] **Step 1: Write the failing test for the new ProviderDef**
 
@@ -473,7 +488,7 @@ func TestProviderDef_DefaultModel(t *testing.T) {
 Run: `go test ./internal/provider/anthropic/... -run TestProviderDef -v`
 Expected: FAIL — `undefined: providerDef` (and `undefined: config` until the import is added — add `"github.com/julianshen/rubichan/internal/config"` to the test file's import block now).
 
-- [ ] **Step 3: Add `providerDef()` and register it in `init()`**
+- [ ] **Step 3: Add `providerDef()`, replace `init()`'s registration**
 
 In `internal/provider/anthropic/provider.go`, replace:
 
@@ -491,9 +506,6 @@ with:
 const anthropicBaseURL = "https://api.anthropic.com"
 
 func init() {
-	provider.RegisterProvider("anthropic", func(baseURL, apiKey string, _ map[string]string) provider.LLMProvider {
-		return New(baseURL, apiKey)
-	})
 	provider.Default.Register(providerDef())
 }
 
@@ -528,42 +540,96 @@ func providerDef() provider.ProviderDef {
 }
 ```
 
-Add `"github.com/julianshen/rubichan/internal/config"` to `internal/provider/anthropic/provider.go`'s import block (`context` and `fmt` are already imported there).
+Add `"github.com/julianshen/rubichan/internal/config"` to `internal/provider/anthropic/provider.go`'s import block (`context` and `fmt` are already imported).
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 4: Cut `factory.go`'s `"anthropic"` switch-case over, delete the old function**
 
-Run: `go test ./internal/provider/anthropic/... -run TestProviderDef -v`
-Expected: PASS
+In `internal/provider/factory.go`, change the switch case (inside `NewProviderWithDebug`) from:
 
-- [ ] **Step 5: Run the full anthropic package and provider package (regression check)**
+```go
+	switch cfg.Provider.Default {
+	case "anthropic":
+		p, err = newAnthropicProvider(cfg)
+```
+
+to:
+
+```go
+	switch cfg.Provider.Default {
+	case "anthropic":
+		p, err = Default.New(cfg)
+```
+
+(This preserves the existing fall-through-to-debug-wrapping behavior for anthropic exactly — the original code already fell through for this case, so nothing about debug-logging changes here.)
+
+Delete the now-unused `newAnthropicProvider` function and the `const anthropicBaseURL = "https://api.anthropic.com"` line from `factory.go` (the constant now lives in `anthropic/provider.go`, added in Step 3). Leave `newOllamaProvider`, `newZaiProvider`, `newOpenAIProvider`, `formatUnknownProviderError`, `registry`, and `RegisterProvider` untouched — they're still used by the other, not-yet-migrated switch cases.
+
+- [ ] **Step 5: Cut `main.go`'s anthropic `if` block over**
+
+In `cmd/rubichan/main.go`'s `loadConfig()`, replace:
+
+```go
+	// Resolve Anthropic's default model if it's the (possibly auto-detected)
+	// provider and no model was specified. This runs last so it only ever
+	// fills in what the provider-specific resolutions above left empty.
+	if cfg.Provider.Default == "anthropic" && cfg.Provider.Model == "" {
+		cfg.Provider.Model = "claude-sonnet-4-5"
+	}
+```
+
+with:
+
+```go
+	// Resolve Anthropic's default model if it's the (possibly auto-detected)
+	// provider and no model was specified. This runs last so it only ever
+	// fills in what the provider-specific resolutions above left empty.
+	// (Zai/Ollama below still resolve their own default inline until Tasks
+	// 3-4 migrate them the same way; Task 5 collapses all three into one
+	// generic call once every provider is registered.)
+	if cfg.Provider.Default == "anthropic" && cfg.Provider.Model == "" {
+		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Provider.Model = model
+	}
+```
+
+`context` and `provider` are both already imported in `cmd/rubichan/main.go`. Leave the zai and ollama `if` blocks below this one exactly as they are — Tasks 3 and 4 migrate those.
+
+- [ ] **Step 6: Run the full anthropic package, provider package, and cmd/rubichan (regression check)**
 
 Run: `go test ./internal/provider/anthropic/... ./internal/provider/... ./cmd/rubichan/...`
-Expected: all PASS unchanged — the old `RegisterProvider` call and `factory.go`'s switch-statement are untouched, so every existing code path behaves exactly as before.
+Expected: all PASS unchanged, including `internal/provider/factory_test.go`'s `TestNewProviderAnthropic`/`TestNewProviderAnthropicMissingKey` (unmodified — they test the public `NewProvider` behavior, which hasn't changed) and `cmd/rubichan/coverage_test.go`'s `TestLoadConfig_AnthropicDefaultModel` (unmodified — same resolved value, same gating).
 
-- [ ] **Step 6: Format, vet, commit**
+- [ ] **Step 7: Format, vet, commit**
 
-Run: `gofmt -l internal/provider/anthropic/provider.go internal/provider/anthropic/provider_test.go` and `go vet ./internal/provider/anthropic/...`.
+Run: `gofmt -l internal/provider/anthropic/provider.go internal/provider/anthropic/provider_test.go internal/provider/factory.go cmd/rubichan/main.go` and `go vet ./internal/provider/anthropic/... ./internal/provider/... ./cmd/rubichan/...`.
 
 ```bash
-git add internal/provider/anthropic/provider.go internal/provider/anthropic/provider_test.go
+git add internal/provider/anthropic/provider.go internal/provider/anthropic/provider_test.go internal/provider/factory.go cmd/rubichan/main.go
 git commit -m "$(cat <<'EOF'
-[BEHAVIORAL] Register Anthropic as a ProviderDef
+[BEHAVIORAL] Migrate Anthropic to a ProviderDef
 
-Adds the new declarative registration alongside the existing
-RegisterProvider call, which factory.go still exclusively uses until the
-Task 6 cutover. providerDef() is exposed so tests exercise Auth/BaseURL/
-DefaultModel directly, isolated from the shared provider.Default registry.
+Fully atomic: registers the new ProviderDef, cuts factory.go's
+"anthropic" switch-case and main.go's anthropic default-model block over
+to it, and deletes newAnthropicProvider/anthropicBaseURL in the same
+commit — no window where the old and new logic coexist.
 EOF
 )"
 ```
 
+This completes a coherent, independently mergeable unit. Suggest a PR checkpoint here (Task 1 + Task 2) before continuing.
+
 ---
 
-## Task 3: Migrate Z.ai to a ProviderDef
+## Task 3: Migrate Z.ai (fully atomic)
 
 **Files:**
 - Modify: `internal/provider/zai/provider.go` (its `init()`, currently lines 15-19)
 - Modify: `internal/provider/zai/provider_test.go`
+- Modify: `internal/provider/factory.go` (the `"zai"` switch-case; delete `newZaiProvider`)
+- Modify: `cmd/rubichan/main.go` (the zai `if` block in `loadConfig()`)
 
 **Interfaces:**
 - Consumes: same as Task 2.
@@ -622,7 +688,7 @@ func TestProviderDef_DefaultModel_UsesConfiguredModel(t *testing.T) {
 Run: `go test ./internal/provider/zai/... -run TestProviderDef -v`
 Expected: FAIL — `undefined: providerDef`.
 
-- [ ] **Step 3: Add `providerDef()` and register it in `init()`**
+- [ ] **Step 3: Add `providerDef()`, replace `init()`'s registration**
 
 In `internal/provider/zai/provider.go`, replace:
 
@@ -638,9 +704,6 @@ with:
 
 ```go
 func init() {
-	provider.RegisterProvider("zai", func(baseURL, apiKey string, extraHeaders map[string]string) provider.LLMProvider {
-		return New(baseURL, apiKey, "glm-5", extraHeaders)
-	})
 	provider.Default.Register(providerDef())
 }
 
@@ -682,46 +745,90 @@ func providerDef() provider.ProviderDef {
 
 Add `"context"` and `"github.com/julianshen/rubichan/internal/config"` to `internal/provider/zai/provider.go`'s import block (`fmt` is already imported).
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 4: Cut `factory.go`'s `"zai"` switch-case over, delete the old function**
 
-Run: `go test ./internal/provider/zai/... -run TestProviderDef -v`
-Expected: PASS
+In `internal/provider/factory.go`, change:
 
-- [ ] **Step 5: Run the full zai package and provider package (regression check)**
+```go
+	case "zai":
+		return newZaiProvider(cfg)
+```
+
+to:
+
+```go
+	case "zai":
+		return Default.New(cfg)
+```
+
+Keep the early `return` (not falling through to the `if debug { EnableDebugLogging(p) }` line below) — this preserves the existing behavior exactly, including its latent quirk that Z.ai (like Ollama) never receives debug-logging even when `--debug` is passed, because the original code also returns early for this case. Task 5 removes the whole switch-statement and fixes this quirk for every provider at once, explicitly flagged there — don't fix it here, to keep this commit's behavior change scoped to "same construction, now via the registry."
+
+Delete the now-unused `newZaiProvider` function from `factory.go`.
+
+- [ ] **Step 5: Cut `main.go`'s zai `if` block over**
+
+In `cmd/rubichan/main.go`'s `loadConfig()`, replace:
+
+```go
+	// Resolve Z.ai's default model if provider is zai and no model specified
+	// via --model. [provider.zai].model wins over the built-in fallback.
+	if cfg.Provider.Default == "zai" && cfg.Provider.Model == "" {
+		if cfg.Provider.Zai.Model != "" {
+			cfg.Provider.Model = cfg.Provider.Zai.Model
+		} else {
+			cfg.Provider.Model = "glm-5"
+		}
+	}
+```
+
+with:
+
+```go
+	// Resolve Z.ai's default model if provider is zai and no model specified.
+	if cfg.Provider.Default == "zai" && cfg.Provider.Model == "" {
+		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Provider.Model = model
+	}
+```
+
+- [ ] **Step 6: Run the full zai package, provider package, and cmd/rubichan (regression check)**
 
 Run: `go test ./internal/provider/zai/... ./internal/provider/... ./cmd/rubichan/...`
-Expected: all PASS unchanged.
+Expected: all PASS unchanged, including `cmd/rubichan/coverage_test.go`'s `TestLoadConfig_ZaiDefaultModel_FallsBackWhenUnset`/`TestLoadConfig_ZaiDefaultModel_UsesConfiguredZaiModel`.
 
-- [ ] **Step 6: Format, vet, commit**
+- [ ] **Step 7: Format, vet, commit**
 
-Run: `gofmt -l internal/provider/zai/provider.go internal/provider/zai/provider_test.go` and `go vet ./internal/provider/zai/...`.
+Run: `gofmt -l internal/provider/zai/provider.go internal/provider/zai/provider_test.go internal/provider/factory.go cmd/rubichan/main.go` and `go vet ./internal/provider/zai/... ./internal/provider/... ./cmd/rubichan/...`.
 
 ```bash
-git add internal/provider/zai/provider.go internal/provider/zai/provider_test.go
+git add internal/provider/zai/provider.go internal/provider/zai/provider_test.go internal/provider/factory.go cmd/rubichan/main.go
 git commit -m "$(cat <<'EOF'
-[BEHAVIORAL] Register Z.ai as a ProviderDef
+[BEHAVIORAL] Migrate Z.ai to a ProviderDef
 
-Same pattern as Anthropic (Task 2). DefaultModel replicates the
-cfg.Provider.Zai.Model -> "glm-5" fallback exactly.
+Same fully-atomic treatment as Anthropic (Task 2): DefaultModel
+replicates the cfg.Provider.Zai.Model -> "glm-5" fallback exactly, and
+newZaiProvider/the old main.go if-block are deleted in this same commit.
 EOF
 )"
 ```
 
-This completes PR 1 (Tasks 1-3: registry core + Anthropic + Z.ai). Suggest opening/pushing here before continuing to Ollama.
-
 ---
 
-## Task 4: Migrate Ollama to a ProviderDef (construction + default model + listing)
+## Task 4: Migrate Ollama (fully atomic — construction + default model + listing)
 
 **Files:**
 - Modify: `internal/provider/ollama/provider.go` (its `init()`, currently lines 17-21)
 - Modify: `internal/provider/ollama/provider_test.go`
+- Modify: `internal/provider/factory.go` (the `"ollama"` switch-case; delete `newOllamaProvider`)
+- Modify: `cmd/rubichan/main.go` (the ollama `if` block in `loadConfig()`; delete `resolveOllamaModel`)
+- Modify: `cmd/rubichan/main_test.go` (delete `TestResolveOllamaModel_SingleModel`, `TestResolveOllamaModel_NoModels`, `TestResolveOllamaModel_MultipleModels`, `TestResolveOllamaModel_ConnectionError` — moved to `internal/provider/ollama/provider_test.go` in this same task, not left behind for later cleanup)
 
 **Interfaces:**
 - Consumes: same as Task 2, plus `ollama.NewClient(baseURL string) *Client` and `Client.ListModels(ctx) ([]ModelInfo, error)` (existing, `internal/provider/ollama/client.go`), `ollama.DefaultBaseURL` (existing constant, `"http://localhost:11434"`).
-- Produces: `ollama.providerDef() provider.ProviderDef`, `ollama.resolveDefaultModel(ctx, cfg) (string, error)`, `ollama.listModels(ctx, cfg) ([]provider.Model, error)` — these two replicate `cmd/rubichan/main.go`'s current `resolveOllamaModel` behavior exactly (single model → auto-select; multiple → first-of-list; zero → error `"no models found; run 'rubichan ollama pull <model>' first"`).
-
-**Note:** this task does *not* touch `cmd/rubichan/main.go`'s existing `resolveOllamaModel` function — it stays, still used by the old path, until Task 9 deletes it. For this task's duration, the same model-resolution logic temporarily exists in two places; that's expected and resolved by Task 9, not a bug to fix now.
+- Produces: `ollama.providerDef() provider.ProviderDef`, `ollama.resolveDefaultModel(ctx, cfg) (string, error)`, `ollama.listModels(ctx, cfg) ([]provider.Model, error)` — these two replicate `cmd/rubichan/main.go`'s `resolveOllamaModel` behavior exactly (single model → auto-select; multiple → first-of-list; zero → error `"no models found; run 'rubichan ollama pull <model>' first"`), and this task deletes `resolveOllamaModel` in the same commit — the old and new implementations never coexist.
 
 - [ ] **Step 1: Write the failing tests for `resolveDefaultModel`/`listModels`**
 
@@ -826,7 +933,7 @@ func TestProviderDef_AuthIsKeyless(t *testing.T) {
 Run: `go test ./internal/provider/ollama/... -run 'TestResolveDefaultModel|TestListModels|TestProviderDef' -v`
 Expected: FAIL — `undefined: resolveDefaultModel` (and friends).
 
-- [ ] **Step 3: Add `resolveDefaultModel`, `listModels`, `providerDef()`, and register it in `init()`**
+- [ ] **Step 3: Add `resolveDefaultModel`, `listModels`, `providerDef()`, replace `init()`'s registration**
 
 In `internal/provider/ollama/provider.go`, replace:
 
@@ -842,9 +949,6 @@ with:
 
 ```go
 func init() {
-	provider.RegisterProvider("ollama", func(baseURL, _ string, _ map[string]string) provider.LLMProvider {
-		return New(baseURL)
-	})
 	provider.Default.Register(providerDef())
 }
 
@@ -907,47 +1011,132 @@ func listModels(ctx context.Context, cfg *config.Config) ([]provider.Model, erro
 
 Add `"github.com/julianshen/rubichan/internal/config"` to `internal/provider/ollama/provider.go`'s import block (`context` and `fmt` are already imported).
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 4: Cut `factory.go`'s `"ollama"` switch-case over, delete the old function**
 
-Run: `go test ./internal/provider/ollama/... -run 'TestResolveDefaultModel|TestListModels|TestProviderDef' -v`
-Expected: PASS
+In `internal/provider/factory.go`, change:
 
-- [ ] **Step 5: Run the full ollama package and provider package (regression check)**
+```go
+	case "ollama":
+		return newOllamaProvider(cfg)
+```
+
+to:
+
+```go
+	case "ollama":
+		return Default.New(cfg)
+```
+
+Keep the early `return`, matching Task 3's reasoning exactly — preserves the existing debug-logging quirk unchanged; Task 5 fixes it for every provider at once, explicitly.
+
+Delete the now-unused `newOllamaProvider` function from `factory.go`.
+
+- [ ] **Step 5: Cut `main.go`'s ollama `if` block over, delete `resolveOllamaModel`**
+
+In `cmd/rubichan/main.go`'s `loadConfig()`, replace:
+
+```go
+	// Resolve Ollama model if provider is ollama and no model specified.
+	if cfg.Provider.Default == "ollama" && cfg.Provider.Model == "" {
+		model, err := resolveOllamaModel(ollamaURL)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Provider.Model = model
+		fmt.Fprintf(os.Stderr, "Using Ollama model: %s\n", model)
+	}
+```
+
+with:
+
+```go
+	// Resolve Ollama model if provider is ollama and no model specified.
+	if cfg.Provider.Default == "ollama" && cfg.Provider.Model == "" {
+		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Provider.Model = model
+		fmt.Fprintf(os.Stderr, "Using Ollama model: %s\n", model)
+	}
+```
+
+`ollamaURL` (computed a few lines above, still used by `autoDetectProvider` just before this block) is no longer read by this block, but leave its computation and the `autoDetectProvider` call untouched — provider auto-*detection* is a separate concern from model resolution, per the design spec.
+
+Delete this function from `cmd/rubichan/main.go` entirely (immediately precedes `loadConfig()`):
+
+```go
+// resolveOllamaModel queries Ollama for available models and resolves which
+// model to use. With a single model it auto-selects; with zero models it
+// returns an error. The ollamaURL parameter allows testing with httptest.
+func resolveOllamaModel(ollamaURL string) (string, error) {
+	client := ollama.NewClient(ollamaURL)
+	models, err := client.ListModels(context.Background())
+	if err != nil {
+		return "", fmt.Errorf("listing Ollama models: %w", err)
+	}
+
+	if len(models) == 0 {
+		return "", fmt.Errorf("no models found; run 'rubichan ollama pull <model>' first")
+	}
+
+	if len(models) == 1 {
+		return models[0].Name, nil
+	}
+
+	// Multiple models — in interactive mode, we'd show a picker.
+	// For now, return the first model. The TUI picker integration
+	// requires running a Bubble Tea program which is complex to wire here.
+	// TODO: integrate tui.ModelPicker when running interactively.
+	return models[0].Name, nil
+}
+```
+
+Leave the `ollama` package import in `main.go` in place — `autoDetectProvider` still uses `ollama.NewClient(...).IsRunning(...)`.
+
+- [ ] **Step 6: Delete `resolveOllamaModel`'s tests from `main_test.go`**
+
+Remove `TestResolveOllamaModel_SingleModel`, `TestResolveOllamaModel_NoModels`, `TestResolveOllamaModel_MultipleModels` (currently just before `capabilityTestProvider`), and `TestResolveOllamaModel_ConnectionError` (currently just before `// saveFlags saves...`) from `cmd/rubichan/main_test.go`. Their behavior is now covered by Step 1's tests in `internal/provider/ollama/provider_test.go`.
+
+- [ ] **Step 7: Run the full ollama package, provider package, and cmd/rubichan (regression check)**
 
 Run: `go test ./internal/provider/ollama/... ./internal/provider/... ./cmd/rubichan/...`
-Expected: all PASS unchanged — `cmd/rubichan/main.go`'s `resolveOllamaModel` and the old switch-statement path are both untouched.
+Expected: all PASS. `grep -rn "resolveOllamaModel" cmd/rubichan/` should return no matches at all (function and all its call sites/tests gone).
 
-- [ ] **Step 6: Format, vet, commit**
+- [ ] **Step 8: Format, vet, commit**
 
-Run: `gofmt -l internal/provider/ollama/provider.go internal/provider/ollama/provider_test.go` and `go vet ./internal/provider/ollama/...`.
+Run: `gofmt -l internal/provider/ollama/provider.go internal/provider/ollama/provider_test.go internal/provider/factory.go cmd/rubichan/main.go cmd/rubichan/main_test.go` and `go vet ./internal/provider/ollama/... ./internal/provider/... ./cmd/rubichan/...`.
 
 ```bash
-git add internal/provider/ollama/provider.go internal/provider/ollama/provider_test.go
+git add internal/provider/ollama/provider.go internal/provider/ollama/provider_test.go internal/provider/factory.go cmd/rubichan/main.go cmd/rubichan/main_test.go
 git commit -m "$(cat <<'EOF'
-[BEHAVIORAL] Register Ollama as a ProviderDef with model listing
+[BEHAVIORAL] Migrate Ollama to a ProviderDef with model listing
 
-Adds resolveDefaultModel/listModels alongside the existing
-cmd/rubichan/main.go resolveOllamaModel (same behavior, temporarily
-duplicated — Task 9 removes the old copy once main.go is cut over).
-ListModels is the first real use of the ProviderDef.ListModels extension
-point; Anthropic/Z.ai don't have a listing API and leave it nil.
+Fully atomic: providerDef's DefaultModel/ListModels replicate
+resolveOllamaModel's exact behavior, and that function (plus its 4 tests
+in main_test.go) is deleted in this same commit — never coexists with
+its replacement. ListModels is the first real use of the
+ProviderDef.ListModels extension point; Anthropic/Z.ai don't have a
+listing API and leave it nil.
 EOF
 )"
 ```
 
-This completes PR 2 (Task 4: Ollama). Suggest opening/pushing here before continuing.
-
 ---
 
-## Task 5: Migrate the OpenAI-compatible provider to a ProviderDef (fallback registration)
+## Task 5: Migrate the OpenAI-compatible provider and remove the switch-statement scaffolding
 
 **Files:**
 - Modify: `internal/provider/openai/provider.go` (its `init()`, currently lines 14-18)
 - Modify: `internal/provider/openai/provider_test.go`
+- Modify: `internal/provider/factory.go` (replace the entire switch-statement with a direct `Default.New` call; delete `newOpenAIProvider`, `formatUnknownProviderError`, `registry`, `RegisterProvider`)
+- Modify: `cmd/rubichan/main.go` (collapse the anthropic/zai/ollama `if` blocks into one generic call)
 
 **Interfaces:**
 - Consumes: `Registry.RegisterFallback` (Task 1) — this provider handles *any* `cfg.Provider.Default` name that doesn't match an exact registration (openrouter, custom proxies, etc.), matching `factory.go`'s current `switch { ...; default: newOpenAIProvider }`.
-- Produces: `openai.providerDef() provider.ProviderDef`, `openai.formatUnknownProviderError(name string, configured []config.OpenAICompatibleConfig) error` (moved here from `factory.go` — Task 7 deletes the `factory.go` copy).
+- Produces: `openai.providerDef() provider.ProviderDef`, `openai.formatUnknownProviderError(name string, configured []config.OpenAICompatibleConfig) error` (moved here from `factory.go` in this same commit).
+
+**This is the last provider migration, so it's also where the shared scaffolding — the switch-statement itself, the old `registry` map, `RegisterProvider` — becomes fully unused and is deleted, and where `main.go`'s three `if` blocks collapse into one. Both are safe only now, for two reasons documented in this plan's Global Constraints: (1) `Registry.lookup` would hard-error for any not-yet-registered provider name, so the generic single-dispatch form can't land until every provider (including this fallback) is registered; (2) `ErrNoDefaultModel` must exist so an OpenAI-compatible provider's absence of default-model resolution is treated as "leave unset," not a startup failure.**
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -991,7 +1180,7 @@ func TestProviderDef_DefaultModelIsNil(t *testing.T) {
 Run: `go test ./internal/provider/openai/... -run TestProviderDef -v`
 Expected: FAIL — `undefined: providerDef`.
 
-- [ ] **Step 3: Add `providerDef()`, `formatUnknownProviderError`, register via `RegisterFallback`**
+- [ ] **Step 3: Add `providerDef()`, `formatUnknownProviderError`, replace `init()`'s registration**
 
 In `internal/provider/openai/provider.go`, replace:
 
@@ -1007,9 +1196,6 @@ with:
 
 ```go
 func init() {
-	provider.RegisterProvider("openai", func(baseURL, apiKey string, extraHeaders map[string]string) provider.LLMProvider {
-		return New(baseURL, apiKey, extraHeaders)
-	})
 	provider.Default.RegisterFallback(providerDef())
 }
 
@@ -1017,7 +1203,9 @@ func init() {
 // for provider.Default. Registered as the fallback (not an exact-ID match)
 // because this provider handles any name found in cfg.Provider.OpenAI —
 // "openai", "openrouter", a custom proxy name, etc. — not one fixed ID.
-// Exposed as a function so tests can exercise it directly.
+// DefaultModel is left nil: this provider has never had default-model
+// resolution (users must pass --model), and Registry.ResolveDefaultModel's
+// ErrNoDefaultModel preserves that — see main.go's loadConfig().
 func providerDef() provider.ProviderDef {
 	return provider.ProviderDef{
 		ID: "openai",
@@ -1094,145 +1282,9 @@ Add `"strings"` and `"github.com/julianshen/rubichan/internal/config"` to `inter
 Run: `go test ./internal/provider/openai/... -run TestProviderDef -v`
 Expected: PASS
 
-- [ ] **Step 5: Run the full openai package and provider package (regression check)**
+- [ ] **Step 5: Replace `factory.go`'s entire switch-statement, delete now-dead code**
 
-Run: `go test ./internal/provider/openai/... ./internal/provider/... ./cmd/rubichan/...`
-Expected: all PASS unchanged.
-
-- [ ] **Step 6: Format, vet, commit**
-
-Run: `gofmt -l internal/provider/openai/provider.go internal/provider/openai/provider_test.go` and `go vet ./internal/provider/openai/...`.
-
-```bash
-git add internal/provider/openai/provider.go internal/provider/openai/provider_test.go
-git commit -m "$(cat <<'EOF'
-[BEHAVIORAL] Register the OpenAI-compatible provider as a Registry fallback
-
-Uses RegisterFallback since this provider handles any name found in
-cfg.Provider.OpenAI, not one fixed ID — mirrors factory.go's switch
-default: case. formatUnknownProviderError moves here from factory.go
-(duplicated for now; Task 7 removes the factory.go copy).
-EOF
-)"
-```
-
----
-
-## Task 6: Cut `factory.go` over to the registry
-
-**Files:**
-- Modify: `internal/provider/factory.go`
-
-**Interfaces:**
-- Consumes: `provider.Default.New(cfg)` (Task 1), fully populated by Tasks 2-5.
-- Produces: `NewProvider`/`NewProviderWithDebug` unchanged signatures, now delegating instead of switching.
-
-This is the actual behavioral cutover — the highest-risk single step in this plan. The old switch-statement (`newAnthropicProvider`, `newOllamaProvider`, `newZaiProvider`, `newOpenAIProvider`, the old `registry` map, `RegisterProvider`) is **not deleted yet** — it becomes unused dead code in this same file, removed cleanly in Task 7 (structural, separated per Tidy First since this task is the behavior change and Task 7 is pure deletion).
-
-- [ ] **Step 1: Run the full existing `factory_test.go` suite first, to have a known-green baseline**
-
-Run: `go test ./internal/provider/... -run TestNewProvider -v`
-Expected: all `TestNewProvider*` tests in `internal/provider/factory_test.go` PASS (11 tests — see file for names).
-
-- [ ] **Step 2: Change `NewProviderWithDebug` to delegate to `Default.New`**
-
-In `internal/provider/factory.go`, replace:
-
-```go
-// NewProviderWithDebug creates an LLMProvider and optionally enables debug
-// logging of HTTP request/response details to stderr via log.Printf.
-func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
-	var p LLMProvider
-	var err error
-
-	switch cfg.Provider.Default {
-	case "anthropic":
-		p, err = newAnthropicProvider(cfg)
-	case "ollama":
-		return newOllamaProvider(cfg)
-	case "zai":
-		return newZaiProvider(cfg)
-	default:
-		p, err = newOpenAIProvider(cfg)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	if debug {
-		EnableDebugLogging(p)
-	}
-
-	return p, nil
-}
-```
-
-with:
-
-```go
-// NewProviderWithDebug creates an LLMProvider and optionally enables debug
-// logging of HTTP request/response details to stderr via log.Printf.
-func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
-	p, err := Default.New(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	if debug {
-		EnableDebugLogging(p)
-	}
-
-	return p, nil
-}
-```
-
-Leave `newAnthropicProvider`, `newOllamaProvider`, `newZaiProvider`, `newOpenAIProvider`, `formatUnknownProviderError`, `anthropicBaseURL`, `registry`, and `RegisterProvider` exactly as they are in the file for now — they're unused by anything except each other after this change, but Task 7 removes them.
-
-- [ ] **Step 3: Run the same tests to verify they still pass, now via the new path**
-
-Run: `go test ./internal/provider/... -run TestNewProvider -v`
-Expected: all still PASS — same behavior, now produced by `Registry.New` instead of the switch-statement.
-
-- [ ] **Step 4: Run the full suite (regression check)**
-
-Run: `go test ./internal/provider/... ./cmd/rubichan/...`
-Expected: all PASS. This is the step that proves the cutover is behavior-preserving — if anything fails here, do not proceed to Task 7; investigate which `ProviderDef` doesn't match its old switch-statement counterpart.
-
-- [ ] **Step 5: Format, vet, commit**
-
-Run: `gofmt -l internal/provider/factory.go` and `go vet ./internal/provider/...`.
-
-```bash
-git add internal/provider/factory.go
-git commit -m "$(cat <<'EOF'
-[BEHAVIORAL] Cut NewProvider/NewProviderWithDebug over to the registry
-
-Delegates to Default.New instead of the switch-statement. The old
-switch-statement and per-provider newXxxProvider functions are now dead
-code, left in place for this commit and removed in the next
-(structural-only) commit so this behavioral change stays isolated and
-easy to revert on its own if something regresses.
-EOF
-)"
-```
-
----
-
-## Task 7: Delete the old switch-statement machinery
-
-**Files:**
-- Modify: `internal/provider/factory.go`
-- Modify: `internal/provider/anthropic/provider.go`, `internal/provider/zai/provider.go`, `internal/provider/ollama/provider.go`, `internal/provider/openai/provider.go` (remove now-redundant `RegisterProvider` calls)
-- Modify: `internal/provider/factory_test.go` (remove/adapt tests that exercised deleted internals — the public-behavior tests calling `NewProvider`/`NewProviderWithDebug` don't need to change at all, since Task 6 proved they still pass)
-
-**Interfaces:** none — pure deletion, no new interfaces produced or consumed. Structural only; run tests before and after per CLAUDE.md's refactoring guideline, revert if anything breaks.
-
-- [ ] **Step 1: Delete the four per-provider constructor functions and `formatUnknownProviderError`/`anthropicBaseURL` from `factory.go`**
-
-Remove from `internal/provider/factory.go`: `newAnthropicProvider`, `newOllamaProvider`, `newZaiProvider`, `newOpenAIProvider`, `formatUnknownProviderError`, the `const anthropicBaseURL = "https://api.anthropic.com"` line, the `registry map[string]ProviderConstructor` var, and `RegisterProvider`. The file should end up containing only: package/imports, `NewProvider`, `NewProviderWithDebug` (from Task 6). Update imports — `strings` is no longer used in this file (it was only for `formatUnknownProviderError`), remove it if `goimports`/`gofmt` doesn't do so automatically.
-
-The resulting `internal/provider/factory.go`:
+`internal/provider/factory.go` should end up containing only `NewProvider` and `NewProviderWithDebug`, plus the imports they need:
 
 ```go
 package provider
@@ -1264,91 +1316,38 @@ func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
 }
 ```
 
-- [ ] **Step 2: Remove the now-redundant `RegisterProvider` calls from each provider's `init()`**
+Delete `newOpenAIProvider`, `formatUnknownProviderError` (moved to `openai/provider.go` in Step 3), the `registry map[string]ProviderConstructor` var, and `RegisterProvider` — every provider now registers via `Default.Register`/`RegisterFallback` in its own `init()`, so nothing calls `RegisterProvider` anymore. Remove the `strings` import if nothing else in the file uses it (it was only for `formatUnknownProviderError`).
 
-In each of `internal/provider/anthropic/provider.go`, `internal/provider/zai/provider.go`, `internal/provider/ollama/provider.go`, `internal/provider/openai/provider.go`, change `init()` to only call `Default.Register(providerDef())` (or `Default.RegisterFallback(providerDef())` for `openai`), removing the `provider.RegisterProvider(...)` call. Example for anthropic:
+**Explicitly flagged behavior change:** the original switch-statement had `case "ollama": return newOllamaProvider(cfg)` and `case "zai": return newZaiProvider(cfg)` — early returns that skipped the `if debug { EnableDebugLogging(p) }` line entirely, so `--debug` never applied to Ollama/Z.ai even when passed (Anthropic and OpenAI-compatible always fell through to the debug check and worked correctly). The unified `Default.New(cfg)` call above has no per-provider branching, so it applies debug-logging uniformly to every provider — this closes that latent gap for Ollama and Z.ai. This is a real, positive behavior change, not incidental noise to hide: call it out in the commit message and PR description.
 
-```go
-func init() {
-	provider.Default.Register(providerDef())
-}
-```
+- [ ] **Step 6: Collapse `main.go`'s three `if` blocks into one generic call**
 
-(Same shape for zai/ollama with `Register`, and openai with `RegisterFallback`.)
-
-- [ ] **Step 3: Run the full test suite**
-
-Run: `go test ./internal/provider/... ./cmd/rubichan/...`
-Expected: all PASS. `factory_test.go`'s existing `TestNewProvider*` tests should compile and pass unmodified — they call the public `NewProvider`/`NewProviderWithDebug` functions, whose behavior Task 6 already proved is unchanged.
-
-If any test fails: revert this task's changes (`git checkout -- <files>` for uncommitted changes) and investigate before retrying — per CLAUDE.md, a structural change that breaks tests gets reverted, not patched forward.
-
-- [ ] **Step 4: Format, vet, commit**
-
-Run: `gofmt -l internal/provider/factory.go internal/provider/anthropic/provider.go internal/provider/zai/provider.go internal/provider/ollama/provider.go internal/provider/openai/provider.go` and `go vet ./internal/provider/...`.
-
-```bash
-git add internal/provider/factory.go internal/provider/anthropic/provider.go internal/provider/zai/provider.go internal/provider/ollama/provider.go internal/provider/openai/provider.go
-git commit -m "$(cat <<'EOF'
-[STRUCTURAL] Remove the old provider switch-statement and RegisterProvider
-
-Dead since the previous commit cut NewProvider/NewProviderWithDebug over
-to the registry. Each provider's init() now registers only its
-ProviderDef. No behavior change — verified by the full test suite passing
-unmodified.
-EOF
-)"
-```
-
-This completes PR 3's first half (Tasks 5-7). Continue directly to Tasks 8-9, or pause here — Tasks 8-9 are independent of whether this is a separate PR.
-
----
-
-## Task 8: Cut `main.go`'s `loadConfig()` over to `ResolveDefaultModel`
-
-**Files:**
-- Modify: `cmd/rubichan/main.go`
-
-**Interfaces:**
-- Consumes: `provider.Default.ResolveDefaultModel(ctx, cfg)` (Task 1, populated by Tasks 2-4; Task 5's OpenAI-compatible provider has no `DefaultModel`, matching today's behavior of never auto-resolving a model for it).
-
-**Reminder:** confirm the Prerequisite section at the top of this plan before starting — this task assumes `loadConfig()` currently has the three `if cfg.Provider.Model == ""` blocks (zai, ollama, anthropic) from PR #329.
-
-- [ ] **Step 1: Run the existing `loadConfig` tests first, to have a known-green baseline**
-
-Run: `go test ./cmd/rubichan/... -run TestLoadConfig -v`
-Expected: PASS (`TestLoadConfig_Default`, `TestLoadConfig_WithModelOverride`, `TestLoadConfig_WithProviderOverride`, `TestLoadConfig_ZaiDefaultModel_FallsBackWhenUnset`, `TestLoadConfig_ZaiDefaultModel_UsesConfiguredZaiModel`, `TestLoadConfig_AnthropicDefaultModel`, `TestLoadConfig_WithCustomConfigPath`).
-
-- [ ] **Step 2: Replace the three `if` blocks with one `ResolveDefaultModel` call**
-
-In `cmd/rubichan/main.go`'s `loadConfig()`, replace:
+In `cmd/rubichan/main.go`'s `loadConfig()`, replace all three of these blocks (anthropic, zai, ollama — by now each looks like `if cfg.Provider.Default == "X" && cfg.Provider.Model == "" { model, err := provider.Default.ResolveDefaultModel(...); ...}`):
 
 ```go
-	// Resolve Z.ai's default model if provider is zai and no model specified
-	// via --model. [provider.zai].model wins over the built-in fallback.
-	if cfg.Provider.Default == "zai" && cfg.Provider.Model == "" {
-		if cfg.Provider.Zai.Model != "" {
-			cfg.Provider.Model = cfg.Provider.Zai.Model
-		} else {
-			cfg.Provider.Model = "glm-5"
+	if cfg.Provider.Default == "anthropic" && cfg.Provider.Model == "" {
+		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
+		if err != nil {
+			return nil, err
 		}
+		cfg.Provider.Model = model
 	}
 
-	// Resolve Ollama model if provider is ollama and no model specified.
+	if cfg.Provider.Default == "zai" && cfg.Provider.Model == "" {
+		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Provider.Model = model
+	}
+
 	if cfg.Provider.Default == "ollama" && cfg.Provider.Model == "" {
-		model, err := resolveOllamaModel(ollamaURL)
+		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
 		if err != nil {
 			return nil, err
 		}
 		cfg.Provider.Model = model
 		fmt.Fprintf(os.Stderr, "Using Ollama model: %s\n", model)
-	}
-
-	// Resolve Anthropic's default model if it's the (possibly auto-detected)
-	// provider and no model was specified. This runs last so it only ever
-	// fills in what the provider-specific resolutions above left empty.
-	if cfg.Provider.Default == "anthropic" && cfg.Provider.Model == "" {
-		cfg.Provider.Model = "claude-sonnet-4-5"
 	}
 ```
 
@@ -1358,129 +1357,65 @@ with:
 	// Resolve the provider's default model if none was specified via
 	// --model or config. Each provider's own resolution logic (constant,
 	// config-driven fallback, or dynamic lookup) lives in its ProviderDef
-	// (internal/provider/{anthropic,zai,ollama}) rather than here.
+	// (internal/provider/{anthropic,zai,ollama}). Providers with no
+	// DefaultModel resolver (e.g. custom OpenAI-compatible endpoints) leave
+	// cfg.Provider.Model unset, matching prior behavior.
 	if cfg.Provider.Model == "" {
 		model, err := provider.Default.ResolveDefaultModel(context.Background(), cfg)
-		if err != nil {
+		switch {
+		case err == nil:
+			cfg.Provider.Model = model
+			if cfg.Provider.Default == "ollama" {
+				fmt.Fprintf(os.Stderr, "Using Ollama model: %s\n", model)
+			}
+		case errors.Is(err, provider.ErrNoDefaultModel):
+			// No default-model resolution for this provider — leave Model
+			// empty, same as before this provider had a Registry entry.
+		default:
 			return nil, err
 		}
-		cfg.Provider.Model = model
-		if cfg.Provider.Default == "ollama" {
-			fmt.Fprintf(os.Stderr, "Using Ollama model: %s\n", model)
-		}
 	}
 ```
 
-`ollamaURL` (computed just above this block) is still used by `autoDetectProvider` a few lines earlier — leave that computation in place. `context` and `provider` are both already imported in `cmd/rubichan/main.go`.
+`"errors"` is already imported in `cmd/rubichan/main.go` (line 8) — no import changes needed for this step.
 
-- [ ] **Step 3: Run the same tests to verify they still pass**
+- [ ] **Step 7: Run the full suite (regression check)**
 
-Run: `go test ./cmd/rubichan/... -run TestLoadConfig -v`
-Expected: all still PASS — same resolved `cfg.Provider.Model` values, now produced by `ResolveDefaultModel` instead of three inline blocks.
+Run: `go test ./internal/provider/... ./cmd/rubichan/...`
+Expected: all PASS, including every `TestLoadConfig_*` and `TestNewProvider*` test, unmodified. `grep -rn "newOpenAIProvider\|RegisterProvider\b" internal/provider/` should return no matches (fully removed).
 
-- [ ] **Step 4: Run the full suite (regression check)**
+- [ ] **Step 8: Format, vet, commit**
 
-Run: `go test ./cmd/rubichan/... ./internal/provider/...`
-Expected: all PASS.
-
-- [ ] **Step 5: Format, vet, commit**
-
-Run: `gofmt -l cmd/rubichan/main.go` and `go vet ./cmd/rubichan/...`.
+Run: `gofmt -l internal/provider/openai/provider.go internal/provider/openai/provider_test.go internal/provider/factory.go cmd/rubichan/main.go` and `go vet ./internal/provider/... ./cmd/rubichan/...`.
 
 ```bash
-git add cmd/rubichan/main.go
+git add internal/provider/openai/provider.go internal/provider/openai/provider_test.go internal/provider/factory.go cmd/rubichan/main.go
 git commit -m "$(cat <<'EOF'
-[BEHAVIORAL] Cut loadConfig()'s default-model resolution over to the registry
+[BEHAVIORAL] Migrate OpenAI-compatible, remove the switch-statement scaffolding
 
-Replaces the three provider-specific if-blocks (zai, ollama, anthropic)
-with one provider.Default.ResolveDefaultModel call. Same resolved values
-for every provider — verified by the existing TestLoadConfig_* suite
-passing unmodified.
+Last provider migration: registers via RegisterFallback (handles any
+provider name in cfg.Provider.OpenAI, not one fixed ID), then removes
+factory.go's now-fully-unused switch/registry/RegisterProvider and
+collapses main.go's three provider-gated default-model blocks into one
+generic call, safe now that every provider (including this fallback) is
+registered and ErrNoDefaultModel distinguishes "no resolver" from a real
+failure.
+
+Flagging one incidental behavior fix: the old switch's early-return
+branches for Ollama/Z.ai skipped debug-log wiring even with --debug set;
+the unified dispatch applies it uniformly to every provider now.
 EOF
 )"
 ```
 
 ---
 
-## Task 9: Delete `resolveOllamaModel` from `main.go`
-
-**Files:**
-- Modify: `cmd/rubichan/main.go` (delete `resolveOllamaModel`, currently the function right before `loadConfig()`)
-- Modify: `cmd/rubichan/main_test.go` (delete `TestResolveOllamaModel_SingleModel`, `TestResolveOllamaModel_NoModels`, `TestResolveOllamaModel_MultipleModels`, `TestResolveOllamaModel_ConnectionError` — their behavior is now covered by Task 4's `TestResolveDefaultModel_*` tests in `internal/provider/ollama/provider_test.go`)
-
-**Interfaces:** none — pure deletion of now-fully-superseded code (Task 4's `ollama.resolveDefaultModel`/`listModels` replicate this function's exact behavior, and Task 8 stopped calling it).
-
-- [ ] **Step 1: Confirm nothing still calls `resolveOllamaModel`**
-
-Run: `grep -rn "resolveOllamaModel" cmd/rubichan/`
-Expected: only its own definition and its 4 tests — no call sites (Task 8 removed the only one).
-
-- [ ] **Step 2: Delete the function from `main.go`**
-
-Remove this function from `cmd/rubichan/main.go` (immediately precedes `loadConfig()`):
-
-```go
-// resolveOllamaModel queries Ollama for available models and resolves which
-// model to use. With a single model it auto-selects; with zero models it
-// returns an error. The ollamaURL parameter allows testing with httptest.
-func resolveOllamaModel(ollamaURL string) (string, error) {
-	client := ollama.NewClient(ollamaURL)
-	models, err := client.ListModels(context.Background())
-	if err != nil {
-		return "", fmt.Errorf("listing Ollama models: %w", err)
-	}
-
-	if len(models) == 0 {
-		return "", fmt.Errorf("no models found; run 'rubichan ollama pull <model>' first")
-	}
-
-	if len(models) == 1 {
-		return models[0].Name, nil
-	}
-
-	// Multiple models — in interactive mode, we'd show a picker.
-	// For now, return the first model. The TUI picker integration
-	// requires running a Bubble Tea program which is complex to wire here.
-	// TODO: integrate tui.ModelPicker when running interactively.
-	return models[0].Name, nil
-}
-```
-
-Leave the `ollama` package import in place — `autoDetectProvider` still uses `ollama.NewClient(...).IsRunning(...)`.
-
-- [ ] **Step 3: Delete its tests from `main_test.go`**
-
-Remove `TestResolveOllamaModel_SingleModel`, `TestResolveOllamaModel_NoModels`, `TestResolveOllamaModel_MultipleModels` (all three currently just before `capabilityTestProvider`), and `TestResolveOllamaModel_ConnectionError` (currently just before `// saveFlags saves...`) from `cmd/rubichan/main_test.go`.
-
-- [ ] **Step 4: Run the full suite**
-
-Run: `go test ./cmd/rubichan/... ./internal/provider/...`
-Expected: all PASS — Ollama default-model-resolution coverage now lives entirely in `internal/provider/ollama/provider_test.go` (Task 4).
-
-- [ ] **Step 5: Format, vet, commit**
-
-Run: `gofmt -l cmd/rubichan/main.go cmd/rubichan/main_test.go` and `go vet ./cmd/rubichan/...`.
-
-```bash
-git add cmd/rubichan/main.go cmd/rubichan/main_test.go
-git commit -m "$(cat <<'EOF'
-[STRUCTURAL] Remove resolveOllamaModel, now fully superseded
-
-ollama.resolveDefaultModel/listModels (internal/provider/ollama) replicate
-its exact behavior and have their own test coverage since Task 4; nothing
-has called this copy since Task 8. autoDetectProvider's ollama.NewClient
-usage is untouched.
-EOF
-)"
-```
-
----
-
-## Final verification (after Task 9)
+## Final verification (after Task 5)
 
 - [ ] Run: `go build ./...` — expect success.
 - [ ] Run: `gofmt -l .` — expect no output.
 - [ ] Run: `go vet ./...` — expect no issues.
-- [ ] Run: `go test ./...` — expect all packages passing, same total test count as before this plan started minus the 4 deleted `TestResolveOllamaModel_*` tests plus every new test this plan added.
+- [ ] Run: `go test ./...` — expect all packages passing.
 - [ ] Run: `go test -race ./internal/provider/... ./cmd/rubichan/...` — expect all passing (matches the verification rigor used in PR #329).
-- [ ] Confirm `internal/provider/factory.go` is now ~20 lines (just `NewProvider`/`NewProviderWithDebug`) and every provider construction/default-model concern lives in exactly one place: that provider's own `providerDef()`.
+- [ ] Run: `grep -rn "RegisterProvider\b\|newAnthropicProvider\|newZaiProvider\|newOllamaProvider\|newOpenAIProvider\|resolveOllamaModel" internal/ cmd/` — expect zero matches; confirms nothing from the old mechanism survives.
+- [ ] Confirm `internal/provider/factory.go` is ~20 lines (just `NewProvider`/`NewProviderWithDebug`) and every provider construction/default-model concern lives in exactly one place: that provider's own `providerDef()`.

--- a/docs/superpowers/specs/2026-07-28-provider-registry-design.md
+++ b/docs/superpowers/specs/2026-07-28-provider-registry-design.md
@@ -56,8 +56,12 @@ type ProviderDef struct {
     BaseURL func(cfg *config.Config) string
     Auth    func(cfg *config.Config) (apiKey string, headers map[string]string, err error)
 
-    // Optional. nil means the provider has no default-model resolution
-    // (caller must always specify one) or no dynamic listing.
+    // Both optional and independent. A nil DefaultModel means the
+    // provider offers no default-model resolution — ResolveDefaultModel
+    // reports ErrNoDefaultModel and the caller leaves the model unset,
+    // which is the preserved behavior for custom OpenAI-compatible
+    // endpoints. It does not oblige the caller to supply a model.
+    // A nil ListModels means no dynamic catalog.
     DefaultModel func(ctx context.Context, cfg *config.Config) (string, error)
     ListModels   func(ctx context.Context, cfg *config.Config) ([]Model, error)
 }
@@ -73,7 +77,9 @@ func (r *Registry) ResolveDefaultModel(ctx context.Context, cfg *config.Config) 
 func (r *Registry) ListModels(ctx context.Context, providerID string, cfg *config.Config) ([]Model, error)
 ```
 
-`Registry.New` looks up `cfg.Provider.Default`, calls the def's `BaseURL`/`Auth`, then `Constructor`. `ResolveDefaultModel` looks up the same def and calls `DefaultModel` (error if nil — caller decides whether that's fatal). `ListModels` calls `ListModels` (error if nil: "provider does not support model listing").
+`Registry.New` looks up `cfg.Provider.Default`, calls the def's `Auth` **first**, then `BaseURL`, then `Constructor`.
+
+**`Auth` before `BaseURL` is a contract, not an incidental order.** The OpenAI-compatible def's `BaseURL` discards its lookup's `ok` flag and returns the zero entry's empty URL for an unrecognized provider name, while its `Auth` returns `formatUnknownProviderError` for that same case. Authenticating first is what makes the descriptive error surface instead of a provider silently built against an empty base URL. A refactor that hoisted `BaseURL` into a variable before the `Auth` call would break this without any type error — `TestNewCallsAuthBeforeBaseURL` and `TestNewSkipsBaseURLWhenAuthFails` in `internal/provider/registry_test.go` pin it (both verified to fail when the order is reversed). `ResolveDefaultModel` looks up the same def and calls `DefaultModel` (error if nil — caller decides whether that's fatal). `ListModels` calls `ListModels` (error if nil: "provider does not support model listing").
 
 **Existing behavior explicitly preserved, not redesigned:**
 - Ollama's `KeepAliveConfigurer` type-assertion (`SetKeepAlive`) — stays exactly as-is, applied after `Constructor` runs.
@@ -84,7 +90,7 @@ func (r *Registry) ListModels(ctx context.Context, providerID string, cfg *confi
 
 ## Call-site impact
 
-`NewProvider(cfg)` / `NewProviderWithDebug(cfg, debug)` keep their exact current signatures in `factory.go`, now implemented as thin delegates to `Default.New(cfg)` (debug logging wrapping unchanged). **Zero changes needed** at any of the 6 existing call sites (`cmd/rubichan/serve.go`, `shell.go`, `knowledge.go`, `main.go` ×3, plus the `newProviderWithDebug` function-variable indirection used for test mocking).
+`NewProvider(cfg)` / `NewProviderWithDebug(cfg, debug)` keep their exact current signatures in `factory.go`, now implemented as thin delegates to `Default.New(cfg)`. **Debug wrapping changes deliberately:** the old switch's Ollama and Z.ai branches returned early and so never reached the `EnableDebugLogging` call, meaning `--debug` silently did nothing for those two providers. The unified dispatch applies it to every provider. This is the one intentional behavior change in the migration. **Zero changes needed** at any of the 6 existing call sites (`cmd/rubichan/serve.go`, `shell.go`, `knowledge.go`, `main.go` ×3, plus the `newProviderWithDebug` function-variable indirection used for test mocking).
 
 `main.go`'s `loadConfig()` replaces its three provider-specific `if cfg.Provider.Model == ""` blocks (zai, ollama, anthropic — added/fixed in PR #329) with one call: `provider.Default.ResolveDefaultModel(ctx, cfg)`, gated the same way. `autoDetectProvider` (which auto-*selects* Ollama when no API key is configured) is unchanged — only model-*selection* moves into the registry; provider auto-detection is a separate concern.
 

--- a/docs/superpowers/specs/2026-07-28-provider-registry-design.md
+++ b/docs/superpowers/specs/2026-07-28-provider-registry-design.md
@@ -1,0 +1,108 @@
+# Provider Registry Design
+
+**Status:** Approved for implementation planning
+**Date:** 2026-07-28
+**Reference:** [earendil-works/pi packages/ai](https://github.com/earendil-works/pi/tree/main/packages/ai) — design inspiration only, not ported wholesale.
+
+## Problem
+
+`internal/provider/factory.go` constructs providers via a hardcoded switch-statement (`NewProviderWithDebug`), and default-model resolution lives as three separate copy-pasted `if` blocks in `cmd/rubichan/main.go`'s `loadConfig()` (zai, ollama, anthropic). These are two views of the same concern — "how do I use provider X" — kept in sync only by developer discipline. That discipline failed once already: PR #329 fixed a bug where `config.DefaultConfig()` baked in an Anthropic-specific model default, which silently defeated Ollama's and Z.ai's own default-model resolution because nobody had a single place enforcing that every provider's defaulting logic actually gets wired up.
+
+pi/ai (a large, mature TypeScript LLM SDK covering 30+ providers) solves the equivalent problem with `createProvider()`: a single declarative registration — identity, auth, base URL, model catalog, wire-protocol dispatch — instead of parallel switch-statements. This spec adopts that *pattern*, not pi/ai's scope (no OAuth, no image generation, no cost tracking, no 30-provider catalog, no changes to the existing `Context`/`Message`/`StreamEvent` data model).
+
+## Scope
+
+**In scope:**
+- A declarative per-provider registration (`ProviderDef`) covering construction, auth, base URL, and model defaulting/listing.
+- A `Registry` type that both provider construction (`factory.go`) and default-model resolution (`main.go`'s `loadConfig()`) delegate to, so a provider is described once.
+- Migrating all 4 existing providers (anthropic, openai-compatible, ollama, zai) onto this registration.
+- A `ListModels` extension point for dynamic model catalogs (only Ollama implements it today — Anthropic/OpenAI-compatible/Z.ai don't have a listing API in scope here).
+
+**Out of scope:**
+- New public `pkg/` surface — this stays inside `internal/provider` (private), no new subpackage.
+- Any change to `CompletionRequest`/`StreamEvent`/`Message`/content-block types, or the streaming event taxonomy. Those already work and aren't part of this problem.
+- `capabilities.go`'s heuristic model-capability detection (unrelated concern, untouched).
+- Adding new providers beyond the existing 4.
+- OAuth, image generation, cost/context-window catalogs, cross-provider handoff, context serialization — all present in pi/ai, all irrelevant to what's broken here.
+
+## Architecture
+
+Everything lives inside the existing `internal/provider` package — this is an evolution of `factory.go`'s existing registry concept (a `map[string]ProviderConstructor` populated by each provider's `init()`), not a new module boundary. The 4 provider sub-packages already import `provider` and self-register via `init()`; that mechanism is unchanged, just registering a richer value.
+
+```
+internal/provider/
+  registry.go       <- NEW: ProviderDef, Model, Registry types
+  factory.go         <- CHANGED: NewProvider/NewProviderWithDebug delegate to Default.New(cfg)
+  anthropic/provider.go  <- CHANGED: init() registers a ProviderDef
+  openai/provider.go     <- CHANGED: init() registers a ProviderDef
+  ollama/provider.go     <- CHANGED: init() registers a ProviderDef; gains DefaultModel/ListModels
+  zai/provider.go        <- CHANGED: init() registers a ProviderDef
+```
+
+## Components
+
+```go
+// registry.go
+
+type Model struct {
+    ID   string
+    Name string // display name, optional
+}
+
+type ProviderDef struct {
+    ID          string
+    Constructor ProviderConstructor // unchanged: func(baseURL, apiKey string, extraHeaders map[string]string) LLMProvider
+
+    BaseURL func(cfg *config.Config) string
+    Auth    func(cfg *config.Config) (apiKey string, headers map[string]string, err error)
+
+    // Optional. nil means the provider has no default-model resolution
+    // (caller must always specify one) or no dynamic listing.
+    DefaultModel func(ctx context.Context, cfg *config.Config) (string, error)
+    ListModels   func(ctx context.Context, cfg *config.Config) ([]Model, error)
+}
+
+type Registry struct { /* unexported map[string]ProviderDef */ }
+
+func NewRegistry() *Registry
+var Default = NewRegistry()
+
+func (r *Registry) Register(def ProviderDef)
+func (r *Registry) New(cfg *config.Config) (LLMProvider, error)
+func (r *Registry) ResolveDefaultModel(ctx context.Context, cfg *config.Config) (string, error)
+func (r *Registry) ListModels(ctx context.Context, providerID string, cfg *config.Config) ([]Model, error)
+```
+
+`Registry.New` looks up `cfg.Provider.Default`, calls the def's `BaseURL`/`Auth`, then `Constructor`. `ResolveDefaultModel` looks up the same def and calls `DefaultModel` (error if nil — caller decides whether that's fatal). `ListModels` calls `ListModels` (error if nil: "provider does not support model listing").
+
+**Existing behavior explicitly preserved, not redesigned:**
+- Ollama's `KeepAliveConfigurer` type-assertion (`SetKeepAlive`) — stays exactly as-is, applied after `Constructor` runs.
+- `formatUnknownProviderError`'s helpful message for an unrecognized OpenAI-compatible provider name — becomes the OpenAI-compatible def's `Auth`/`BaseURL` error path.
+- Ollama's current auto-select behavior (single model → use it, multiple → first-of-list) moves verbatim from `resolveOllamaModel` in `main.go` into the Ollama `ProviderDef.DefaultModel`.
+- Z.ai's `cfg.Provider.Zai.Model` → `"glm-5"` fallback moves verbatim from `main.go`'s `loadConfig()` into the Z.ai `ProviderDef.DefaultModel`.
+- Anthropic's `DefaultModel` returns the constant `"claude-sonnet-4-5"`.
+
+## Call-site impact
+
+`NewProvider(cfg)` / `NewProviderWithDebug(cfg, debug)` keep their exact current signatures in `factory.go`, now implemented as thin delegates to `Default.New(cfg)` (debug logging wrapping unchanged). **Zero changes needed** at any of the 6 existing call sites (`cmd/rubichan/serve.go`, `shell.go`, `knowledge.go`, `main.go` ×3, plus the `newProviderWithDebug` function-variable indirection used for test mocking).
+
+`main.go`'s `loadConfig()` replaces its three provider-specific `if cfg.Provider.Model == ""` blocks (zai, ollama, anthropic — added/fixed in PR #329) with one call: `provider.Default.ResolveDefaultModel(ctx, cfg)`, gated the same way. `autoDetectProvider` (which auto-*selects* Ollama when no API key is configured) is unchanged — only model-*selection* moves into the registry; provider auto-detection is a separate concern.
+
+## Migration plan
+
+Each step is independently shippable and TDD'd (characterization test before each provider migrates, so a regression is caught immediately, not at the end):
+
+1. Add `Registry`/`ProviderDef`/`Model` to `internal/provider/registry.go` with full unit test coverage. Pure addition — nothing calls it yet, no behavior change anywhere.
+2. Migrate Anthropic and Z.ai (simplest — constant/config-driven defaults, no dynamic listing).
+3. Migrate Ollama (the one provider with real behavioral logic to move: `ListModels` + auto-select `DefaultModel`).
+4. Migrate the OpenAI-compatible provider (per-entry base URL/key lookup, unknown-provider error message).
+5. Switch `factory.go` to delegate to `Default.New`; delete the old switch-statement and per-provider `newXxxProvider` functions.
+6. Switch `main.go`'s `loadConfig()` to call `Default.ResolveDefaultModel`; delete the three now-redundant `if` blocks and the model-selection half of `resolveOllamaModel`.
+
+Likely 2-3 PRs: (registry + Anthropic + Z.ai), (Ollama), (OpenAI-compatible + factory.go/main.go cleanup) — each a coherent, reviewable unit, per CLAUDE.md's small-PR preference. Structural/behavioral commits kept separate within each PR per Tidy First.
+
+## Testing
+
+- `Registry.New`/`ResolveDefaultModel`/`ListModels` get direct unit tests against fake `ProviderDef`s — no HTTP involved.
+- Each provider's `ProviderDef` gets a test asserting it resolves the same auth/base-URL/default-model as today; most of this is adapting existing `factory_test.go` cases, not writing from scratch.
+- No behavior change anywhere is a hard requirement, verified at every step against the existing `cmd/rubichan` and `internal/provider` suites (both 100% green as of PR #329).

--- a/internal/provider/anthropic/provider.go
+++ b/internal/provider/anthropic/provider.go
@@ -10,14 +10,45 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
+const anthropicBaseURL = "https://api.anthropic.com"
+
 func init() {
-	provider.RegisterProvider("anthropic", func(baseURL, apiKey string, _ map[string]string) provider.LLMProvider {
-		return New(baseURL, apiKey)
-	})
+	provider.Default.Register(providerDef())
+}
+
+// providerDef describes this provider's construction, auth, and default
+// model for provider.Default. Exposed as a function (not inlined in init)
+// so tests can exercise it directly without depending on the shared
+// provider.Default registry's global state.
+func providerDef() provider.ProviderDef {
+	return provider.ProviderDef{
+		ID: "anthropic",
+		Constructor: func(baseURL, apiKey string, _ map[string]string) provider.LLMProvider {
+			return New(baseURL, apiKey)
+		},
+		BaseURL: func(cfg *config.Config) string {
+			return anthropicBaseURL
+		},
+		Auth: func(cfg *config.Config) (string, map[string]string, error) {
+			apiKey, err := config.ResolveAPIKey(
+				cfg.Provider.Anthropic.APIKeySource,
+				cfg.Provider.Anthropic.APIKey,
+				"ANTHROPIC_API_KEY",
+			)
+			if err != nil {
+				return "", nil, fmt.Errorf("resolving Anthropic API key: %w", err)
+			}
+			return apiKey, nil, nil
+		},
+		DefaultModel: func(_ context.Context, _ *config.Config) (string, error) {
+			return "claude-sonnet-4-5", nil
+		},
+	}
 }
 
 // Provider implements the LLMProvider interface for the Anthropic API.

--- a/internal/provider/anthropic/provider_test.go
+++ b/internal/provider/anthropic/provider_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/testutil"
 	"github.com/julianshen/rubichan/pkg/agentsdk"
@@ -1129,6 +1130,38 @@ func TestStream_SetsRequestIDHeader(t *testing.T) {
 }
 
 func floatPtr(f float64) *float64 { return &f }
+
+func TestProviderDef_BaseURLAndAuth(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+
+	def := providerDef()
+	cfg := config.DefaultConfig()
+
+	assert.Equal(t, "https://api.anthropic.com", def.BaseURL(cfg))
+
+	apiKey, headers, err := def.Auth(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "test-anthropic-key", apiKey)
+	assert.Nil(t, headers)
+}
+
+func TestProviderDef_AuthMissingKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	def := providerDef()
+	cfg := config.DefaultConfig()
+
+	_, _, err := def.Auth(cfg)
+	require.Error(t, err)
+}
+
+func TestProviderDef_DefaultModel(t *testing.T) {
+	def := providerDef()
+
+	model, err := def.DefaultModel(context.Background(), config.DefaultConfig())
+	require.NoError(t, err)
+	assert.Equal(t, "claude-sonnet-4-5", model)
+}
 
 func TestConvertSSEEvent_MessageDelta_StopReason(t *testing.T) {
 	p := New("http://localhost", "test-key")

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -9,17 +9,6 @@ import (
 
 const anthropicBaseURL = "https://api.anthropic.com"
 
-// ProviderConstructor is a function that creates a new LLMProvider.
-type ProviderConstructor func(baseURL, apiKey string, extraHeaders map[string]string) LLMProvider
-
-// KeepAliveConfigurer is implemented by providers that support configurable
-// model keep-alive duration (e.g., Ollama). Defined here so the factory can
-// type-assert without importing provider sub-packages.
-type KeepAliveConfigurer interface {
-	SetKeepAlive(duration string)
-	KeepAlive() string
-}
-
 // registry holds registered provider constructors.
 // This map is only written to during init() functions and read thereafter,
 // so it is safe for concurrent reads without a mutex.

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -34,7 +34,7 @@ func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
 	case "anthropic":
 		p, err = Default.New(cfg)
 	case "ollama":
-		return newOllamaProvider(cfg)
+		return Default.New(cfg)
 	case "zai":
 		return Default.New(cfg)
 	default:
@@ -49,26 +49,6 @@ func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
 		EnableDebugLogging(p)
 	}
 
-	return p, nil
-}
-
-func newOllamaProvider(cfg *config.Config) (LLMProvider, error) {
-	constructor, ok := registry["ollama"]
-	if !ok {
-		return nil, fmt.Errorf("ollama provider not registered")
-	}
-
-	baseURL := cfg.Provider.Ollama.BaseURL
-	if baseURL == "" {
-		baseURL = "http://localhost:11434" // matches ollama.DefaultBaseURL (can't import due to cycle)
-	}
-
-	p := constructor(baseURL, "", nil)
-	if ka := cfg.Agent.Cache.OllamaKeepAlive; ka != "" {
-		if kac, ok := p.(KeepAliveConfigurer); ok {
-			kac.SetKeepAlive(ka)
-		}
-	}
 	return p, nil
 }
 

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -7,8 +7,6 @@ import (
 	"github.com/julianshen/rubichan/internal/config"
 )
 
-const anthropicBaseURL = "https://api.anthropic.com"
-
 // registry holds registered provider constructors.
 // This map is only written to during init() functions and read thereafter,
 // so it is safe for concurrent reads without a mutex.
@@ -34,7 +32,7 @@ func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
 
 	switch cfg.Provider.Default {
 	case "anthropic":
-		p, err = newAnthropicProvider(cfg)
+		p, err = Default.New(cfg)
 	case "ollama":
 		return newOllamaProvider(cfg)
 	case "zai":
@@ -52,24 +50,6 @@ func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
 	}
 
 	return p, nil
-}
-
-func newAnthropicProvider(cfg *config.Config) (LLMProvider, error) {
-	constructor, ok := registry["anthropic"]
-	if !ok {
-		return nil, fmt.Errorf("anthropic provider not registered")
-	}
-
-	apiKey, err := config.ResolveAPIKey(
-		cfg.Provider.Anthropic.APIKeySource,
-		cfg.Provider.Anthropic.APIKey,
-		"ANTHROPIC_API_KEY",
-	)
-	if err != nil {
-		return nil, fmt.Errorf("resolving Anthropic API key: %w", err)
-	}
-
-	return constructor(anthropicBaseURL, apiKey, nil), nil
 }
 
 func newOllamaProvider(cfg *config.Config) (LLMProvider, error) {

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -1,24 +1,11 @@
 package provider
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/julianshen/rubichan/internal/config"
 )
 
-// registry holds registered provider constructors.
-// This map is only written to during init() functions and read thereafter,
-// so it is safe for concurrent reads without a mutex.
-var registry = map[string]ProviderConstructor{}
-
-// RegisterProvider registers a provider constructor by name.
-func RegisterProvider(name string, constructor ProviderConstructor) {
-	registry[name] = constructor
-}
-
 // NewProvider creates an LLMProvider based on the given configuration.
-// It routes to the appropriate provider constructor based on the default provider name.
+// It routes to the appropriate provider based on the default provider name.
 // Use NewProviderWithDebug to enable debug logging of API requests/responses.
 func NewProvider(cfg *config.Config) (LLMProvider, error) {
 	return NewProviderWithDebug(cfg, false)
@@ -27,20 +14,7 @@ func NewProvider(cfg *config.Config) (LLMProvider, error) {
 // NewProviderWithDebug creates an LLMProvider and optionally enables debug
 // logging of HTTP request/response details to stderr via log.Printf.
 func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
-	var p LLMProvider
-	var err error
-
-	switch cfg.Provider.Default {
-	case "anthropic":
-		p, err = Default.New(cfg)
-	case "ollama":
-		return Default.New(cfg)
-	case "zai":
-		return Default.New(cfg)
-	default:
-		p, err = newOpenAIProvider(cfg)
-	}
-
+	p, err := Default.New(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -50,58 +24,4 @@ func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
 	}
 
 	return p, nil
-}
-
-func newOpenAIProvider(cfg *config.Config) (LLMProvider, error) {
-	name := cfg.Provider.Default
-
-	constructor, ok := registry["openai"]
-	if !ok {
-		return nil, fmt.Errorf("openai provider not registered")
-	}
-
-	for _, oc := range cfg.Provider.OpenAI {
-		if oc.Name == name {
-			apiKey, err := config.ResolveOpenAICompatibleAPIKey(oc)
-			if err != nil {
-				return nil, fmt.Errorf("resolving %s API key: %w", name, err)
-			}
-
-			return constructor(oc.BaseURL, apiKey, oc.ExtraHeaders), nil
-		}
-	}
-
-	return nil, formatUnknownProviderError(name, cfg.Provider.OpenAI)
-}
-
-// formatUnknownProviderError builds a helpful error message when the requested
-// provider name doesn't match any configured [[provider.openai_compatible]]
-// entry. It lists what IS configured and shows example config / CLI usage.
-func formatUnknownProviderError(name string, configured []config.OpenAICompatibleConfig) error {
-	var b strings.Builder
-	fmt.Fprintf(&b, "unknown provider: %q\n\n", name)
-
-	if len(configured) > 0 {
-		b.WriteString("Configured OpenAI-compatible providers:\n")
-		for _, oc := range configured {
-			fmt.Fprintf(&b, "  - %s (%s)\n", oc.Name, oc.BaseURL)
-		}
-		b.WriteString("\n")
-	} else {
-		b.WriteString("No OpenAI-compatible providers are configured.\n\n")
-	}
-
-	b.WriteString("Quick fix — use CLI flags:\n")
-	fmt.Fprintf(&b, "  rubichan --provider %s --api-base http://localhost:1234/v1 --model my-model\n\n", name)
-
-	b.WriteString("Or add to ~/.config/rubichan/config.toml:\n")
-	fmt.Fprintf(&b, "  [provider]\n")
-	fmt.Fprintf(&b, "  default = %q\n", name)
-	fmt.Fprintf(&b, "  model   = \"my-model\"\n\n")
-	fmt.Fprintf(&b, "  [[provider.openai_compatible]]\n")
-	fmt.Fprintf(&b, "  name     = %q\n", name)
-	fmt.Fprintf(&b, "  base_url = \"http://localhost:1234/v1\"\n")
-	fmt.Fprintf(&b, "  api_key  = \"none\"")
-
-	return fmt.Errorf("%s", b.String())
 }

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -36,7 +36,7 @@ func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
 	case "ollama":
 		return newOllamaProvider(cfg)
 	case "zai":
-		return newZaiProvider(cfg)
+		return Default.New(cfg)
 	default:
 		p, err = newOpenAIProvider(cfg)
 	}
@@ -70,29 +70,6 @@ func newOllamaProvider(cfg *config.Config) (LLMProvider, error) {
 		}
 	}
 	return p, nil
-}
-
-func newZaiProvider(cfg *config.Config) (LLMProvider, error) {
-	constructor, ok := registry["zai"]
-	if !ok {
-		return nil, fmt.Errorf("zai provider not registered")
-	}
-
-	apiKey, err := config.ResolveAPIKey(
-		cfg.Provider.Zai.APIKeySource,
-		cfg.Provider.Zai.APIKey,
-		"Z_AI_API_KEY",
-	)
-	if err != nil {
-		return nil, fmt.Errorf("resolving Z.ai API key: %w", err)
-	}
-
-	baseURL := cfg.Provider.Zai.BaseURL
-	if baseURL == "" {
-		baseURL = "https://api.z.ai/api/coding/paas/v4"
-	}
-
-	return constructor(baseURL, apiKey, nil), nil
 }
 
 func newOpenAIProvider(cfg *config.Config) (LLMProvider, error) {

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"fmt"
+
 	"github.com/julianshen/rubichan/internal/config"
 )
 
@@ -16,7 +18,7 @@ func NewProvider(cfg *config.Config) (LLMProvider, error) {
 func NewProviderWithDebug(cfg *config.Config, debug bool) (LLMProvider, error) {
 	p, err := Default.New(cfg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating provider: %w", err)
 	}
 
 	if debug {

--- a/internal/provider/ollama/provider.go
+++ b/internal/provider/ollama/provider.go
@@ -11,13 +11,68 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/provider"
 )
 
 func init() {
-	provider.RegisterProvider("ollama", func(baseURL, _ string, _ map[string]string) provider.LLMProvider {
-		return New(baseURL)
-	})
+	provider.Default.Register(providerDef())
+}
+
+// providerDef describes this provider's construction, auth, default model,
+// and model listing for provider.Default. Exposed as a function so tests
+// can exercise it directly, isolated from the shared provider.Default
+// registry.
+func providerDef() provider.ProviderDef {
+	return provider.ProviderDef{
+		ID: "ollama",
+		Constructor: func(baseURL, _ string, _ map[string]string) provider.LLMProvider {
+			return New(baseURL)
+		},
+		BaseURL: func(cfg *config.Config) string {
+			return resolveBaseURL(cfg)
+		},
+		Auth: func(cfg *config.Config) (string, map[string]string, error) {
+			return "", nil, nil // local server, no credentials
+		},
+		DefaultModel: resolveDefaultModel,
+		ListModels:   listModels,
+	}
+}
+
+func resolveBaseURL(cfg *config.Config) string {
+	if cfg.Provider.Ollama.BaseURL != "" {
+		return cfg.Provider.Ollama.BaseURL
+	}
+	return DefaultBaseURL
+}
+
+// resolveDefaultModel queries Ollama for available models and resolves
+// which model to use. With a single model it auto-selects; with multiple,
+// it returns the first (a future TUI picker would use listModels/ListModels
+// directly instead of this auto-select).
+func resolveDefaultModel(ctx context.Context, cfg *config.Config) (string, error) {
+	models, err := listModels(ctx, cfg)
+	if err != nil {
+		return "", err
+	}
+	if len(models) == 0 {
+		return "", fmt.Errorf("no models found; run 'rubichan ollama pull <model>' first")
+	}
+	return models[0].ID, nil
+}
+
+func listModels(ctx context.Context, cfg *config.Config) ([]provider.Model, error) {
+	client := NewClient(resolveBaseURL(cfg))
+	infos, err := client.ListModels(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing Ollama models: %w", err)
+	}
+	models := make([]provider.Model, len(infos))
+	for i, info := range infos {
+		models[i] = provider.Model{ID: info.Name, Name: info.Name}
+	}
+	return models, nil
 }
 
 // Provider implements the LLMProvider interface for Ollama (local LLM server).

--- a/internal/provider/ollama/provider_test.go
+++ b/internal/provider/ollama/provider_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -903,4 +904,96 @@ func TestConvertUserMessagesStripsEmptyText(t *testing.T) {
 	require.Len(t, msgs, 1)
 	assert.Equal(t, "user", msgs[0].Role)
 	assert.Equal(t, "helloworld", msgs[0].Content)
+}
+
+func TestResolveDefaultModel_SingleModel(t *testing.T) {
+	srv := testutil.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"models": [{"name": "llama3.2:latest", "size": 4294967296}]}`))
+	}))
+	defer srv.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Ollama.BaseURL = srv.URL
+
+	model, err := resolveDefaultModel(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "llama3.2:latest", model)
+}
+
+func TestResolveDefaultModel_NoModels(t *testing.T) {
+	srv := testutil.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"models": []}`))
+	}))
+	defer srv.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Ollama.BaseURL = srv.URL
+
+	_, err := resolveDefaultModel(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no models found")
+}
+
+func TestResolveDefaultModel_MultipleModels(t *testing.T) {
+	srv := testutil.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"models": [
+			{"name": "llama3.2:latest", "size": 4294967296},
+			{"name": "codellama:7b", "size": 3758096384}
+		]}`))
+	}))
+	defer srv.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Ollama.BaseURL = srv.URL
+
+	model, err := resolveDefaultModel(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "llama3.2:latest", model) // returns first model
+}
+
+func TestResolveDefaultModel_ConnectionError(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Provider.Ollama.BaseURL = "http://localhost:1"
+
+	_, err := resolveDefaultModel(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing Ollama models")
+}
+
+func TestListModels(t *testing.T) {
+	srv := testutil.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"models": [{"name": "llama3.2:latest", "size": 1}]}`))
+	}))
+	defer srv.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Ollama.BaseURL = srv.URL
+
+	models, err := listModels(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, []provider.Model{{ID: "llama3.2:latest", Name: "llama3.2:latest"}}, models)
+}
+
+func TestProviderDef_BaseURLDefault(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+
+	assert.Equal(t, DefaultBaseURL, def.BaseURL(cfg))
+}
+
+func TestProviderDef_BaseURLOverride(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Ollama.BaseURL = "http://custom-ollama:1234"
+
+	assert.Equal(t, "http://custom-ollama:1234", def.BaseURL(cfg))
+}
+
+func TestProviderDef_AuthIsKeyless(t *testing.T) {
+	def := providerDef()
+
+	apiKey, headers, err := def.Auth(config.DefaultConfig())
+	require.NoError(t, err)
+	assert.Empty(t, apiKey)
+	assert.Nil(t, headers)
 }

--- a/internal/provider/openai/provider.go
+++ b/internal/provider/openai/provider.go
@@ -6,15 +6,88 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
+	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/provider/ssecompat"
 )
 
 func init() {
-	provider.RegisterProvider("openai", func(baseURL, apiKey string, extraHeaders map[string]string) provider.LLMProvider {
-		return New(baseURL, apiKey, extraHeaders)
-	})
+	provider.Default.RegisterFallback(providerDef())
+}
+
+// providerDef describes this provider's construction, auth, and base URL
+// for provider.Default. Registered as the fallback (not an exact-ID match)
+// because this provider handles any name found in cfg.Provider.OpenAI —
+// "openai", "openrouter", a custom proxy name, etc. — not one fixed ID.
+// DefaultModel is left nil: this provider has never had default-model
+// resolution (users must pass --model), and Registry.ResolveDefaultModel's
+// ErrNoDefaultModel preserves that — see main.go's loadConfig().
+func providerDef() provider.ProviderDef {
+	return provider.ProviderDef{
+		ID: "openai",
+		Constructor: func(baseURL, apiKey string, extraHeaders map[string]string) provider.LLMProvider {
+			return New(baseURL, apiKey, extraHeaders)
+		},
+		BaseURL: func(cfg *config.Config) string {
+			oc, _ := lookupCompatEntry(cfg)
+			return oc.BaseURL
+		},
+		Auth: func(cfg *config.Config) (string, map[string]string, error) {
+			oc, ok := lookupCompatEntry(cfg)
+			if !ok {
+				return "", nil, formatUnknownProviderError(cfg.Provider.Default, cfg.Provider.OpenAI)
+			}
+			apiKey, err := config.ResolveOpenAICompatibleAPIKey(oc)
+			if err != nil {
+				return "", nil, fmt.Errorf("resolving %s API key: %w", cfg.Provider.Default, err)
+			}
+			return apiKey, oc.ExtraHeaders, nil
+		},
+	}
+}
+
+func lookupCompatEntry(cfg *config.Config) (config.OpenAICompatibleConfig, bool) {
+	for _, oc := range cfg.Provider.OpenAI {
+		if oc.Name == cfg.Provider.Default {
+			return oc, true
+		}
+	}
+	return config.OpenAICompatibleConfig{}, false
+}
+
+// formatUnknownProviderError builds a helpful error message when the
+// requested provider name doesn't match any configured
+// [[provider.openai_compatible]] entry. It lists what IS configured and
+// shows example config / CLI usage.
+func formatUnknownProviderError(name string, configured []config.OpenAICompatibleConfig) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "unknown provider: %q\n\n", name)
+
+	if len(configured) > 0 {
+		b.WriteString("Configured OpenAI-compatible providers:\n")
+		for _, oc := range configured {
+			fmt.Fprintf(&b, "  - %s (%s)\n", oc.Name, oc.BaseURL)
+		}
+		b.WriteString("\n")
+	} else {
+		b.WriteString("No OpenAI-compatible providers are configured.\n\n")
+	}
+
+	b.WriteString("Quick fix — use CLI flags:\n")
+	fmt.Fprintf(&b, "  rubichan --provider %s --api-base http://localhost:1234/v1 --model my-model\n\n", name)
+
+	b.WriteString("Or add to ~/.config/rubichan/config.toml:\n")
+	fmt.Fprintf(&b, "  [provider]\n")
+	fmt.Fprintf(&b, "  default = %q\n", name)
+	fmt.Fprintf(&b, "  model   = \"my-model\"\n\n")
+	fmt.Fprintf(&b, "  [[provider.openai_compatible]]\n")
+	fmt.Fprintf(&b, "  name     = %q\n", name)
+	fmt.Fprintf(&b, "  base_url = \"http://localhost:1234/v1\"\n")
+	fmt.Fprintf(&b, "  api_key  = \"none\"")
+
+	return fmt.Errorf("%s", b.String())
 }
 
 // Provider implements the LLMProvider interface for OpenAI-compatible APIs.

--- a/internal/provider/openai/provider_test.go
+++ b/internal/provider/openai/provider_test.go
@@ -10,11 +10,43 @@ import (
 	"testing"
 	"time"
 
+	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestProviderDef_BaseURLAndAuth(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "openrouter"
+	cfg.Provider.OpenAI = []config.OpenAICompatibleConfig{
+		{Name: "openrouter", BaseURL: "https://openrouter.ai/api/v1", APIKeySource: "config", APIKey: "test-key", ExtraHeaders: map[string]string{"X-Test": "1"}},
+	}
+
+	assert.Equal(t, "https://openrouter.ai/api/v1", def.BaseURL(cfg))
+
+	apiKey, headers, err := def.Auth(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "test-key", apiKey)
+	assert.Equal(t, map[string]string{"X-Test": "1"}, headers)
+}
+
+func TestProviderDef_AuthUnknownProvider(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "does-not-exist"
+
+	_, _, err := def.Auth(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"does-not-exist"`)
+}
+
+func TestProviderDef_DefaultModelIsNil(t *testing.T) {
+	def := providerDef()
+	assert.Nil(t, def.DefaultModel)
+}
 
 func TestStreamTextResponse(t *testing.T) {
 	sseBody := `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -1,0 +1,146 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/julianshen/rubichan/internal/config"
+)
+
+// ProviderConstructor is a function that creates a new LLMProvider.
+type ProviderConstructor func(baseURL, apiKey string, extraHeaders map[string]string) LLMProvider
+
+// KeepAliveConfigurer is implemented by providers that support configurable
+// model keep-alive duration (e.g., Ollama). Registry.New type-asserts
+// against it after construction, for any provider that happens to
+// implement it — no provider-specific wiring needed here.
+type KeepAliveConfigurer interface {
+	SetKeepAlive(duration string)
+	KeepAlive() string
+}
+
+// ErrNoDefaultModel is returned by Registry.ResolveDefaultModel when the
+// resolved provider has no DefaultModel resolver (e.g. a custom
+// OpenAI-compatible endpoint). Callers should treat this as "leave the
+// model unset," not as a failure — the provider was found, it simply
+// doesn't offer default-model resolution.
+var ErrNoDefaultModel = errors.New("provider has no default model")
+
+// Model describes one entry in a provider's model catalog, whether static
+// or fetched dynamically via ProviderDef.ListModels.
+type Model struct {
+	ID   string
+	Name string
+}
+
+// ProviderDef is a declarative registration for one provider: how to build
+// it, how to authenticate it, and (optionally) how to resolve or list its
+// models. Registering a ProviderDef replaces registering a bare
+// ProviderConstructor — construction and default-model resolution are
+// described once, together, instead of as parallel switch-statements in
+// factory.go and cmd/rubichan/main.go.
+type ProviderDef struct {
+	ID          string
+	Constructor ProviderConstructor
+	BaseURL     func(cfg *config.Config) string
+	Auth        func(cfg *config.Config) (apiKey string, headers map[string]string, err error)
+
+	// DefaultModel resolves the model to use when the user hasn't specified
+	// one. nil means the provider has no default-model resolution (the
+	// caller must always specify a model explicitly) — ResolveDefaultModel
+	// returns ErrNoDefaultModel in that case.
+	DefaultModel func(ctx context.Context, cfg *config.Config) (string, error)
+
+	// ListModels returns the provider's available models. nil means the
+	// provider doesn't support dynamic listing.
+	ListModels func(ctx context.Context, cfg *config.Config) ([]Model, error)
+}
+
+// Registry holds ProviderDefs, registered by each provider package's init().
+type Registry struct {
+	defs        map[string]ProviderDef
+	fallback    ProviderDef
+	hasFallback bool
+}
+
+// NewRegistry returns an empty Registry. Most callers use Default; tests
+// that want isolation from global registration state use NewRegistry.
+func NewRegistry() *Registry {
+	return &Registry{defs: make(map[string]ProviderDef)}
+}
+
+// Default is the registry every provider package registers against via
+// init(). cmd/rubichan and factory.go use this one.
+var Default = NewRegistry()
+
+// Register adds or replaces a provider definition, looked up by ID.
+func (r *Registry) Register(def ProviderDef) {
+	r.defs[def.ID] = def
+}
+
+// RegisterFallback registers a definition used when cfg.Provider.Default
+// doesn't match any exact-ID registration — mirrors the OpenAI-compatible
+// provider's role of handling any provider name found in
+// cfg.Provider.OpenAI rather than one fixed ID.
+func (r *Registry) RegisterFallback(def ProviderDef) {
+	r.fallback = def
+	r.hasFallback = true
+}
+
+func (r *Registry) lookup(id string) (ProviderDef, error) {
+	if def, ok := r.defs[id]; ok {
+		return def, nil
+	}
+	if r.hasFallback {
+		return r.fallback, nil
+	}
+	return ProviderDef{}, fmt.Errorf("provider %q not registered", id)
+}
+
+// New builds the LLMProvider for cfg.Provider.Default.
+func (r *Registry) New(cfg *config.Config) (LLMProvider, error) {
+	def, err := r.lookup(cfg.Provider.Default)
+	if err != nil {
+		return nil, err
+	}
+	apiKey, headers, err := def.Auth(cfg)
+	if err != nil {
+		return nil, err
+	}
+	p := def.Constructor(def.BaseURL(cfg), apiKey, headers)
+	if ka := cfg.Agent.Cache.OllamaKeepAlive; ka != "" {
+		if kac, ok := p.(KeepAliveConfigurer); ok {
+			kac.SetKeepAlive(ka)
+		}
+	}
+	return p, nil
+}
+
+// ResolveDefaultModel returns the model to use for cfg.Provider.Default when
+// the user hasn't specified one. Returns ErrNoDefaultModel if the provider
+// has no DefaultModel resolver (distinct from any other error, which means
+// resolution was attempted and failed).
+func (r *Registry) ResolveDefaultModel(ctx context.Context, cfg *config.Config) (string, error) {
+	def, err := r.lookup(cfg.Provider.Default)
+	if err != nil {
+		return "", err
+	}
+	if def.DefaultModel == nil {
+		return "", ErrNoDefaultModel
+	}
+	return def.DefaultModel(ctx, cfg)
+}
+
+// ListModels returns the available models for providerID. Returns an error
+// if the provider has no ListModels resolver.
+func (r *Registry) ListModels(ctx context.Context, providerID string, cfg *config.Config) ([]Model, error) {
+	def, err := r.lookup(providerID)
+	if err != nil {
+		return nil, err
+	}
+	if def.ListModels == nil {
+		return nil, fmt.Errorf("provider %q does not support model listing", providerID)
+	}
+	return def.ListModels(ctx, cfg)
+}

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -75,6 +75,9 @@ func NewRegistry() *Registry {
 var Default = NewRegistry()
 
 // Register adds or replaces a provider definition, looked up by ID.
+// Called only from each provider package's init(), which runs
+// single-threaded before main(); safe without a mutex as long as nothing
+// calls Register on Default after program startup.
 func (r *Registry) Register(def ProviderDef) {
 	r.defs[def.ID] = def
 }

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -79,6 +79,7 @@ var Default = NewRegistry()
 // single-threaded before main(); safe without a mutex as long as nothing
 // calls Register on Default after program startup.
 func (r *Registry) Register(def ProviderDef) {
+	validateDef(def)
 	r.defs[def.ID] = def
 }
 
@@ -87,8 +88,25 @@ func (r *Registry) Register(def ProviderDef) {
 // provider's role of handling any provider name found in
 // cfg.Provider.OpenAI rather than one fixed ID.
 func (r *Registry) RegisterFallback(def ProviderDef) {
+	validateDef(def)
 	r.fallback = def
 	r.hasFallback = true
+}
+
+// validateDef panics on a definition missing a hook that New or
+// ResolveDefaultModel will call unconditionally. Registration happens in
+// init(), so this fails at program start with the provider named, rather
+// than as a bare nil-function-call on the first request that reaches it.
+// DefaultModel and ListModels are genuinely optional and not checked.
+func validateDef(def ProviderDef) {
+	switch {
+	case def.Constructor == nil:
+		panic(fmt.Errorf("provider %q: Constructor is required", def.ID))
+	case def.BaseURL == nil:
+		panic(fmt.Errorf("provider %q: BaseURL is required", def.ID))
+	case def.Auth == nil:
+		panic(fmt.Errorf("provider %q: Auth is required", def.ID))
+	}
 }
 
 func (r *Registry) lookup(id string) (ProviderDef, error) {

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -1,0 +1,169 @@
+package provider_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/config"
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeProvider struct {
+	baseURL, apiKey string
+	headers         map[string]string
+}
+
+func (f *fakeProvider) Stream(context.Context, provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
+	return nil, nil
+}
+
+func fakeDef(id string) provider.ProviderDef {
+	return provider.ProviderDef{
+		ID: id,
+		Constructor: func(baseURL, apiKey string, headers map[string]string) provider.LLMProvider {
+			return &fakeProvider{baseURL: baseURL, apiKey: apiKey, headers: headers}
+		},
+		BaseURL: func(cfg *config.Config) string { return "https://" + id + ".example.com" },
+		Auth: func(cfg *config.Config) (string, map[string]string, error) {
+			return "key-" + id, map[string]string{"X-Test": id}, nil
+		},
+	}
+}
+
+func TestRegistry_New_BuildsRegisteredProvider(t *testing.T) {
+	r := provider.NewRegistry()
+	r.Register(fakeDef("acme"))
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "acme"
+
+	p, err := r.New(cfg)
+	require.NoError(t, err)
+	fp, ok := p.(*fakeProvider)
+	require.True(t, ok)
+	assert.Equal(t, "https://acme.example.com", fp.baseURL)
+	assert.Equal(t, "key-acme", fp.apiKey)
+	assert.Equal(t, map[string]string{"X-Test": "acme"}, fp.headers)
+}
+
+func TestRegistry_New_UnknownProvider(t *testing.T) {
+	r := provider.NewRegistry()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "nope"
+
+	_, err := r.New(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"nope"`)
+}
+
+func TestRegistry_New_AuthError(t *testing.T) {
+	r := provider.NewRegistry()
+	def := fakeDef("acme")
+	def.Auth = func(cfg *config.Config) (string, map[string]string, error) {
+		return "", nil, fmt.Errorf("no key configured")
+	}
+	r.Register(def)
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "acme"
+
+	_, err := r.New(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no key configured")
+}
+
+func TestRegistry_New_FallsBackWhenNoExactMatch(t *testing.T) {
+	r := provider.NewRegistry()
+	r.RegisterFallback(fakeDef("compat"))
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "my-custom-endpoint"
+
+	p, err := r.New(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+}
+
+type keepAliveFakeProvider struct {
+	fakeProvider
+	keepAlive string
+}
+
+func (k *keepAliveFakeProvider) SetKeepAlive(d string) { k.keepAlive = d }
+func (k *keepAliveFakeProvider) KeepAlive() string     { return k.keepAlive }
+
+func TestRegistry_New_AppliesKeepAliveConfigurer(t *testing.T) {
+	r := provider.NewRegistry()
+	r.Register(provider.ProviderDef{
+		ID: "ka",
+		Constructor: func(baseURL, apiKey string, headers map[string]string) provider.LLMProvider {
+			return &keepAliveFakeProvider{}
+		},
+		BaseURL: func(cfg *config.Config) string { return "" },
+		Auth:    func(cfg *config.Config) (string, map[string]string, error) { return "", nil, nil },
+	})
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "ka"
+	cfg.Agent.Cache.OllamaKeepAlive = "10m"
+
+	p, err := r.New(cfg)
+	require.NoError(t, err)
+	kap, ok := p.(*keepAliveFakeProvider)
+	require.True(t, ok)
+	assert.Equal(t, "10m", kap.keepAlive)
+}
+
+func TestRegistry_ResolveDefaultModel(t *testing.T) {
+	r := provider.NewRegistry()
+	def := fakeDef("acme")
+	def.DefaultModel = func(ctx context.Context, cfg *config.Config) (string, error) {
+		return "acme-model-1", nil
+	}
+	r.Register(def)
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "acme"
+
+	model, err := r.ResolveDefaultModel(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "acme-model-1", model)
+}
+
+func TestRegistry_ResolveDefaultModel_NoResolver(t *testing.T) {
+	r := provider.NewRegistry()
+	r.Register(fakeDef("acme")) // DefaultModel left nil
+
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "acme"
+
+	_, err := r.ResolveDefaultModel(context.Background(), cfg)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, provider.ErrNoDefaultModel))
+}
+
+func TestRegistry_ListModels(t *testing.T) {
+	r := provider.NewRegistry()
+	def := fakeDef("acme")
+	def.ListModels = func(ctx context.Context, cfg *config.Config) ([]provider.Model, error) {
+		return []provider.Model{{ID: "m1", Name: "Model One"}}, nil
+	}
+	r.Register(def)
+
+	models, err := r.ListModels(context.Background(), "acme", config.DefaultConfig())
+	require.NoError(t, err)
+	assert.Equal(t, []provider.Model{{ID: "m1", Name: "Model One"}}, models)
+}
+
+func TestRegistry_ListModels_NoResolver(t *testing.T) {
+	r := provider.NewRegistry()
+	r.Register(fakeDef("acme")) // ListModels left nil
+
+	_, err := r.ListModels(context.Background(), "acme", config.DefaultConfig())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support model listing")
+}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -227,3 +227,74 @@ func TestRegisterAcceptsCompleteDef(t *testing.T) {
 	require.NotPanics(t, func() { r.Register(def) })
 	require.NotPanics(t, func() { r.RegisterFallback(def) })
 }
+
+// TestNewCallsAuthBeforeBaseURL pins an ordering the OpenAI-compatible
+// provider depends on for correctness.
+//
+// Its BaseURL discards the lookup's ok flag and returns the zero entry's
+// empty URL for an unknown provider, while its Auth returns a descriptive
+// error for that same case. Because New authenticates first, the error
+// surfaces and BaseURL's silent empty string never reaches a constructor.
+// Reversing the order — or evaluating BaseURL into a variable before the
+// Auth call — would turn a clear "unknown provider" error into a provider
+// built against an empty base URL, failing later and less legibly.
+func TestNewCallsAuthBeforeBaseURL(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	def := provider.ProviderDef{
+		ID: "test",
+		Constructor: func(string, string, map[string]string) provider.LLMProvider {
+			calls = append(calls, "Constructor")
+			return &fakeProvider{}
+		},
+		BaseURL: func(*config.Config) string {
+			calls = append(calls, "BaseURL")
+			return ""
+		},
+		Auth: func(*config.Config) (string, map[string]string, error) {
+			calls = append(calls, "Auth")
+			return "", nil, nil
+		},
+	}
+
+	r := provider.NewRegistry()
+	r.Register(def)
+
+	cfg := &config.Config{}
+	cfg.Provider.Default = "test"
+	_, err := r.New(cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"Auth", "BaseURL", "Constructor"}, calls,
+		"New must authenticate before resolving the base URL")
+}
+
+// TestNewSkipsBaseURLWhenAuthFails is the consequence of that ordering:
+// a failed Auth short-circuits, so BaseURL never runs on a config it
+// cannot resolve.
+func TestNewSkipsBaseURLWhenAuthFails(t *testing.T) {
+	t.Parallel()
+
+	baseURLCalled := false
+	def := provider.ProviderDef{
+		ID:          "test",
+		Constructor: func(string, string, map[string]string) provider.LLMProvider { return &fakeProvider{} },
+		BaseURL: func(*config.Config) string {
+			baseURLCalled = true
+			return ""
+		},
+		Auth: func(*config.Config) (string, map[string]string, error) {
+			return "", nil, errors.New("no credentials")
+		},
+	}
+
+	r := provider.NewRegistry()
+	r.Register(def)
+
+	cfg := &config.Config{}
+	cfg.Provider.Default = "test"
+	_, err := r.New(cfg)
+	require.Error(t, err)
+	require.False(t, baseURLCalled, "BaseURL must not run once Auth has failed")
+}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -169,11 +169,11 @@ func TestRegistry_ListModels_NoResolver(t *testing.T) {
 }
 
 // TestRegisterRejectsIncompleteDef pins the registration-time contract.
-// New and ResolveDefaultModel call Constructor, BaseURL and Auth without
-// nil checks, so a def missing one of them panics on the first request
-// that reaches it — far from the init() that registered it, with a bare
-// nil-function-call and no provider name. Failing at registration keeps
-// the blame at the offending provider.
+// New calls Constructor, BaseURL and Auth without nil checks, so a def
+// missing one of them panics on the first request that reaches it — far
+// from the init() that registered it, with a bare nil-function-call and
+// no provider name. Failing at registration keeps the blame at the
+// offending provider.
 func TestRegisterRejectsIncompleteDef(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -167,3 +167,63 @@ func TestRegistry_ListModels_NoResolver(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not support model listing")
 }
+
+// TestRegisterRejectsIncompleteDef pins the registration-time contract.
+// New and ResolveDefaultModel call Constructor, BaseURL and Auth without
+// nil checks, so a def missing one of them panics on the first request
+// that reaches it — far from the init() that registered it, with a bare
+// nil-function-call and no provider name. Failing at registration keeps
+// the blame at the offending provider.
+func TestRegisterRejectsIncompleteDef(t *testing.T) {
+	t.Parallel()
+
+	complete := func() provider.ProviderDef {
+		return provider.ProviderDef{
+			ID:          "test",
+			Constructor: func(string, string, map[string]string) provider.LLMProvider { return nil },
+			BaseURL:     func(*config.Config) string { return "" },
+			Auth:        func(*config.Config) (string, map[string]string, error) { return "", nil, nil },
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*provider.ProviderDef)
+		missing string
+	}{
+		{"missing Constructor", func(d *provider.ProviderDef) { d.Constructor = nil }, "Constructor"},
+		{"missing BaseURL", func(d *provider.ProviderDef) { d.BaseURL = nil }, "BaseURL"},
+		{"missing Auth", func(d *provider.ProviderDef) { d.Auth = nil }, "Auth"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			def := complete()
+			tt.mutate(&def)
+
+			r := provider.NewRegistry()
+			require.PanicsWithError(t, `provider "test": `+tt.missing+" is required",
+				func() { r.Register(def) })
+			require.PanicsWithError(t, `provider "test": `+tt.missing+" is required",
+				func() { r.RegisterFallback(def) })
+		})
+	}
+}
+
+// TestRegisterAcceptsCompleteDef guards against the validation rejecting
+// a valid registration — the optional resolvers stay optional.
+func TestRegisterAcceptsCompleteDef(t *testing.T) {
+	t.Parallel()
+
+	def := provider.ProviderDef{
+		ID:          "test",
+		Constructor: func(string, string, map[string]string) provider.LLMProvider { return nil },
+		BaseURL:     func(*config.Config) string { return "" },
+		Auth:        func(*config.Config) (string, map[string]string, error) { return "", nil, nil },
+	}
+
+	r := provider.NewRegistry()
+	require.NotPanics(t, func() { r.Register(def) })
+	require.NotPanics(t, func() { r.RegisterFallback(def) })
+}

--- a/internal/provider/zai/provider.go
+++ b/internal/provider/zai/provider.go
@@ -7,15 +7,49 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/provider/openai"
 	"github.com/julianshen/rubichan/internal/provider/ssecompat"
 )
 
 func init() {
-	provider.RegisterProvider("zai", func(baseURL, apiKey string, extraHeaders map[string]string) provider.LLMProvider {
-		return New(baseURL, apiKey, "glm-5", extraHeaders)
-	})
+	provider.Default.Register(providerDef())
+}
+
+// providerDef describes this provider's construction, auth, and default
+// model for provider.Default. Exposed as a function so tests can exercise
+// it directly, isolated from the shared provider.Default registry.
+func providerDef() provider.ProviderDef {
+	return provider.ProviderDef{
+		ID: "zai",
+		Constructor: func(baseURL, apiKey string, extraHeaders map[string]string) provider.LLMProvider {
+			return New(baseURL, apiKey, "glm-5", extraHeaders)
+		},
+		BaseURL: func(cfg *config.Config) string {
+			if cfg.Provider.Zai.BaseURL != "" {
+				return cfg.Provider.Zai.BaseURL
+			}
+			return "https://api.z.ai/api/coding/paas/v4"
+		},
+		Auth: func(cfg *config.Config) (string, map[string]string, error) {
+			apiKey, err := config.ResolveAPIKey(
+				cfg.Provider.Zai.APIKeySource,
+				cfg.Provider.Zai.APIKey,
+				"Z_AI_API_KEY",
+			)
+			if err != nil {
+				return "", nil, fmt.Errorf("resolving Z.ai API key: %w", err)
+			}
+			return apiKey, nil, nil
+		},
+		DefaultModel: func(_ context.Context, cfg *config.Config) (string, error) {
+			if cfg.Provider.Zai.Model != "" {
+				return cfg.Provider.Zai.Model, nil
+			}
+			return "glm-5", nil
+		},
+	}
 }
 
 // Provider implements the LLMProvider interface for Z.ai API.

--- a/internal/provider/zai/provider.go
+++ b/internal/provider/zai/provider.go
@@ -24,7 +24,9 @@ func providerDef() provider.ProviderDef {
 	return provider.ProviderDef{
 		ID: "zai",
 		Constructor: func(baseURL, apiKey string, extraHeaders map[string]string) provider.LLMProvider {
-			return New(baseURL, apiKey, "glm-5", extraHeaders)
+			// New defaults a blank model to glm-5; repeating the literal here
+			// would make the same default live in three places.
+			return New(baseURL, apiKey, "", extraHeaders)
 		},
 		BaseURL: func(cfg *config.Config) string {
 			if cfg.Provider.Zai.BaseURL != "" {

--- a/internal/provider/zai/provider_test.go
+++ b/internal/provider/zai/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -1034,6 +1035,54 @@ data: [DONE]
 
 	assert.Equal(t, []string{"Valid"}, textParts)
 	assert.True(t, hasStop)
+}
+
+// Task 3 - ProviderDef Tests
+
+func TestProviderDef_BaseURLAndAuth(t *testing.T) {
+	t.Setenv("Z_AI_API_KEY", "test-zai-key")
+
+	def := providerDef()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "zai"
+	// config.DefaultConfig() only defaults APIKeySource to "env" for
+	// Anthropic; Z.ai has no such default (pre-existing gap, unrelated to
+	// this migration), so set it explicitly to exercise the env lookup.
+	cfg.Provider.Zai.APIKeySource = "env"
+
+	assert.Equal(t, "https://api.z.ai/api/coding/paas/v4", def.BaseURL(cfg))
+
+	apiKey, headers, err := def.Auth(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "test-zai-key", apiKey)
+	assert.Nil(t, headers)
+}
+
+func TestProviderDef_BaseURLOverride(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Zai.BaseURL = "https://custom.zai.example.com"
+
+	assert.Equal(t, "https://custom.zai.example.com", def.BaseURL(cfg))
+}
+
+func TestProviderDef_DefaultModel_FallsBackToGlm5(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+
+	model, err := def.DefaultModel(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "glm-5", model)
+}
+
+func TestProviderDef_DefaultModel_UsesConfiguredModel(t *testing.T) {
+	def := providerDef()
+	cfg := config.DefaultConfig()
+	cfg.Provider.Zai.Model = "custom-glm"
+
+	model, err := def.DefaultModel(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "custom-glm", model)
 }
 
 func TestExtraHeadersInRequest(t *testing.T) {


### PR DESCRIPTION
## Summary

Replaces `internal/provider/factory.go`'s hardcoded switch-statement and `cmd/rubichan/main.go`'s three copy-pasted default-model `if`-blocks with one declarative per-provider registration (`internal/provider/registry.go`: `Registry`/`ProviderDef`/`Model`). Design inspired by [earendil-works/pi](https://github.com/earendil-works/pi/tree/main/packages/ai)'s `createProvider()` pattern, adapted in scope to this repo's 4 providers — no new public API surface, no changes to the existing `CompletionRequest`/`StreamEvent` data model.

**Motivation:** PR #329 (merged just before this branch started) fixed a bug where `config.DefaultConfig()` baking in an Anthropic-specific model default silently defeated Ollama's and Z.ai's own default-model resolution, because construction (`factory.go`) and default-model resolution (`main.go`) were two separate places that had to be kept in sync by hand. This registry makes that bug class structurally harder to reintroduce: each provider now describes construction, auth, base URL, and default-model/model-listing resolution in exactly one place — its own `providerDef()`.

- Design spec: `docs/superpowers/specs/2026-07-28-provider-registry-design.md`
- Implementation plan (5 tasks, full code per step): `docs/superpowers/plans/2026-07-28-provider-registry.md`

## Migration approach

Each provider (Anthropic, Z.ai, Ollama, OpenAI-compatible) was migrated **fully atomically, one per commit**: register the new `ProviderDef`, cut `factory.go`'s switch-case and `main.go`'s default-model block over to it, and delete the superseded old code — all in the same commit. No commit leaves duplicate logic or dead code for a later commit to clean up.

The final task (OpenAI-compatible) also removed the now-fully-unused switch-statement scaffolding and collapsed `main.go`'s three provider-gated blocks into one generic call — safe only because every provider (including the OpenAI-compatible fallback) is registered, and because `provider.ErrNoDefaultModel` distinguishes "this provider has no default-model resolver" (leave `Model` unset, matching prior behavior for custom OpenAI-compatible endpoints) from "resolution was attempted and failed" (e.g. Ollama's zero-models case — still a hard error).

**One intentional, flagged behavior fix:** the old switch's early-return branches for Ollama/Z.ai always skipped `--debug` wiring; the unified dispatch applies it uniformly to every provider now.

## Review process

Each of the 5 tasks got an independent task-scoped review (spec compliance + code quality) before the next task started — all approved, no Critical/Important findings. A final whole-branch review (on the most capable model) traced the highest-risk mechanism (`ErrNoDefaultModel` handling) end-to-end and returned **Ready to merge: Yes**. Its two Minor findings were addressed in the last commit, which also caught and fixed a genuine pre-existing, unrelated test-isolation bug the new assertion exposed (`TestLoadConfig_WithProviderOverride` was reading the real `~/.config/rubichan/config.toml` on whatever machine ran it, instead of an isolated temp path).

## Test plan

- [x] `go build ./...`, `gofmt -l .`, `go vet ./...` — clean
- [x] `go test ./internal/provider/... ./cmd/rubichan/...` — 596 passed, 0 failed
- [x] `go test -race ./internal/provider/... ./cmd/rubichan/...` — clean aside from pre-existing, unrelated flaky tests (confirmed via `git stash` comparison against the pre-branch base): `streamwatchdog_test.go`'s short-timer test (~20% flake under `-race` scheduling noise, from PR #329, untouched by this branch) and `replay_test.go`'s follow-mode races (untouched by this branch)
- [x] `grep -rn "RegisterProvider\b|newAnthropicProvider|newZaiProvider|newOllamaProvider|newOpenAIProvider|resolveOllamaModel" internal/ cmd/` — zero matches, confirms nothing from the old mechanism survives
- [x] All 6 existing call sites of `provider.NewProvider`/`NewProviderWithDebug` (`serve.go`, `shell.go`, `knowledge.go`, `main.go` ×3) needed zero changes — public signatures unchanged throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Default model resolution is now consistent across supported providers, and if a provider has no default model, the model remains unset instead of failing.
  * Ollama can automatically select an available model when no model is specified.
  * OpenAI-compatible provider configuration now provides clearer, actionable guidance when a provider name is invalid.
  * Existing provider-specific settings, authentication, custom endpoints, and extra headers continue to work.
* **Documentation**
  * Added a detailed provider registry plan and design spec covering registration, model selection, and migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->