### PR TITLE
Phase 3 slice 2: extract internal/folderaccess from main.go

### DIFF
--- a/cmd/rubichan/coverage_test.go
+++ b/cmd/rubichan/coverage_test.go
@@ -1112,40 +1112,6 @@ func TestWireExtendedTools_SomeEnabled(t *testing.T) {
 // promptFolderAccess
 // ---------------------------------------------------------------------------
 
-func TestPromptFolderAccess_YesResponse(t *testing.T) {
-	t.Parallel()
-	var buf []byte
-	w := &writerBuffer{buf: &buf}
-	r := readerString("yes\n")
-
-	allowed, err := promptFolderAccess("/tmp/project", r, w)
-	require.NoError(t, err)
-	assert.True(t, allowed)
-	assert.Contains(t, string(buf), "Allow rubichan to access this folder?")
-}
-
-func TestPromptFolderAccess_NoResponse(t *testing.T) {
-	t.Parallel()
-	var buf []byte
-	w := &writerBuffer{buf: &buf}
-	r := readerString("no\n")
-
-	allowed, err := promptFolderAccess("/tmp/project", r, w)
-	require.NoError(t, err)
-	assert.False(t, allowed)
-}
-
-func TestPromptFolderAccess_CaseInsensitive(t *testing.T) {
-	t.Parallel()
-	var buf []byte
-	w := &writerBuffer{buf: &buf}
-	r := readerString("YES\n")
-
-	allowed, err := promptFolderAccess("/tmp/project", r, w)
-	require.NoError(t, err)
-	assert.True(t, allowed)
-}
-
 // writerBuffer is a minimal io.Writer for tests.
 type writerBuffer struct {
 	buf *[]byte

--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -30,6 +29,7 @@ import (
 	"github.com/julianshen/rubichan/internal/commands"
 	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/diag"
+	"github.com/julianshen/rubichan/internal/folderaccess"
 	"github.com/julianshen/rubichan/internal/hooks"
 	"github.com/julianshen/rubichan/internal/integrations"
 	"github.com/julianshen/rubichan/internal/knowledgegraph"
@@ -870,67 +870,6 @@ func loadProjectHooks(cfg *config.Config, s hooks.HookApprovalStore, cwd string)
 	return configs
 }
 
-func promptFolderAccess(workingDir string, in io.Reader, out io.Writer) (bool, error) {
-	if _, err := fmt.Fprintf(out, "Allow rubichan to access this folder?\n  %s\nType 'yes' to continue: ", workingDir); err != nil {
-		return false, fmt.Errorf("writing folder access prompt: %w", err)
-	}
-
-	line, err := bufio.NewReader(in).ReadString('\n')
-	if err != nil && !errors.Is(err, io.EOF) {
-		return false, fmt.Errorf("reading folder access response: %w", err)
-	}
-	return strings.EqualFold(strings.TrimSpace(line), "yes"), nil
-}
-
-func ensureFolderAccessApproved(s *store.Store, workingDir string, in io.Reader, out io.Writer) error {
-	approved, err := s.IsFolderApproved(workingDir)
-	if err != nil {
-		return fmt.Errorf("checking folder access approval: %w", err)
-	}
-	if approved {
-		return nil
-	}
-
-	allow, err := promptFolderAccess(workingDir, in, out)
-	if err != nil {
-		return err
-	}
-	if !allow {
-		return fmt.Errorf("folder access denied by user")
-	}
-
-	if err := s.ApproveFolderAccess(workingDir); err != nil {
-		return fmt.Errorf("saving folder access approval: %w", err)
-	}
-	return nil
-}
-
-func ensureFolderAccessApprovedInteractive(s *store.Store, workingDir string, in io.Reader, out io.Writer, autoApprove, approveCwd bool) error {
-	if autoApprove || approveCwd {
-		return ensureFolderAccessApprovedNonInteractive(s, workingDir, autoApprove, approveCwd)
-	}
-	return ensureFolderAccessApproved(s, workingDir, in, out)
-}
-
-func ensureFolderAccessApprovedNonInteractive(s *store.Store, workingDir string, autoApprove, approveCwd bool) error {
-	approved, err := s.IsFolderApproved(workingDir)
-	if err != nil {
-		return fmt.Errorf("checking folder access approval: %w", err)
-	}
-	if approved {
-		return nil
-	}
-
-	if !autoApprove && !approveCwd {
-		return fmt.Errorf("folder access for %q is not approved; rerun interactively to approve or use --approve-cwd/--auto-approve", workingDir)
-	}
-
-	if err := s.ApproveFolderAccess(workingDir); err != nil {
-		return fmt.Errorf("saving folder access approval: %w", err)
-	}
-	return nil
-}
-
 const memorySaveTimeout = 5 * time.Second
 
 func saveMemoriesBestEffort(parentCtx context.Context, a *agent.Agent, out io.Writer) {
@@ -1532,7 +1471,7 @@ func runInteractive() error {
 		return fmt.Errorf("opening store: %w", err)
 	}
 	defer s.Close()
-	if err := ensureFolderAccessApprovedInteractive(s, cwd, os.Stdin, os.Stderr, autoApprove, approveCwd); err != nil {
+	if err := folderaccess.EnsureApprovedInteractive(s, cwd, os.Stdin, os.Stderr, autoApprove, approveCwd); err != nil {
 		return err
 	}
 	opts = append(opts, agent.WithStore(s))
@@ -2022,7 +1961,7 @@ func runHeadless() error {
 		return fmt.Errorf("opening store: %w", err)
 	}
 	defer s.Close()
-	if err := ensureFolderAccessApprovedNonInteractive(s, cwd, autoApprove, approveCwd); err != nil {
+	if err := folderaccess.EnsureApprovedNonInteractive(s, cwd, autoApprove, approveCwd); err != nil {
 		return err
 	}
 	opts = append(opts, agent.WithStore(s))

--- a/cmd/rubichan/main_test.go
+++ b/cmd/rubichan/main_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -17,7 +16,6 @@ import (
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/runner"
 	"github.com/julianshen/rubichan/internal/security"
-	"github.com/julianshen/rubichan/internal/store"
 	"github.com/julianshen/rubichan/internal/testutil"
 	"github.com/julianshen/rubichan/internal/tools/xcode"
 	"github.com/spf13/cobra"
@@ -108,32 +106,6 @@ func TestOpenStore_CreatesMissingDirs(t *testing.T) {
 	dbPath := filepath.Join(dir, "rubichan.db")
 	_, err = os.Stat(dbPath)
 	assert.NoError(t, err, "database file should exist in nested directory")
-}
-
-func TestEnsureFolderAccessApprovedNonInteractiveRequiresExplicitApproval(t *testing.T) {
-	dir := t.TempDir()
-	s, err := openStore(dir)
-	require.NoError(t, err)
-	defer s.Close()
-
-	err = ensureFolderAccessApprovedNonInteractive(s, filepath.Join(dir, "repo"), false, false)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--approve-cwd/--auto-approve")
-}
-
-func TestEnsureFolderAccessApprovedNonInteractiveApproveCwd(t *testing.T) {
-	dir := t.TempDir()
-	s, err := openStore(dir)
-	require.NoError(t, err)
-	defer s.Close()
-
-	repoDir := filepath.Join(dir, "repo")
-	err = ensureFolderAccessApprovedNonInteractive(s, repoDir, false, true)
-	require.NoError(t, err)
-
-	approved, err := s.IsFolderApproved(repoDir)
-	require.NoError(t, err)
-	assert.True(t, approved)
 }
 
 func TestAppendWorkingDirOptionAlwaysAppliesCWD(t *testing.T) {
@@ -534,97 +506,6 @@ func TestApplyAPIKeyFlag_OpenAICompatible(t *testing.T) {
 
 	assert.Equal(t, "config", cfg.Provider.OpenAI[0].APIKeySource)
 	assert.Equal(t, "new-key", cfg.Provider.OpenAI[0].APIKey)
-}
-
-func TestEnsureFolderAccessApproved_FirstTimeApprove(t *testing.T) {
-	s := mustOpenStore(t)
-	defer s.Close()
-
-	var out bytes.Buffer
-	err := ensureFolderAccessApproved(s, "/tmp/project", strings.NewReader("yes\n"), &out)
-	require.NoError(t, err)
-	assert.Contains(t, out.String(), "Allow rubichan to access this folder?")
-
-	approved, err := s.IsFolderApproved("/tmp/project")
-	require.NoError(t, err)
-	assert.True(t, approved)
-}
-
-func TestEnsureFolderAccessApproved_Denied(t *testing.T) {
-	s := mustOpenStore(t)
-	defer s.Close()
-
-	var out bytes.Buffer
-	err := ensureFolderAccessApproved(s, "/tmp/project", strings.NewReader("no\n"), &out)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "folder access denied")
-}
-
-func TestEnsureFolderAccessApproved_AlreadyApprovedSkipsPrompt(t *testing.T) {
-	s := mustOpenStore(t)
-	defer s.Close()
-	require.NoError(t, s.ApproveFolderAccess("/tmp/project"))
-
-	var out bytes.Buffer
-	err := ensureFolderAccessApproved(s, "/tmp/project", strings.NewReader(""), &out)
-	require.NoError(t, err)
-	assert.Empty(t, out.String())
-}
-
-func mustOpenStore(t *testing.T) *store.Store {
-	t.Helper()
-	s, err := store.NewStore(":memory:")
-	require.NoError(t, err)
-	return s
-}
-
-func TestEnsureFolderAccessApprovedNonInteractive_DeniedWithoutAutoApprove(t *testing.T) {
-	s := mustOpenStore(t)
-	defer s.Close()
-
-	err := ensureFolderAccessApprovedNonInteractive(s, "/tmp/project", false, false)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not approved")
-}
-
-func TestEnsureFolderAccessApprovedNonInteractive_AutoApproves(t *testing.T) {
-	s := mustOpenStore(t)
-	defer s.Close()
-
-	err := ensureFolderAccessApprovedNonInteractive(s, "/tmp/project", true, false)
-	require.NoError(t, err)
-
-	approved, err := s.IsFolderApproved("/tmp/project")
-	require.NoError(t, err)
-	assert.True(t, approved)
-}
-
-func TestEnsureFolderAccessApprovedInteractive_UsesAutoApprove(t *testing.T) {
-	s := mustOpenStore(t)
-	defer s.Close()
-
-	var out bytes.Buffer
-	err := ensureFolderAccessApprovedInteractive(s, "/tmp/project", strings.NewReader(""), &out, true, false)
-	require.NoError(t, err)
-	assert.Empty(t, out.String())
-
-	approved, err := s.IsFolderApproved("/tmp/project")
-	require.NoError(t, err)
-	assert.True(t, approved)
-}
-
-func TestEnsureFolderAccessApprovedInteractive_UsesApproveCwd(t *testing.T) {
-	s := mustOpenStore(t)
-	defer s.Close()
-
-	var out bytes.Buffer
-	err := ensureFolderAccessApprovedInteractive(s, "/tmp/project", strings.NewReader(""), &out, false, true)
-	require.NoError(t, err)
-	assert.Empty(t, out.String())
-
-	approved, err := s.IsFolderApproved("/tmp/project")
-	require.NoError(t, err)
-	assert.True(t, approved)
 }
 
 func TestPersonaErrorMessage(t *testing.T) {

--- a/docs/MODULAR_CORE_REDESIGN.md
+++ b/docs/MODULAR_CORE_REDESIGN.md
@@ -182,6 +182,17 @@ For each subsystem, introduce the right seam interface and move it behind it, re
 **Phase 3 — Adapters over the core.**
 Reduce `cmd/rubichan/main.go` to composition only: build core, register modules, pick an adapter. Move mode wiring into `internal/modes/*` (or `pkg` for reusable ones). Target: `main.go` under a few hundred lines.
 
+> **Status update (2026-07): Phase 3 started — two slices out, both extractions of things that were never composition.**
+>
+> The phase is being taken as a sequence of named clusters rather than one move, since main.go's contents are not homogeneous: some of it is genuinely composition (build a registry, pick a provider) and belongs where it is; the rest is subsystems that happen to be spelled inline.
+>
+> - **Slice 1 — `internal/diag`.** Process-level diagnostics: the session log, the JSONL event log, the stack dumps written on signal or panic (20 tests moved with it). File layout, permissions and log-writer swapping are not main's business.
+> - **Slice 2 — `internal/folderaccess`.** The working-directory approval gate: prompt, interactive path, headless path. Whether an unapproved folder is a question or an error, and what `--approve-cwd`/`--auto-approve` mean, is product policy the entrypoint should call rather than contain. Its persistence dependency is a two-method `Store` interface declared in the package, so the policy does not import the persistence layer to state its own rules.
+>
+> **Measured: 3,383 → 3,173 lines.** That is 210 lines across two slices, against a target of "a few hundred" — i.e. roughly 7% of the distance, and the remaining ~2,900 lines are the harder part (the inline interactive/headless/wiki flows identified in Problem C, which need the dormant `internal/modes/*` adapters to become the real path). The line count also moves independently of this work: #329's Ollama fix added 17 lines to main.go between the two slices. Treat the number as a direction of travel, not a burn-down.
+>
+> **Both slices were pure `[STRUCTURAL]` moves** — bodies verbatim, tests moved with them, before-and-after test runs identical — which is what makes them cheap to review and safe to land alongside unrelated work in the same file.
+
 **Phase 4 — Publish the module API.**
 Document the ~7 seams in `pkg/…` with examples (`examples/` already exists). External apps now embed the **real** core and opt into exactly the modules they want (e.g. a NATS bridge with tools + checkpoint but no TUI).
 

--- a/docs/MODULAR_CORE_REDESIGN.md
+++ b/docs/MODULAR_CORE_REDESIGN.md
@@ -191,7 +191,14 @@ Reduce `cmd/rubichan/main.go` to composition only: build core, register modules,
 >
 > **Measured: 3,383 → 3,173 lines.** That is 210 lines across two slices, against a target of "a few hundred" — i.e. roughly 7% of the distance, and the remaining ~2,900 lines are the harder part (the inline interactive/headless/wiki flows identified in Problem C, which need the dormant `internal/modes/*` adapters to become the real path). The line count also moves independently of this work: #329's Ollama fix added 17 lines to main.go between the two slices. Treat the number as a direction of travel, not a burn-down.
 >
-> **Both slices were pure `[STRUCTURAL]` moves** — bodies verbatim, tests moved with them, before-and-after test runs identical — which is what makes them cheap to review and safe to land alongside unrelated work in the same file.
+> **Slice 1 was a pure `[STRUCTURAL]` move** — bodies verbatim, tests moved with them, before-and-after test runs identical, which is what makes that shape cheap to review and safe to land alongside unrelated work in the same file.
+>
+> **Slice 2 started as one and did not stay one.** The move itself was verbatim, but giving the code a package boundary turned two of its implementation details into a published contract, and both were wrong:
+>
+> - `Prompt` wrapped the caller's `io.Reader` in a `bufio.Reader` and discarded it, so anything the stream offered after the response line was lost. Harmless while the reader was a local detail of main.go on a canonical-mode terminal (each `read(2)` ends at the newline); a real defect once the same `os.Stdin` is documented as passing to the TUI afterwards. Reachable today with piped stdin.
+> - Replacing `bufio` then dropped its guard against readers that return `(0, nil)` forever, turning a prompt that errors into a prompt that hangs. Restored with the same 100-read threshold.
+>
+> Both went in as separate `[BEHAVIORAL]` commits after the structural one, per Tidy-First. The general lesson for the remaining slices: **an extraction is behaviour-preserving in the mechanical sense while still promoting private assumptions into public contracts.** Expect to find and fix a defect per slice, and expect the fix to be a separate commit rather than a reason to make the move impure.
 
 **Phase 4 — Publish the module API.**
 Document the ~7 seams in `pkg/…` with examples (`examples/` already exists). External apps now embed the **real** core and opt into exactly the modules they want (e.g. a NATS bridge with tools + checkpoint but no TUI).

--- a/internal/folderaccess/folderaccess.go
+++ b/internal/folderaccess/folderaccess.go
@@ -54,9 +54,11 @@ func Prompt(workingDir string, in io.Reader, out io.Writer) (bool, error) {
 func readLine(in io.Reader) (string, error) {
 	var line []byte
 	var buf [1]byte
+	stalled := 0
 	for {
 		n, err := in.Read(buf[:])
 		if n > 0 {
+			stalled = 0
 			if buf[0] == '\n' {
 				return string(line), nil
 			}
@@ -65,8 +67,22 @@ func readLine(in io.Reader) (string, error) {
 		if err != nil {
 			return string(line), err
 		}
+		// io.Reader permits (0, nil) and asks callers to treat it as a
+		// no-op, so a reader that never progresses would spin here
+		// forever. bufio.Reader gives up after this many attempts; a
+		// prompt that hangs is worse than one that errors.
+		if n == 0 {
+			stalled++
+			if stalled >= maxStalledReads {
+				return string(line), io.ErrNoProgress
+			}
+		}
 	}
 }
+
+// maxStalledReads matches bufio.Reader's tolerance for readers that return no
+// bytes and no error, so replacing it here does not lose its guard.
+const maxStalledReads = 100
 
 // EnsureApproved returns nil once workingDir is approved, prompting the user
 // when it is not already on record. A denial is an error: the caller cannot

--- a/internal/folderaccess/folderaccess.go
+++ b/internal/folderaccess/folderaccess.go
@@ -1,0 +1,100 @@
+// Package folderaccess gates rubichan on the user having approved the
+// directory it was started in. Approval is per working directory and
+// persisted, so the question is asked once per folder rather than once per
+// session.
+//
+// It lives outside cmd/ because the policy — when a prompt is allowed, what
+// the CLI flags mean, what an unapproved folder costs — is product behaviour
+// that main.go should call rather than contain. Extracted from
+// cmd/rubichan/main.go as a slice of the redesign's Phase 3.
+package folderaccess
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Store persists folder-access decisions. It is the subset of
+// internal/store.Store this package needs, declared here so the policy does
+// not depend on the persistence layer's package.
+type Store interface {
+	IsFolderApproved(workingDir string) (bool, error)
+	ApproveFolderAccess(workingDir string) error
+}
+
+// Prompt asks the user to approve workingDir and reports their answer. Only
+// "yes" (in any case) approves; anything else — including EOF from a closed
+// stdin — declines, because access to a folder should never be granted by
+// silence.
+func Prompt(workingDir string, in io.Reader, out io.Writer) (bool, error) {
+	if _, err := fmt.Fprintf(out, "Allow rubichan to access this folder?\n  %s\nType 'yes' to continue: ", workingDir); err != nil {
+		return false, fmt.Errorf("writing folder access prompt: %w", err)
+	}
+
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, fmt.Errorf("reading folder access response: %w", err)
+	}
+	return strings.EqualFold(strings.TrimSpace(line), "yes"), nil
+}
+
+// EnsureApproved returns nil once workingDir is approved, prompting the user
+// when it is not already on record. A denial is an error: the caller cannot
+// proceed without the folder.
+func EnsureApproved(s Store, workingDir string, in io.Reader, out io.Writer) error {
+	approved, err := s.IsFolderApproved(workingDir)
+	if err != nil {
+		return fmt.Errorf("checking folder access approval: %w", err)
+	}
+	if approved {
+		return nil
+	}
+
+	allow, err := Prompt(workingDir, in, out)
+	if err != nil {
+		return err
+	}
+	if !allow {
+		return fmt.Errorf("folder access denied by user")
+	}
+
+	if err := s.ApproveFolderAccess(workingDir); err != nil {
+		return fmt.Errorf("saving folder access approval: %w", err)
+	}
+	return nil
+}
+
+// EnsureApprovedInteractive is the interactive mode's entry point. Either
+// approval flag turns the prompt off, so a user who already said yes on the
+// command line is not asked again.
+func EnsureApprovedInteractive(s Store, workingDir string, in io.Reader, out io.Writer, autoApprove, approveCwd bool) error {
+	if autoApprove || approveCwd {
+		return EnsureApprovedNonInteractive(s, workingDir, autoApprove, approveCwd)
+	}
+	return EnsureApproved(s, workingDir, in, out)
+}
+
+// EnsureApprovedNonInteractive is the headless entry point: with no user to
+// ask, an unapproved folder is an error unless a flag granted approval up
+// front.
+func EnsureApprovedNonInteractive(s Store, workingDir string, autoApprove, approveCwd bool) error {
+	approved, err := s.IsFolderApproved(workingDir)
+	if err != nil {
+		return fmt.Errorf("checking folder access approval: %w", err)
+	}
+	if approved {
+		return nil
+	}
+
+	if !autoApprove && !approveCwd {
+		return fmt.Errorf("folder access for %q is not approved; rerun interactively to approve or use --approve-cwd/--auto-approve", workingDir)
+	}
+
+	if err := s.ApproveFolderAccess(workingDir); err != nil {
+		return fmt.Errorf("saving folder access approval: %w", err)
+	}
+	return nil
+}

--- a/internal/folderaccess/folderaccess.go
+++ b/internal/folderaccess/folderaccess.go
@@ -10,7 +10,6 @@
 package folderaccess
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -34,11 +33,39 @@ func Prompt(workingDir string, in io.Reader, out io.Writer) (bool, error) {
 		return false, fmt.Errorf("writing folder access prompt: %w", err)
 	}
 
-	line, err := bufio.NewReader(in).ReadString('\n')
+	line, err := readLine(in)
 	if err != nil && !errors.Is(err, io.EOF) {
 		return false, fmt.Errorf("reading folder access response: %w", err)
 	}
 	return strings.EqualFold(strings.TrimSpace(line), "yes"), nil
+}
+
+// readLine consumes one line from in and not a byte more, returning it without
+// the trailing newline. A buffered reader cannot be used here: it fills its
+// buffer from a single underlying read and is then discarded, so anything the
+// stream offered after the response line would be lost. Prompt does not own
+// its reader — the interactive path hands the same os.Stdin to the TUI once
+// the folder is approved — so over-reading would swallow the user's first
+// keystrokes.
+//
+// Reaching the end of the stream without a newline returns what was read
+// along with io.EOF, leaving the caller to decide whether that counts as an
+// answer.
+func readLine(in io.Reader) (string, error) {
+	var line []byte
+	var buf [1]byte
+	for {
+		n, err := in.Read(buf[:])
+		if n > 0 {
+			if buf[0] == '\n' {
+				return string(line), nil
+			}
+			line = append(line, buf[0])
+		}
+		if err != nil {
+			return string(line), err
+		}
+	}
 }
 
 // EnsureApproved returns nil once workingDir is approved, prompting the user

--- a/internal/folderaccess/folderaccess_test.go
+++ b/internal/folderaccess/folderaccess_test.go
@@ -2,6 +2,7 @@ package folderaccess_test
 
 import (
 	"bytes"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -143,4 +144,127 @@ func TestEnsureApprovedInteractiveUsesApproveCwd(t *testing.T) {
 	approved, err := s.IsFolderApproved("/tmp/project")
 	require.NoError(t, err)
 	assert.True(t, approved)
+}
+
+// failingStore lets the error paths be exercised: a real store only fails on
+// conditions (a corrupt database, a full disk) that a test cannot stage.
+type failingStore struct {
+	checkErr   error
+	approveErr error
+	approved   bool
+}
+
+func (f *failingStore) IsFolderApproved(string) (bool, error) { return f.approved, f.checkErr }
+func (f *failingStore) ApproveFolderAccess(string) error      { return f.approveErr }
+
+// failingWriter refuses every write, standing in for a closed or broken
+// terminal.
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("terminal closed") }
+
+// failingReader refuses every read with something other than EOF, which the
+// prompt must distinguish from a user simply pressing enter.
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) { return 0, errors.New("stdin broken") }
+
+func TestPromptReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	allowed, err := folderaccess.Prompt("/tmp/project", strings.NewReader("yes\n"), failingWriter{})
+	require.Error(t, err)
+	assert.False(t, allowed, "a prompt the user never saw cannot be an approval")
+	assert.Contains(t, err.Error(), "writing folder access prompt")
+}
+
+func TestPromptReportsReadFailure(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	allowed, err := folderaccess.Prompt("/tmp/project", failingReader{}, &out)
+	require.Error(t, err)
+	assert.False(t, allowed)
+	assert.Contains(t, err.Error(), "reading folder access response")
+}
+
+func TestPromptTreatsEOFAsDeclined(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	allowed, err := folderaccess.Prompt("/tmp/project", strings.NewReader("yes"), &out)
+	require.NoError(t, err, "input without a trailing newline is not a failure")
+	assert.True(t, allowed)
+
+	allowed, err = folderaccess.Prompt("/tmp/project", strings.NewReader(""), &out)
+	require.NoError(t, err)
+	assert.False(t, allowed, "silence is not approval")
+}
+
+func TestEnsureApprovedReportsCheckFailure(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	err := folderaccess.EnsureApproved(&failingStore{checkErr: errors.New("db gone")},
+		"/tmp/project", strings.NewReader("yes\n"), &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checking folder access approval")
+	assert.Empty(t, out.String(), "an unreadable store must not fall through to the prompt")
+}
+
+func TestEnsureApprovedPropagatesPromptFailure(t *testing.T) {
+	t.Parallel()
+
+	err := folderaccess.EnsureApproved(&failingStore{}, "/tmp/project",
+		strings.NewReader("yes\n"), failingWriter{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writing folder access prompt")
+}
+
+func TestEnsureApprovedReportsSaveFailure(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	err := folderaccess.EnsureApproved(&failingStore{approveErr: errors.New("disk full")},
+		"/tmp/project", strings.NewReader("yes\n"), &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "saving folder access approval")
+}
+
+func TestEnsureApprovedNonInteractiveReportsCheckFailure(t *testing.T) {
+	t.Parallel()
+
+	err := folderaccess.EnsureApprovedNonInteractive(&failingStore{checkErr: errors.New("db gone")},
+		"/tmp/project", true, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checking folder access approval")
+}
+
+func TestEnsureApprovedNonInteractiveReportsSaveFailure(t *testing.T) {
+	t.Parallel()
+
+	err := folderaccess.EnsureApprovedNonInteractive(&failingStore{approveErr: errors.New("disk full")},
+		"/tmp/project", true, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "saving folder access approval")
+}
+
+func TestEnsureApprovedNonInteractiveSkipsSaveWhenAlreadyApproved(t *testing.T) {
+	t.Parallel()
+
+	err := folderaccess.EnsureApprovedNonInteractive(
+		&failingStore{approved: true, approveErr: errors.New("must not be called")},
+		"/tmp/project", false, false)
+	assert.NoError(t, err, "an already-approved folder needs neither a flag nor a second write")
+}
+
+func TestEnsureApprovedInteractivePromptsWithoutFlags(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	err := folderaccess.EnsureApprovedInteractive(&failingStore{}, "/tmp/project",
+		strings.NewReader("yes\n"), &out, false, false)
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Allow rubichan to access this folder?",
+		"with neither flag set the user must still be asked")
 }

--- a/internal/folderaccess/folderaccess_test.go
+++ b/internal/folderaccess/folderaccess_test.go
@@ -1,0 +1,146 @@
+package folderaccess_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/folderaccess"
+	"github.com/julianshen/rubichan/internal/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustOpenStore(t *testing.T) *store.Store {
+	t.Helper()
+	s, err := store.NewStore(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestPromptYesResponse(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+
+	allowed, err := folderaccess.Prompt("/tmp/project", strings.NewReader("yes\n"), &out)
+	require.NoError(t, err)
+	assert.True(t, allowed)
+	assert.Contains(t, out.String(), "Allow rubichan to access this folder?")
+}
+
+func TestPromptNoResponse(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+
+	allowed, err := folderaccess.Prompt("/tmp/project", strings.NewReader("no\n"), &out)
+	require.NoError(t, err)
+	assert.False(t, allowed)
+}
+
+func TestPromptCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+
+	allowed, err := folderaccess.Prompt("/tmp/project", strings.NewReader("YES\n"), &out)
+	require.NoError(t, err)
+	assert.True(t, allowed)
+}
+
+func TestEnsureApprovedFirstTimeApprove(t *testing.T) {
+	s := mustOpenStore(t)
+
+	var out bytes.Buffer
+	err := folderaccess.EnsureApproved(s, "/tmp/project", strings.NewReader("yes\n"), &out)
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Allow rubichan to access this folder?")
+
+	approved, err := s.IsFolderApproved("/tmp/project")
+	require.NoError(t, err)
+	assert.True(t, approved)
+}
+
+func TestEnsureApprovedDenied(t *testing.T) {
+	s := mustOpenStore(t)
+
+	var out bytes.Buffer
+	err := folderaccess.EnsureApproved(s, "/tmp/project", strings.NewReader("no\n"), &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "folder access denied")
+}
+
+func TestEnsureApprovedAlreadyApprovedSkipsPrompt(t *testing.T) {
+	s := mustOpenStore(t)
+	require.NoError(t, s.ApproveFolderAccess("/tmp/project"))
+
+	var out bytes.Buffer
+	err := folderaccess.EnsureApproved(s, "/tmp/project", strings.NewReader(""), &out)
+	require.NoError(t, err)
+	assert.Empty(t, out.String())
+}
+
+func TestEnsureApprovedNonInteractiveDeniedWithoutAutoApprove(t *testing.T) {
+	s := mustOpenStore(t)
+
+	err := folderaccess.EnsureApprovedNonInteractive(s, "/tmp/project", false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not approved")
+}
+
+func TestEnsureApprovedNonInteractiveAutoApproves(t *testing.T) {
+	s := mustOpenStore(t)
+
+	err := folderaccess.EnsureApprovedNonInteractive(s, "/tmp/project", true, false)
+	require.NoError(t, err)
+
+	approved, err := s.IsFolderApproved("/tmp/project")
+	require.NoError(t, err)
+	assert.True(t, approved)
+}
+
+func TestEnsureApprovedNonInteractiveRequiresExplicitApproval(t *testing.T) {
+	s := mustOpenStore(t)
+
+	err := folderaccess.EnsureApprovedNonInteractive(s, filepath.Join(t.TempDir(), "repo"), false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--approve-cwd/--auto-approve")
+}
+
+func TestEnsureApprovedNonInteractiveApproveCwd(t *testing.T) {
+	s := mustOpenStore(t)
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	err := folderaccess.EnsureApprovedNonInteractive(s, repoDir, false, true)
+	require.NoError(t, err)
+
+	approved, err := s.IsFolderApproved(repoDir)
+	require.NoError(t, err)
+	assert.True(t, approved)
+}
+
+func TestEnsureApprovedInteractiveUsesAutoApprove(t *testing.T) {
+	s := mustOpenStore(t)
+
+	var out bytes.Buffer
+	err := folderaccess.EnsureApprovedInteractive(s, "/tmp/project", strings.NewReader(""), &out, true, false)
+	require.NoError(t, err)
+	assert.Empty(t, out.String())
+
+	approved, err := s.IsFolderApproved("/tmp/project")
+	require.NoError(t, err)
+	assert.True(t, approved)
+}
+
+func TestEnsureApprovedInteractiveUsesApproveCwd(t *testing.T) {
+	s := mustOpenStore(t)
+
+	var out bytes.Buffer
+	err := folderaccess.EnsureApprovedInteractive(s, "/tmp/project", strings.NewReader(""), &out, false, true)
+	require.NoError(t, err)
+	assert.Empty(t, out.String())
+
+	approved, err := s.IsFolderApproved("/tmp/project")
+	require.NoError(t, err)
+	assert.True(t, approved)
+}

--- a/internal/folderaccess/folderaccess_test.go
+++ b/internal/folderaccess/folderaccess_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/julianshen/rubichan/internal/folderaccess"
 	"github.com/julianshen/rubichan/internal/store"
@@ -288,4 +289,36 @@ func TestPromptLeavesLaterInputForTheNextReader(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "hello from the TUI\n", string(rest),
 		"Prompt must consume its line and no more")
+}
+
+// stalledReader always reports zero bytes and no error. io.Reader permits this
+// and tells callers to treat it as a no-op, so a reader that never progresses
+// must be given up on rather than spun on forever — bufio.Reader, which this
+// package used to rely on, bails after 100 such reads.
+type stalledReader struct{}
+
+func (stalledReader) Read([]byte) (int, error) { return 0, nil }
+
+func TestPromptGivesUpOnAReaderThatNeverProgresses(t *testing.T) {
+	t.Parallel()
+
+	type result struct {
+		allowed bool
+		err     error
+	}
+	done := make(chan result, 1)
+	go func() {
+		var out bytes.Buffer
+		allowed, err := folderaccess.Prompt("/tmp/project", stalledReader{}, &out)
+		done <- result{allowed, err}
+	}()
+
+	select {
+	case got := <-done:
+		require.Error(t, got.err, "a reader that never progresses is not an approval")
+		assert.False(t, got.allowed)
+		assert.Contains(t, got.err.Error(), "reading folder access response")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Prompt hung on a reader that never progresses")
+	}
 }

--- a/internal/folderaccess/folderaccess_test.go
+++ b/internal/folderaccess/folderaccess_test.go
@@ -3,6 +3,7 @@ package folderaccess_test
 import (
 	"bytes"
 	"errors"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -267,4 +268,24 @@ func TestEnsureApprovedInteractivePromptsWithoutFlags(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, out.String(), "Allow rubichan to access this folder?",
 		"with neither flag set the user must still be asked")
+}
+
+// TestPromptLeavesLaterInputForTheNextReader pins the contract that makes
+// Prompt safe on a stream it does not own: the interactive path hands the same
+// os.Stdin to the TUI once the prompt is answered, so consuming past the
+// response line would swallow the user's first keystrokes.
+func TestPromptLeavesLaterInputForTheNextReader(t *testing.T) {
+	t.Parallel()
+
+	in := strings.NewReader("yes\nhello from the TUI\n")
+	var out bytes.Buffer
+
+	allowed, err := folderaccess.Prompt("/tmp/project", in, &out)
+	require.NoError(t, err)
+	require.True(t, allowed)
+
+	rest, err := io.ReadAll(in)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from the TUI\n", string(rest),
+		"Prompt must consume its line and no more")
 }


### PR DESCRIPTION
## What

Second slice of the modular-core redesign's **Phase 3** ("reduce `main.go` to composition only"), following the `internal/diag` extraction.

The working-directory approval gate — four functions in `main.go` — moves to a new `internal/folderaccess` package:

| was | is |
| --- | --- |
| `promptFolderAccess` | `folderaccess.Prompt` |
| `ensureFolderAccessApproved` | `folderaccess.EnsureApproved` |
| `ensureFolderAccessApprovedInteractive` | `folderaccess.EnsureApprovedInteractive` |
| `ensureFolderAccessApprovedNonInteractive` | `folderaccess.EnsureApprovedNonInteractive` |

## Why

`main.go`'s job is composition. Whether an unapproved folder is a *question* or an *error*, and what `--approve-cwd` / `--auto-approve` mean, is product policy — the entrypoint should call it, not contain it.

The persistence dependency is declared as a local two-method `Store` interface rather than `*store.Store`, so the policy package does not import the persistence layer in order to state its own rules. (`internal/store` remains a test-only import, so the moved tests keep exercising the real SQLite path.)

## Commits

| # | commit | what |
| --- | --- | --- |
| 1 | `[STRUCTURAL]` Move Method | Bodies verbatim, thirteen tests moved with them. `main.go`: 3,234 → 3,173 lines. |
| 2 | `[BEHAVIORAL]` | Error-path tests. The moved functions arrived with only happy paths covered; every wrapped error (unreadable store, broken terminal, failed write of the approval) was untested, because a real store only fails on conditions a test cannot stage. A fake `Store` plus failing `io.Reader`/`io.Writer` stage them. Coverage 71.9% → **100%**. |
| 3 | `[STRUCTURAL]` Doc | Phase 3 had no status entry (the `internal/diag` slice went unrecorded). |
| 4 | `[BEHAVIORAL]` | Stop the prompt over-reading its input — found by CodeRabbit, see below. |
| 5 | `[BEHAVIORAL]` | Restore the no-progress guard that commit 4 lost with `bufio` — self-caught, see below. |
| 6 | `[STRUCTURAL]` Doc | Correct the slice-2 status entry, which still claimed the slice was behavior-preserving — found by Codex. |

Tidy-First: structural and behavioral changes are in separate commits throughout. The structural move never contained a behavior change.

## The over-read fix (commit 4)

`Prompt` built a `bufio.Reader` over the caller's `io.Reader` and discarded it. `bufio` fills its buffer from a single underlying read, so everything the stream offered after the response line was silently dropped:

```
prompt consumed: "yes\n"
left for next reader: ""      // input "yes\nhello from the TUI\n"
```

`Prompt` does not own its reader — the interactive path passes the same `os.Stdin` to `Prompt` (`main.go:1474`) and then to the plain host (`:1551`) or bubbletea (`:1827`) — so the dropped bytes are the user's first keystrokes. Latent on a real terminal, where canonical mode ends each `read(2)` at the newline; live with piped stdin (`printf 'yes\nhello\n' | rubichan --plain` on a first-visit folder loses `hello`). Pre-existing since #53.

`readLine` now consumes a byte at a time and stops at the newline. EOF handling is unchanged: `yes` without a trailing newline still approves, silence still declines.

Fixed here rather than deferred because this extraction is what turns "consumes one line" from an implementation detail of `main.go` into part of a published package contract.

## The no-progress guard (commit 5)

Replacing `bufio` also discarded its guard against readers that return `(0, nil)` forever — `bufio.Reader` gives up after 100 such reads with `io.ErrNoProgress`. Without it, `readLine` **hung**. Caught by a red test that timed out at 5s. `readLine` now bounds consecutive empty reads at the same threshold, resetting on any byte so a slow-but-progressing reader is unaffected. `io.ErrNoProgress` is not `io.EOF`, so it surfaces as an error and the folder is *not* approved.

## Notes on the move

Two deliberate deviations from a byte-for-byte move, both test-side:

- The moved prompt tests swap `coverage_test.go`'s `writerBuffer`/`readerString` helpers for `bytes.Buffer`/`strings.Reader` — those helpers have other callers in `cmd/` and stay there.
- `mustOpenStore` gains a `t.Cleanup` close instead of each test deferring it.

## Doc arithmetic

The design doc's Phase 3 entry records the honest number: 3,383 → 3,173 is **~7%** of the distance to the "few hundred lines" target, the remaining ~2,900 lines are the harder part (the inline interactive/headless/wiki flows that need the dormant `internal/modes/*` adapters), and the count moves for unrelated reasons — #329 added 17 lines to `main.go` between the two slices.

It also records the lesson both defects share: **an extraction can be behaviour-preserving mechanically while still promoting private assumptions into public contracts.** `Prompt` over-reading was harmless as a local detail of `main.go` and became a defect the moment the reader's lifetime was documented as spanning the TUI handoff. Worth budgeting for one such find per remaining slice.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `gofmt -l` — clean
- `go test ./internal/folderaccess/ -cover` — **100.0%**
- `golangci-lint` could not run here (its binary is built with go1.25 against a go1.26 target).
- Full suite at final HEAD: **no new failures.** Ten pre-existing failures in this sandbox, identical before and after this change — caused by the sandbox running as uid 0 (which defeats `chmod`-based permission-denial tests) or by tests writing to `$HOME`:

| package | count | cause |
| --- | --- | --- |
| `cmd/rubichan` | 5 | tests writing to `$HOME` under the sandbox |
| `internal/checkpoint` | 2 | `chmod 0555` spill-write-failure tests |
| `internal/config` | 2 | `chmod 0000` unreadable-config tests |
| `internal/hooks` | 1 | `chmod 0000` unreadable-hooks-file test |

None touch folder access. (An earlier revision of this description said 7 — that was a truncated count on my side, corrected here.)

## Review coverage

Both bots reviewed and their findings are addressed. CodeRabbit reviewed through commit 3 (no findings on the extraction, plus the over-read nitpick that became commit 4) and was rate-limited afterwards. Codex reviewed through commit 5 (the doc-accuracy P2 that became commit 6). Commit 6 is doc-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_