### PR TITLE
Fix ProviderDef.DefaultModel's doc comment

### DIFF
--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -47,8 +47,8 @@ type ProviderDef struct {
 	Auth        func(cfg *config.Config) (apiKey string, headers map[string]string, err error)
 
 	// DefaultModel resolves the model to use when the user hasn't specified
-	// one. nil means the provider has no default-model resolution (the
-	// caller must always specify a model explicitly) — ResolveDefaultModel
+	// one. nil means the provider has no default-model resolution — the
+	// model is left unset rather than defaulted. ResolveDefaultModel
 	// returns ErrNoDefaultModel in that case.
 	DefaultModel func(ctx context.Context, cfg *config.Config) (string, error)
 


### PR DESCRIPTION
## Summary

CodeRabbit flagged this on #332 but the fix never landed before merge (crossed with an unrelated comment fix in the same review pass). `ProviderDef.DefaultModel`'s doc comment claimed a nil value means "the caller must always specify a model explicitly" — the opposite of the actual, correct behavior: `Registry.ResolveDefaultModel` returns `ErrNoDefaultModel`, and `cmd/rubichan/main.go`'s `loadConfig()` treats that as "leave `cfg.Provider.Model` unset," not an error. Comment-only fix, no behavior change.

## Test plan

- [x] `go build ./...`, `gofmt -l .`, `go vet ./internal/provider/...` clean
- [x] `go test ./internal/provider/...` passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)