### PR TITLE
Phase 3 slice 3: extract internal/modelcheck from main.go

### DIFF
--- a/cmd/rubichan/main.go
+++ b/cmd/rubichan/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/julianshen/rubichan/internal/hooks"
 	"github.com/julianshen/rubichan/internal/integrations"
 	"github.com/julianshen/rubichan/internal/knowledgegraph"
+	"github.com/julianshen/rubichan/internal/modelcheck"
 	"github.com/julianshen/rubichan/internal/output"
 	"github.com/julianshen/rubichan/internal/parser"
 	"github.com/julianshen/rubichan/internal/permissions"
@@ -442,112 +443,7 @@ func runModelCapabilityTest() error {
 		return fmt.Errorf("creating provider: %w", err)
 	}
 
-	return executeModelCapabilityTest(context.Background(), os.Stdout, p, cfg.Provider.Default, cfg.Provider.Model)
-}
-
-func executeModelCapabilityTest(ctx context.Context, out io.Writer, p provider.LLMProvider, providerName, model string) error {
-	if p == nil {
-		return fmt.Errorf("provider is nil")
-	}
-	if strings.TrimSpace(model) == "" {
-		return fmt.Errorf("model is not configured")
-	}
-
-	caps := provider.DetectCapabilities(providerName, model)
-	fmt.Fprintf(out, "Provider: %s\nModel: %s\n", providerName, model)
-	fmt.Fprintf(out, "Capabilities: native_tool_use=%t system_prompt=%t tool_discovery_hint=%t max_tool_count=%d reasoning_effort=%q\n",
-		caps.SupportsNativeToolUse,
-		caps.SupportsSystemPrompt,
-		caps.NeedsToolDiscoveryHint,
-		caps.MaxToolCount,
-		caps.ReasoningEffort,
-	)
-
-	req := provider.CompletionRequest{
-		Model:     model,
-		Messages:  []provider.Message{provider.NewUserMessage("Reply with exactly: OK")},
-		MaxTokens: 16,
-	}
-
-	stream, err := p.Stream(ctx, req)
-	if err != nil {
-		return fmt.Errorf("model connectivity test failed: %w", err)
-	}
-
-	var sawStop bool
-	for evt := range stream {
-		switch evt.Type {
-		case "text_delta":
-			if evt.Text != "" {
-				fmt.Fprint(out, evt.Text)
-			}
-		case "stop":
-			sawStop = true
-		case "error":
-			return fmt.Errorf("model stream test failed: %w", evt.Error)
-		}
-	}
-
-	if !sawStop {
-		return fmt.Errorf("model stream ended without stop event")
-	}
-
-	if caps.SupportsNativeToolUse {
-		toolSupported, err := checkToolSupport(ctx, p, model)
-		if err != nil {
-			return err
-		}
-		if !toolSupported {
-			fmt.Fprintln(out, "Tool support: INCONCLUSIVE (no tool_use emitted during probe)")
-		} else {
-			fmt.Fprintln(out, "Tool support: PASS")
-		}
-	} else {
-		fmt.Fprintln(out, "Tool support: SKIPPED (model capability indicates no native tool use)")
-	}
-
-	fmt.Fprintln(out, "\nModel test: PASS")
-	return nil
-}
-
-func checkToolSupport(ctx context.Context, p provider.LLMProvider, model string) (bool, error) {
-	req := provider.CompletionRequest{
-		Model: model,
-		Messages: []provider.Message{provider.NewUserMessage(
-			"Call the capability_probe tool with an empty JSON object and do not output any text.",
-		)},
-		Tools: []provider.ToolDef{{
-			Name:        "capability_probe",
-			Description: "Capability probe tool for testing native tool use support",
-			InputSchema: json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`),
-		}},
-		MaxTokens: 64,
-	}
-
-	stream, err := p.Stream(ctx, req)
-	if err != nil {
-		return false, fmt.Errorf("tool support test request failed: %w", err)
-	}
-
-	var sawStop bool
-	for evt := range stream {
-		switch evt.Type {
-		case "tool_use":
-			if evt.ToolUse != nil && evt.ToolUse.Name == "capability_probe" {
-				return true, nil
-			}
-		case "error":
-			return false, fmt.Errorf("tool support stream failed: %w", evt.Error)
-		case "stop":
-			sawStop = true
-		}
-	}
-
-	if !sawStop {
-		return false, fmt.Errorf("tool support stream ended without stop event")
-	}
-
-	return false, nil
+	return modelcheck.Run(context.Background(), os.Stdout, p, cfg.Provider.Default, cfg.Provider.Model)
 }
 
 // parseSkillsFlag splits a comma-separated skills string into a slice of names.

--- a/cmd/rubichan/main_test.go
+++ b/cmd/rubichan/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -13,7 +12,6 @@ import (
 	"github.com/julianshen/rubichan/internal/agent"
 	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/persona"
-	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/internal/runner"
 	"github.com/julianshen/rubichan/internal/security"
 	"github.com/julianshen/rubichan/internal/testutil"
@@ -317,78 +315,6 @@ func TestResolveOllamaModel_MultipleModels(t *testing.T) {
 	model, err := resolveOllamaModel(srv.URL)
 	require.NoError(t, err)
 	assert.Equal(t, "llama3.2:latest", model) // returns first model
-}
-
-type capabilityTestProvider struct {
-	eventsByCall [][]provider.StreamEvent
-	errByCall    []error
-	requests     []provider.CompletionRequest
-	callCount    int
-}
-
-func (p *capabilityTestProvider) Stream(_ context.Context, req provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
-	p.requests = append(p.requests, req)
-	idx := p.callCount
-	p.callCount++
-	if idx < len(p.errByCall) && p.errByCall[idx] != nil {
-		return nil, p.errByCall[idx]
-	}
-	var events []provider.StreamEvent
-	if idx < len(p.eventsByCall) {
-		events = p.eventsByCall[idx]
-	}
-	ch := make(chan provider.StreamEvent, len(events))
-	for _, evt := range events {
-		ch <- evt
-	}
-	close(ch)
-	return ch, nil
-}
-
-func TestExecuteModelCapabilityTest_Success(t *testing.T) {
-	p := &capabilityTestProvider{eventsByCall: [][]provider.StreamEvent{
-		{{Type: "text_delta", Text: "OK"}, {Type: "stop"}},
-		{{Type: "tool_use", ToolUse: &provider.ToolUseBlock{Name: "capability_probe", Input: []byte(`{}`)}}, {Type: "stop"}},
-	}}
-	var out bytes.Buffer
-
-	err := executeModelCapabilityTest(context.Background(), &out, p, "openai", "gpt-4o")
-	require.NoError(t, err)
-	require.Len(t, p.requests, 2)
-	assert.Equal(t, "gpt-4o", p.requests[0].Model)
-	assert.Equal(t, "capability_probe", p.requests[1].Tools[0].Name)
-	assert.Contains(t, out.String(), "Provider: openai")
-	assert.Contains(t, out.String(), "Capabilities:")
-	assert.Contains(t, out.String(), "Tool support: PASS")
-	assert.Contains(t, out.String(), "Model test: PASS")
-}
-
-func TestExecuteModelCapabilityTest_MissingModel(t *testing.T) {
-	var out bytes.Buffer
-	err := executeModelCapabilityTest(context.Background(), &out, &capabilityTestProvider{}, "openai", "")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "model is not configured")
-}
-
-func TestExecuteModelCapabilityTest_StreamErrorEvent(t *testing.T) {
-	p := &capabilityTestProvider{eventsByCall: [][]provider.StreamEvent{{{Type: "error", Error: fmt.Errorf("boom")}}}}
-	var out bytes.Buffer
-
-	err := executeModelCapabilityTest(context.Background(), &out, p, "openai", "gpt-4o")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "model stream test failed")
-}
-
-func TestExecuteModelCapabilityTest_ToolSupportMissing(t *testing.T) {
-	p := &capabilityTestProvider{eventsByCall: [][]provider.StreamEvent{
-		{{Type: "text_delta", Text: "OK"}, {Type: "stop"}},
-		{{Type: "stop"}},
-	}}
-	var out bytes.Buffer
-
-	err := executeModelCapabilityTest(context.Background(), &out, p, "openai", "gpt-4o")
-	require.NoError(t, err)
-	assert.Contains(t, out.String(), "Tool support: INCONCLUSIVE")
 }
 
 func TestResolveOllamaModel_ConnectionError(t *testing.T) {

--- a/docs/MODULAR_CORE_REDESIGN.md
+++ b/docs/MODULAR_CORE_REDESIGN.md
@@ -182,14 +182,15 @@ For each subsystem, introduce the right seam interface and move it behind it, re
 **Phase 3 — Adapters over the core.**
 Reduce `cmd/rubichan/main.go` to composition only: build core, register modules, pick an adapter. Move mode wiring into `internal/modes/*` (or `pkg` for reusable ones). Target: `main.go` under a few hundred lines.
 
-> **Status update (2026-07): Phase 3 started — two slices out, both extractions of things that were never composition.**
+> **Status update (2026-07): Phase 3 started — three slices out, all extractions of things that were never composition.**
 >
 > The phase is being taken as a sequence of named clusters rather than one move, since main.go's contents are not homogeneous: some of it is genuinely composition (build a registry, pick a provider) and belongs where it is; the rest is subsystems that happen to be spelled inline.
 >
 > - **Slice 1 — `internal/diag`.** Process-level diagnostics: the session log, the JSONL event log, the stack dumps written on signal or panic (20 tests moved with it). File layout, permissions and log-writer swapping are not main's business.
 > - **Slice 2 — `internal/folderaccess`.** The working-directory approval gate: prompt, interactive path, headless path. Whether an unapproved folder is a question or an error, and what `--approve-cwd`/`--auto-approve` mean, is product policy the entrypoint should call rather than contain. Its persistence dependency is a two-method `Store` interface declared in the package, so the policy does not import the persistence layer to state its own rules.
+> - **Slice 3 — `internal/modelcheck`.** The `--test` flag's probes: report the capabilities rubichan believes a model has, then check the belief against the live endpoint with one completion and one tool call. What counts as a working model is product behaviour. This slice also shows where the phase's boundary actually falls — `runModelCapabilityTest` stayed in main.go, because loading config and building a provider *is* composition; only the probing moved, taking both as arguments.
 >
-> **Measured: 3,383 → 3,173 lines.** That is 210 lines across two slices, against a target of "a few hundred" — i.e. roughly 7% of the distance, and the remaining ~2,900 lines are the harder part (the inline interactive/headless/wiki flows identified in Problem C, which need the dormant `internal/modes/*` adapters to become the real path). The line count also moves independently of this work: #329's Ollama fix added 17 lines to main.go between the two slices. Treat the number as a direction of travel, not a burn-down.
+> **Measured: 3,383 → 3,069 lines.** That is 314 lines across three slices, against a target of "a few hundred" — i.e. roughly 11% of the distance, and the remaining ~2,800 lines are the harder part (the inline interactive/headless/wiki flows identified in Problem C, which need the dormant `internal/modes/*` adapters to become the real path). The line count also moves independently of this work: #329's Ollama fix added 17 lines to main.go between slices 1 and 2. Treat the number as a direction of travel, not a burn-down.
 >
 > **Slice 1 was a pure `[STRUCTURAL]` move** — bodies verbatim, tests moved with them, before-and-after test runs identical, which is what makes that shape cheap to review and safe to land alongside unrelated work in the same file.
 >
@@ -199,6 +200,8 @@ Reduce `cmd/rubichan/main.go` to composition only: build core, register modules,
 > - Replacing `bufio` then dropped its guard against readers that return `(0, nil)` forever, turning a prompt that errors into a prompt that hangs. Restored with the same 100-read threshold.
 >
 > Both went in as separate `[BEHAVIORAL]` commits after the structural one, per Tidy-First. The general lesson for the remaining slices: **an extraction is behaviour-preserving in the mechanical sense while still promoting private assumptions into public contracts.** Expect to find and fix a defect per slice, and expect the fix to be a separate commit rather than a reason to make the move impure.
+>
+> **Slice 3 was a clean move, and what it surfaced was dead code rather than a defect.** `Run`'s "Tool support: SKIPPED" branch is unreachable: `agentsdk.DefaultCapabilities` enables native tool use and no provider profile disables it, so `DetectCapabilities` returns true for every provider/model pair. The branch is kept — the capability is a real field the agent consults elsewhere — but it is now commented as untested for that reason rather than left looking like an oversight. Worth noting as a second thing extraction does reliably: **moving code into a package where its coverage is measured in isolation exposes which branches production never takes.** In main.go, at 3,000 lines, that signal was invisible.
 
 **Phase 4 — Publish the module API.**
 Document the ~7 seams in `pkg/…` with examples (`examples/` already exists). External apps now embed the **real** core and opt into exactly the modules they want (e.g. a NATS bridge with tools + checkpoint but no TUI).

--- a/internal/modelcheck/modelcheck.go
+++ b/internal/modelcheck/modelcheck.go
@@ -86,6 +86,12 @@ func Run(ctx context.Context, out io.Writer, p provider.LLMProvider, providerNam
 			fmt.Fprintln(out, "Tool support: PASS")
 		}
 	} else {
+		// Unreachable through provider.DetectCapabilities as it stands:
+		// agentsdk.DefaultCapabilities enables native tool use and no
+		// profile disables it, so every provider/model pair reports true.
+		// Kept because the capability is a real field the agent consults
+		// elsewhere — if a profile ever turns it off, this is the honest
+		// report — but it is untested for that reason.
 		fmt.Fprintln(out, "Tool support: SKIPPED (model capability indicates no native tool use)")
 	}
 

--- a/internal/modelcheck/modelcheck.go
+++ b/internal/modelcheck/modelcheck.go
@@ -46,6 +46,37 @@ func Run(ctx context.Context, out io.Writer, p provider.LLMProvider, providerNam
 		caps.ReasoningEffort,
 	)
 
+	if err := probeConnectivity(ctx, out, p, model); err != nil {
+		return err
+	}
+
+	if caps.SupportsNativeToolUse {
+		toolSupported, err := probeToolSupport(ctx, p, model)
+		if err != nil {
+			return err
+		}
+		if !toolSupported {
+			fmt.Fprintln(out, "Tool support: INCONCLUSIVE (no tool_use emitted during probe)")
+		} else {
+			fmt.Fprintln(out, "Tool support: PASS")
+		}
+	} else {
+		// Unreachable through provider.DetectCapabilities as it stands:
+		// agentsdk.DefaultCapabilities enables native tool use and no
+		// profile disables it, so every provider/model pair reports true.
+		// Kept because the capability is a real field the agent consults
+		// elsewhere — if a profile ever turns it off, this is the honest
+		// report — but it is untested for that reason.
+		fmt.Fprintln(out, "Tool support: SKIPPED (model capability indicates no native tool use)")
+	}
+
+	fmt.Fprintln(out, "\nModel test: PASS")
+	return nil
+}
+
+// probeConnectivity asks for a one-word reply and echoes whatever comes back,
+// proving the endpoint is reachable and that streaming works end to end.
+func probeConnectivity(ctx context.Context, out io.Writer, p provider.LLMProvider, model string) error {
 	req := provider.CompletionRequest{
 		Model:     model,
 		Messages:  []provider.Message{provider.NewUserMessage("Reply with exactly: OK")},
@@ -75,27 +106,6 @@ func Run(ctx context.Context, out io.Writer, p provider.LLMProvider, providerNam
 		return fmt.Errorf("model stream ended without stop event")
 	}
 
-	if caps.SupportsNativeToolUse {
-		toolSupported, err := probeToolSupport(ctx, p, model)
-		if err != nil {
-			return err
-		}
-		if !toolSupported {
-			fmt.Fprintln(out, "Tool support: INCONCLUSIVE (no tool_use emitted during probe)")
-		} else {
-			fmt.Fprintln(out, "Tool support: PASS")
-		}
-	} else {
-		// Unreachable through provider.DetectCapabilities as it stands:
-		// agentsdk.DefaultCapabilities enables native tool use and no
-		// profile disables it, so every provider/model pair reports true.
-		// Kept because the capability is a real field the agent consults
-		// elsewhere — if a profile ever turns it off, this is the honest
-		// report — but it is untested for that reason.
-		fmt.Fprintln(out, "Tool support: SKIPPED (model capability indicates no native tool use)")
-	}
-
-	fmt.Fprintln(out, "\nModel test: PASS")
 	return nil
 }
 

--- a/internal/modelcheck/modelcheck.go
+++ b/internal/modelcheck/modelcheck.go
@@ -120,12 +120,20 @@ func probeToolSupport(ctx context.Context, p provider.LLMProvider, model string)
 		return false, fmt.Errorf("tool support test request failed: %w", err)
 	}
 
-	var sawStop bool
+	var sawStop, calledProbe bool
 	for evt := range stream {
 		switch evt.Type {
 		case "tool_use":
+			// Recorded rather than returned on: the stream has to be
+			// consumed to the end either way. Providers send with
+			// `select { case ch <- evt: case <-ctx.Done(): }`, and this
+			// probe's context is not cancelled on the way out, so
+			// abandoning the channel would strand the producer goroutine
+			// and its connection. Returning early also hid whatever the
+			// model did next — Ollama emits tool calls and then reports a
+			// missing done signal when the connection drops.
 			if evt.ToolUse != nil && evt.ToolUse.Name == probeToolName {
-				return true, nil
+				calledProbe = true
 			}
 		case "error":
 			return false, fmt.Errorf("tool support stream failed: %w", evt.Error)
@@ -134,9 +142,12 @@ func probeToolSupport(ctx context.Context, p provider.LLMProvider, model string)
 		}
 	}
 
+	// A clean stop is required even when the probe was called, matching how
+	// Run treats the connectivity probe: a stream that never finished has not
+	// demonstrated anything, whatever it managed to emit first.
 	if !sawStop {
 		return false, fmt.Errorf("tool support stream ended without stop event")
 	}
 
-	return false, nil
+	return calledProbe, nil
 }

--- a/internal/modelcheck/modelcheck.go
+++ b/internal/modelcheck/modelcheck.go
@@ -83,6 +83,16 @@ func probeConnectivity(ctx context.Context, out io.Writer, p provider.LLMProvide
 		MaxTokens: 16,
 	}
 
+	// The probe owns its context so that returning early — on an error
+	// event, or on any path added later — releases the producer. Providers
+	// send with `select { case ch <- evt: case <-ctx.Done(): }` and an error
+	// event is not the end of the stream: the Ollama and SSE-compatible
+	// parsers both emit a parse error and keep scanning. Without this,
+	// abandoning the channel parked that goroutine and its connection for
+	// the life of the process, since Run is handed context.Background().
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	stream, err := p.Stream(ctx, req)
 	if err != nil {
 		return fmt.Errorf("model connectivity test failed: %w", err)
@@ -124,6 +134,10 @@ func probeToolSupport(ctx context.Context, p provider.LLMProvider, model string)
 		}},
 		MaxTokens: 64,
 	}
+
+	// Owned context, for the same reason as probeConnectivity.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	stream, err := p.Stream(ctx, req)
 	if err != nil {

--- a/internal/modelcheck/modelcheck.go
+++ b/internal/modelcheck/modelcheck.go
@@ -1,0 +1,136 @@
+// Package modelcheck answers "is this provider and model actually usable?"
+// for the CLI's --test flag. It reports the capabilities rubichan believes a
+// model has, then verifies the belief against the live endpoint: one
+// completion to prove connectivity and streaming, and — when the model is
+// expected to support them — one tool call to prove native tool use.
+//
+// The probes live here rather than in cmd/ because what counts as a working
+// model is product behaviour. Composition stays with the caller: it loads
+// config and builds the provider, then hands both to Run.
+package modelcheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/julianshen/rubichan/internal/provider"
+)
+
+// probeToolName is the tool offered during the tool-use probe. Nothing
+// executes it — emitting the call is the whole signal.
+const probeToolName = "capability_probe"
+
+// Run reports model capabilities to out and probes the endpoint to confirm
+// them. It returns an error when the model cannot be reached, when the stream
+// ends without a stop event, or when a probe fails outright. A model that
+// simply declines to call the probe tool is reported as inconclusive rather
+// than failed: the model answered, it just did not take the bait.
+func Run(ctx context.Context, out io.Writer, p provider.LLMProvider, providerName, model string) error {
+	if p == nil {
+		return fmt.Errorf("provider is nil")
+	}
+	if strings.TrimSpace(model) == "" {
+		return fmt.Errorf("model is not configured")
+	}
+
+	caps := provider.DetectCapabilities(providerName, model)
+	fmt.Fprintf(out, "Provider: %s\nModel: %s\n", providerName, model)
+	fmt.Fprintf(out, "Capabilities: native_tool_use=%t system_prompt=%t tool_discovery_hint=%t max_tool_count=%d reasoning_effort=%q\n",
+		caps.SupportsNativeToolUse,
+		caps.SupportsSystemPrompt,
+		caps.NeedsToolDiscoveryHint,
+		caps.MaxToolCount,
+		caps.ReasoningEffort,
+	)
+
+	req := provider.CompletionRequest{
+		Model:     model,
+		Messages:  []provider.Message{provider.NewUserMessage("Reply with exactly: OK")},
+		MaxTokens: 16,
+	}
+
+	stream, err := p.Stream(ctx, req)
+	if err != nil {
+		return fmt.Errorf("model connectivity test failed: %w", err)
+	}
+
+	var sawStop bool
+	for evt := range stream {
+		switch evt.Type {
+		case "text_delta":
+			if evt.Text != "" {
+				fmt.Fprint(out, evt.Text)
+			}
+		case "stop":
+			sawStop = true
+		case "error":
+			return fmt.Errorf("model stream test failed: %w", evt.Error)
+		}
+	}
+
+	if !sawStop {
+		return fmt.Errorf("model stream ended without stop event")
+	}
+
+	if caps.SupportsNativeToolUse {
+		toolSupported, err := probeToolSupport(ctx, p, model)
+		if err != nil {
+			return err
+		}
+		if !toolSupported {
+			fmt.Fprintln(out, "Tool support: INCONCLUSIVE (no tool_use emitted during probe)")
+		} else {
+			fmt.Fprintln(out, "Tool support: PASS")
+		}
+	} else {
+		fmt.Fprintln(out, "Tool support: SKIPPED (model capability indicates no native tool use)")
+	}
+
+	fmt.Fprintln(out, "\nModel test: PASS")
+	return nil
+}
+
+// probeToolSupport asks the model to call one trivial tool and reports whether
+// it did. A false return is not a failure — see Run.
+func probeToolSupport(ctx context.Context, p provider.LLMProvider, model string) (bool, error) {
+	req := provider.CompletionRequest{
+		Model: model,
+		Messages: []provider.Message{provider.NewUserMessage(
+			"Call the " + probeToolName + " tool with an empty JSON object and do not output any text.",
+		)},
+		Tools: []provider.ToolDef{{
+			Name:        probeToolName,
+			Description: "Capability probe tool for testing native tool use support",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`),
+		}},
+		MaxTokens: 64,
+	}
+
+	stream, err := p.Stream(ctx, req)
+	if err != nil {
+		return false, fmt.Errorf("tool support test request failed: %w", err)
+	}
+
+	var sawStop bool
+	for evt := range stream {
+		switch evt.Type {
+		case "tool_use":
+			if evt.ToolUse != nil && evt.ToolUse.Name == probeToolName {
+				return true, nil
+			}
+		case "error":
+			return false, fmt.Errorf("tool support stream failed: %w", evt.Error)
+		case "stop":
+			sawStop = true
+		}
+	}
+
+	if !sawStop {
+		return false, fmt.Errorf("tool support stream ended without stop event")
+	}
+
+	return false, nil
+}

--- a/internal/modelcheck/modelcheck_test.go
+++ b/internal/modelcheck/modelcheck_test.go
@@ -86,3 +86,112 @@ func TestRunToolSupportMissing(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, out.String(), "Tool support: INCONCLUSIVE")
 }
+
+func TestRunRejectsNilProvider(t *testing.T) {
+	var out bytes.Buffer
+	err := modelcheck.Run(context.Background(), &out, nil, "openai", "gpt-4o")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider is nil")
+	assert.Empty(t, out.String(), "nothing should be reported about a provider that does not exist")
+}
+
+func TestRunReportsConnectivityFailure(t *testing.T) {
+	p := &fakeProvider{errByCall: []error{fmt.Errorf("dial tcp: refused")}}
+	var out bytes.Buffer
+
+	err := modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "model connectivity test failed")
+	assert.Contains(t, err.Error(), "dial tcp: refused", "the transport's reason is what makes this actionable")
+}
+
+// TestRunRequiresAStopEvent covers a stream that ends without stopping — a
+// truncated or half-closed response. It has to fail: a model that never
+// finished a sixteen-token reply has not demonstrated it works.
+func TestRunRequiresAStopEvent(t *testing.T) {
+	p := &fakeProvider{eventsByCall: [][]provider.StreamEvent{
+		{{Type: "text_delta", Text: "OK"}},
+	}}
+	var out bytes.Buffer
+
+	err := modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "model stream ended without stop event")
+	assert.NotContains(t, out.String(), "Model test: PASS")
+}
+
+func TestRunReportsToolProbeRequestFailure(t *testing.T) {
+	p := &fakeProvider{
+		eventsByCall: [][]provider.StreamEvent{{{Type: "stop"}}},
+		errByCall:    []error{nil, fmt.Errorf("429 rate limited")},
+	}
+	var out bytes.Buffer
+
+	err := modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tool support test request failed")
+	assert.Contains(t, err.Error(), "429 rate limited")
+}
+
+func TestRunReportsToolProbeStreamError(t *testing.T) {
+	p := &fakeProvider{eventsByCall: [][]provider.StreamEvent{
+		{{Type: "stop"}},
+		{{Type: "error", Error: fmt.Errorf("tools unsupported")}},
+	}}
+	var out bytes.Buffer
+
+	err := modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tool support stream failed")
+}
+
+// TestRunRequiresAStopEventFromTheToolProbe distinguishes a model that
+// declined the probe from one whose stream died mid-probe. The first is
+// inconclusive; the second is an error, because nothing was learned.
+func TestRunRequiresAStopEventFromTheToolProbe(t *testing.T) {
+	p := &fakeProvider{eventsByCall: [][]provider.StreamEvent{
+		{{Type: "stop"}},
+		{{Type: "text_delta", Text: "thinking"}},
+	}}
+	var out bytes.Buffer
+
+	err := modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tool support stream ended without stop event")
+	assert.NotContains(t, out.String(), "INCONCLUSIVE",
+		"a dead stream must not be reported as the model declining the probe")
+}
+
+// TestRunProbeOffersExactlyOneTool pins the probe's shape. A probe that
+// offered several tools, or a schema the model could not satisfy, would
+// measure the prompt rather than the capability.
+func TestRunProbeOffersExactlyOneTool(t *testing.T) {
+	p := &fakeProvider{eventsByCall: [][]provider.StreamEvent{
+		{{Type: "stop"}},
+		{{Type: "tool_use", ToolUse: &provider.ToolUseBlock{Name: "capability_probe"}}, {Type: "stop"}},
+	}}
+	var out bytes.Buffer
+
+	require.NoError(t, modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o"))
+	require.Len(t, p.requests, 2)
+	probe := p.requests[1]
+	require.Len(t, probe.Tools, 1)
+	assert.Equal(t, "capability_probe", probe.Tools[0].Name)
+	assert.JSONEq(t, `{"type":"object","properties":{},"additionalProperties":false}`,
+		string(probe.Tools[0].InputSchema))
+	assert.Contains(t, probe.Messages[0].Content[0].Text, "capability_probe",
+		"the prompt must name the tool it offers")
+}
+
+// TestRunIgnoresAnUnrelatedToolCall guards the name comparison: a model that
+// invents its own tool has not demonstrated it can call the one it was given.
+func TestRunIgnoresAnUnrelatedToolCall(t *testing.T) {
+	p := &fakeProvider{eventsByCall: [][]provider.StreamEvent{
+		{{Type: "stop"}},
+		{{Type: "tool_use", ToolUse: &provider.ToolUseBlock{Name: "something_else"}}, {Type: "stop"}},
+	}}
+	var out bytes.Buffer
+
+	require.NoError(t, modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o"))
+	assert.Contains(t, out.String(), "Tool support: INCONCLUSIVE")
+}

--- a/internal/modelcheck/modelcheck_test.go
+++ b/internal/modelcheck/modelcheck_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/julianshen/rubichan/internal/modelcheck"
 	"github.com/julianshen/rubichan/internal/provider"
@@ -263,4 +264,94 @@ func TestRunDrainsTheToolProbeStream(t *testing.T) {
 	require.NoError(t, modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o"))
 	assert.Contains(t, out.String(), "Tool support: PASS")
 	assert.Equal(t, 0, p.undrained(), "every event offered must be consumed")
+}
+
+// blockingProvider mimics how real providers emit: a goroutine sending on an
+// unbuffered channel with `select { case ch <- evt: case <-ctx.Done(): }`, as
+// internal/provider/ollama and internal/provider/ssecompat both do. A consumer
+// that stops reading strands that goroutine until the context is cancelled,
+// which a fake with a buffered, pre-closed channel can never reveal.
+type blockingProvider struct {
+	eventsByCall [][]provider.StreamEvent
+	callCount    int
+	exited       chan struct{}
+}
+
+func newBlockingProvider(eventsByCall [][]provider.StreamEvent) *blockingProvider {
+	return &blockingProvider{eventsByCall: eventsByCall, exited: make(chan struct{}, 8)}
+}
+
+func (p *blockingProvider) Stream(ctx context.Context, _ provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
+	idx := p.callCount
+	p.callCount++
+	var events []provider.StreamEvent
+	if idx < len(p.eventsByCall) {
+		events = p.eventsByCall[idx]
+	}
+
+	ch := make(chan provider.StreamEvent)
+	go func() {
+		defer func() { p.exited <- struct{}{} }()
+		defer close(ch)
+		for _, evt := range events {
+			select {
+			case ch <- evt:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return ch, nil
+}
+
+// awaitProducerExit fails if the producer goroutine is still parked on a send.
+func (p *blockingProvider) awaitProducerExit(t *testing.T) {
+	t.Helper()
+	for i := 0; i < p.callCount; i++ {
+		select {
+		case <-p.exited:
+		case <-time.After(2 * time.Second):
+			t.Fatal("provider goroutine still blocked on send — the stream was abandoned without cancelling its context")
+		}
+	}
+}
+
+// TestRunReleasesTheProducerAfterAConnectivityError covers an error event that
+// is not the end of the stream. Both the Ollama and SSE-compatible parsers
+// emit a parse error and keep scanning, so returning on the error leaves the
+// producer holding a connection with no one reading.
+func TestRunReleasesTheProducerAfterAConnectivityError(t *testing.T) {
+	p := newBlockingProvider([][]provider.StreamEvent{
+		{
+			{Type: "error", Error: fmt.Errorf("parsing chunk: unexpected token")},
+			{Type: "text_delta", Text: "more output nobody is reading"},
+			{Type: "stop"},
+		},
+	})
+	var out bytes.Buffer
+
+	err := modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "model stream test failed")
+	p.awaitProducerExit(t)
+}
+
+// TestRunReleasesTheProducerAfterAToolProbeError is the same hazard on the
+// second probe, which is where review first spotted it.
+func TestRunReleasesTheProducerAfterAToolProbeError(t *testing.T) {
+	p := newBlockingProvider([][]provider.StreamEvent{
+		{{Type: "stop"}},
+		{
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{Name: "capability_probe"}},
+			{Type: "error", Error: fmt.Errorf("parsing chunk: unexpected token")},
+			{Type: "text_delta", Text: "still going"},
+			{Type: "stop"},
+		},
+	})
+	var out bytes.Buffer
+
+	err := modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tool support stream failed")
+	p.awaitProducerExit(t)
 }

--- a/internal/modelcheck/modelcheck_test.go
+++ b/internal/modelcheck/modelcheck_test.go
@@ -19,6 +19,7 @@ type fakeProvider struct {
 	eventsByCall [][]provider.StreamEvent
 	errByCall    []error
 	requests     []provider.CompletionRequest
+	streams      []chan provider.StreamEvent
 	callCount    int
 }
 
@@ -38,7 +39,19 @@ func (p *fakeProvider) Stream(_ context.Context, req provider.CompletionRequest)
 		ch <- evt
 	}
 	close(ch)
+	p.streams = append(p.streams, ch)
 	return ch, nil
+}
+
+// undrained reports how many events are still sitting in the streams handed
+// out. A real provider blocks on send until its context is cancelled, so
+// anything left here would be a stranded producer in production.
+func (p *fakeProvider) undrained() int {
+	n := 0
+	for _, ch := range p.streams {
+		n += len(ch)
+	}
+	return n
 }
 
 func TestRunSuccess(t *testing.T) {
@@ -194,4 +207,60 @@ func TestRunIgnoresAnUnrelatedToolCall(t *testing.T) {
 
 	require.NoError(t, modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o"))
 	assert.Contains(t, out.String(), "Tool support: INCONCLUSIVE")
+}
+
+// TestRunFailsOnErrorAfterToolUse covers a stream that demonstrates the
+// capability and then falls over. Ollama does exactly this: it emits tool
+// calls and, if the connection drops before the done chunk, reports "stream
+// ended without done signal". A diagnostic that watched a probe fail and
+// printed PASS is worse than useless.
+func TestRunFailsOnErrorAfterToolUse(t *testing.T) {
+	p := &fakeProvider{eventsByCall: [][]provider.StreamEvent{
+		{{Type: "stop"}},
+		{
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{Name: "capability_probe"}},
+			{Type: "error", Error: fmt.Errorf("stream ended without done signal")},
+		},
+	}}
+	var out bytes.Buffer
+
+	err := modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tool support stream failed")
+	assert.NotContains(t, out.String(), "Model test: PASS")
+}
+
+// TestRunFailsOnMissingStopAfterToolUse holds the two probes to the same
+// standard: Run already fails the connectivity probe when its stream ends
+// without a stop, so the tool probe cannot quietly accept one.
+func TestRunFailsOnMissingStopAfterToolUse(t *testing.T) {
+	p := &fakeProvider{eventsByCall: [][]provider.StreamEvent{
+		{{Type: "stop"}},
+		{{Type: "tool_use", ToolUse: &provider.ToolUseBlock{Name: "capability_probe"}}},
+	}}
+	var out bytes.Buffer
+
+	err := modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tool support stream ended without stop event")
+}
+
+// TestRunDrainsTheToolProbeStream pins that the probe consumes its stream to
+// completion. Providers send with `select { case ch <- evt: case <-ctx.Done() }`
+// and Run is handed a context that never cancels, so a probe that returned
+// early would strand the producer goroutine and its connection.
+func TestRunDrainsTheToolProbeStream(t *testing.T) {
+	p := &fakeProvider{eventsByCall: [][]provider.StreamEvent{
+		{{Type: "stop"}},
+		{
+			{Type: "tool_use", ToolUse: &provider.ToolUseBlock{Name: "capability_probe"}},
+			{Type: "text_delta", Text: "trailing"},
+			{Type: "stop"},
+		},
+	}}
+	var out bytes.Buffer
+
+	require.NoError(t, modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o"))
+	assert.Contains(t, out.String(), "Tool support: PASS")
+	assert.Equal(t, 0, p.undrained(), "every event offered must be consumed")
 }

--- a/internal/modelcheck/modelcheck_test.go
+++ b/internal/modelcheck/modelcheck_test.go
@@ -1,0 +1,88 @@
+package modelcheck_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/modelcheck"
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeProvider scripts one stream per call so a test can drive the
+// connectivity probe and the tool probe independently, and records the
+// requests so the probes' shape can be asserted.
+type fakeProvider struct {
+	eventsByCall [][]provider.StreamEvent
+	errByCall    []error
+	requests     []provider.CompletionRequest
+	callCount    int
+}
+
+func (p *fakeProvider) Stream(_ context.Context, req provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
+	p.requests = append(p.requests, req)
+	idx := p.callCount
+	p.callCount++
+	if idx < len(p.errByCall) && p.errByCall[idx] != nil {
+		return nil, p.errByCall[idx]
+	}
+	var events []provider.StreamEvent
+	if idx < len(p.eventsByCall) {
+		events = p.eventsByCall[idx]
+	}
+	ch := make(chan provider.StreamEvent, len(events))
+	for _, evt := range events {
+		ch <- evt
+	}
+	close(ch)
+	return ch, nil
+}
+
+func TestRunSuccess(t *testing.T) {
+	p := &fakeProvider{eventsByCall: [][]provider.StreamEvent{
+		{{Type: "text_delta", Text: "OK"}, {Type: "stop"}},
+		{{Type: "tool_use", ToolUse: &provider.ToolUseBlock{Name: "capability_probe", Input: []byte(`{}`)}}, {Type: "stop"}},
+	}}
+	var out bytes.Buffer
+
+	err := modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o")
+	require.NoError(t, err)
+	require.Len(t, p.requests, 2)
+	assert.Equal(t, "gpt-4o", p.requests[0].Model)
+	assert.Equal(t, "capability_probe", p.requests[1].Tools[0].Name)
+	assert.Contains(t, out.String(), "Provider: openai")
+	assert.Contains(t, out.String(), "Capabilities:")
+	assert.Contains(t, out.String(), "Tool support: PASS")
+	assert.Contains(t, out.String(), "Model test: PASS")
+}
+
+func TestRunMissingModel(t *testing.T) {
+	var out bytes.Buffer
+	err := modelcheck.Run(context.Background(), &out, &fakeProvider{}, "openai", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "model is not configured")
+}
+
+func TestRunStreamErrorEvent(t *testing.T) {
+	p := &fakeProvider{eventsByCall: [][]provider.StreamEvent{{{Type: "error", Error: fmt.Errorf("boom")}}}}
+	var out bytes.Buffer
+
+	err := modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "model stream test failed")
+}
+
+func TestRunToolSupportMissing(t *testing.T) {
+	p := &fakeProvider{eventsByCall: [][]provider.StreamEvent{
+		{{Type: "text_delta", Text: "OK"}, {Type: "stop"}},
+		{{Type: "stop"}},
+	}}
+	var out bytes.Buffer
+
+	err := modelcheck.Run(context.Background(), &out, p, "openai", "gpt-4o")
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Tool support: INCONCLUSIVE")
+}


### PR DESCRIPTION
## What

Third slice of the modular-core redesign's **Phase 3** ("reduce `main.go` to composition only"), after `internal/diag` (#331) and `internal/folderaccess` (#333).

The `--test` flag's model-capability probes move to a new `internal/modelcheck`:

| was | is |
| --- | --- |
| `executeModelCapabilityTest` | `modelcheck.Run` |
| `checkToolSupport` | `modelcheck.probeToolSupport` (now private) |
| *(extracted from `Run` during review)* | `modelcheck.probeConnectivity` |

## Why, and where the boundary falls

What counts as a *working model* — report the capabilities rubichan believes it has, then check the belief against the live endpoint with one completion and one tool call — is product behaviour, not composition.

This slice shows where Phase 3's boundary actually sits. **`runModelCapabilityTest` stayed in `main.go`**, because loading config and building a provider *is* composition. Only the probing moved, taking both as arguments. Two of three functions, not three: the phase is about relocating what was never composition, not emptying the file. Both reviewers confirmed this boundary.

## Commits

| # | commit | what |
| --- | --- | --- |
| 1 | `[STRUCTURAL]` Move Method | Bodies and their four tests moved. One behaviour-identical refactoring rides along — **Extract Constant** for the probe tool's name, which appeared three times (prompt, `ToolDef`, event comparison); the concatenated prompt string is byte-identical to the literal it replaces. `main.go`: 3,173 → 3,069 lines. |
| 2 | `[BEHAVIORAL]` | Error-path tests. Coverage 81.8% → 97.7%. |
| 3 | `[STRUCTURAL]` | Comment why the one remaining uncovered branch is unreachable. |
| 4 | `[STRUCTURAL]` Doc | Record the slice. |
| 5 | `[BEHAVIORAL]` | Drain the tool probe; stop trusting a truncated stream. *(CodeRabbit)* |
| 6 | `[STRUCTURAL]` Extract Method | `probeConnectivity` out of `Run`, giving each probe its own scope. |
| 7 | `[BEHAVIORAL]` | Owned cancellable context per probe, so early returns release the producer. *(Codex)* |

Tidy-First throughout: no commit mixes structural and behavioral change.

## Three defects, all pre-existing, all surfaced by the extraction

**1 — The tool probe reported PASS on a failed stream.** `probeToolSupport` returned on the first matching `tool_use`, so a stream that emitted the tool call and then errored printed `Tool support: PASS` / `Model test: PASS`. Real sequence: `internal/provider/ollama/provider.go:380` emits the tool call, `:426` emits `stream ended without done signal` when the connection drops. Now the observation is recorded, the stream consumed, and a clean stop required before success — matching how the connectivity probe already behaved.

**2 — Abandoned streams stranded their producers.** The early return above also stopped reading the channel. Providers send with `select { case ch <- evt: case <-ctx.Done(): }`, and `Run` receives `context.Background()` from `runModelCapabilityTest`, so the producer goroutine and its connection parked until process exit.

**3 — Draining didn't cover the error path.** `case "error": return` still abandoned the channel, and an error event is *not* terminal: the Ollama parser (`:362-367`) and the SSE-compatible parser (`ssecompat/processor.go:161-167`) both emit a parse error and keep scanning. The same early return existed in `Run`'s connectivity loop, which review had not flagged.

Fixed by giving each probe an owned cancellable context with `defer cancel()`, rather than draining on error — draining-on-error is unbounded, whereas the cancel releases the producer on every exit path including ones added later.

## What the extraction surfaced besides defects

`Run`'s `Tool support: SKIPPED` branch is **unreachable**: `agentsdk.DefaultCapabilities()` enables native tool use and no provider profile disables it, so `provider.DetectCapabilities` returns `true` for every provider/model pair — verified by probing it directly across `anthropic`/`ollama`/`openai` and several model IDs including unknown ones. The branch is kept (`SupportsNativeToolUse` is a real field the agent consults elsewhere) but commented as untested, so it doesn't read as an oversight.

Two mechanisms now recorded in the design doc:
- **Extraction promotes private assumptions into public contracts** (slice 2's lesson, and defects 1–3 here).
- **Measuring a package's coverage in isolation exposes branches production never takes.** At 3,000 lines in `main.go`, that signal was invisible.

## A testing lesson worth keeping

The original fake couldn't have caught defects 2 or 3: buffered channel, pre-closed, so abandoning it costs nothing. The new `blockingProvider` sends on an *unbuffered* channel with `select { case ch <- evt: case <-ctx.Done(): }`, mirroring the real providers, and asserts the goroutine exits. Both tests failed with `provider goroutine still blocked on send` before the fix. **A fake that can't strand can't demonstrate stranding.**

## Verification

- `go build ./...`, `go vet ./...` — clean
- `gofmt -l` — clean
- `go test ./internal/modelcheck/ -cover` — **98.0%**; the single uncovered statement is the unreachable branch above
- `golangci-lint` could not run here (its binary is built with go1.25 against a go1.26 target)
- Full suite: **no new failures.** The same ten pre-existing failures as #333, all from this sandbox running as uid 0 (defeating `chmod`-based permission-denial tests) or from tests writing to `$HOME`: `cmd/rubichan` 5, `internal/checkpoint` 2, `internal/config` 2, `internal/hooks` 1. None touch model checking.

## Review coverage

CodeRabbit reviewed through commit 4 and found defect 1; Codex reviewed through commit 5 and found defect 3. Codex's earlier pass on commit 4 returned clean on the commit containing defect 1, and CodeRabbit's suggested fix for defect 1 did not close defect 3 — recorded so the review history is accurate about what each pass caught. Commits 6 and 7 are unreviewed by either bot (CodeRabbit rate-limited).

## Phase 3 progress

**3,383 → 3,069 lines**, ~11% of the distance to the "few hundred" target. The remaining ~2,800 lines are the harder part — the inline interactive/headless/wiki flows that need the dormant `internal/modes/*` adapters to become the real path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_