### PR TITLE
Fix silent slash commands in plain interactive mode (/resume, /about, /undo, /model)

### DIFF
--- a/cmd/rubichan/plain_interactive.go
+++ b/cmd/rubichan/plain_interactive.go
@@ -307,6 +307,10 @@ func (h *plainInteractiveHost) handleCommandParts(ctx context.Context, line stri
 		_, _ = fmt.Fprintln(h.out, "Config overlay is not available in plain interactive mode.")
 	case commands.ActionOpenWiki:
 		_, _ = fmt.Fprintln(h.out, "Wiki overlay is not available in plain interactive mode.")
+	case commands.ActionResume:
+		// resumeCommand returns an empty Output, so without this case the
+		// command resolved, printed nothing, and looked like it had worked.
+		_, _ = fmt.Fprintln(h.out, "Resume overlay is not available in plain interactive mode. Restart with --resume <session-id>.")
 	}
 
 	return false, nil

--- a/cmd/rubichan/plain_interactive.go
+++ b/cmd/rubichan/plain_interactive.go
@@ -301,6 +301,8 @@ func (h *plainInteractiveHost) handleCommandParts(ctx context.Context, line stri
 	logPlainSlashCommand(line, result.Output, activated, deactivated)
 
 	switch result.Action {
+	case commands.ActionNone:
+		// Ordinary command. Its Output, if any, was printed above.
 	case commands.ActionQuit:
 		return true, nil
 	case commands.ActionOpenConfig:
@@ -308,9 +310,14 @@ func (h *plainInteractiveHost) handleCommandParts(ctx context.Context, line stri
 	case commands.ActionOpenWiki:
 		_, _ = fmt.Fprintln(h.out, "Wiki overlay is not available in plain interactive mode.")
 	case commands.ActionResume:
-		// resumeCommand returns an empty Output, so without this case the
-		// command resolved, printed nothing, and looked like it had worked.
 		_, _ = fmt.Fprintln(h.out, "Resume overlay is not available in plain interactive mode. Restart with --resume <session-id>.")
+	default:
+		// Every remaining Action opens a TUI overlay, and each of those
+		// commands returns an empty Output — so a missing case here is not a
+		// no-op the user can see, it is silence indistinguishable from success.
+		// A default rather than one case per action, so that an Action added
+		// later cannot rejoin that set unnoticed.
+		_, _ = fmt.Fprintln(h.out, "That command needs the full terminal UI and is not available in plain interactive mode.")
 	}
 
 	return false, nil

--- a/cmd/rubichan/plain_interactive.go
+++ b/cmd/rubichan/plain_interactive.go
@@ -243,12 +243,15 @@ func (h *plainInteractiveHost) displayExitMessage() {
 // exitMessage renders the saved-session notice. Split out from
 // displayExitMessage so the wording can be tested without standing up an
 // agent and its store, which is the only way to obtain a session ID.
+//
+// It advertises only --resume. /resume opens a selector overlay that exists
+// only in the Bubble Tea TUI, so naming it here would send a plain-mode user
+// to a command this host declines to run — and it would do so on the way out,
+// where the claim cannot be tested until their next session.
 func exitMessage(sessionID string) string {
 	return fmt.Sprintf(
 		"\nSession saved: %s\n"+
-			"Resume your session next time:\n"+
-			"  • Type:    /resume\n"+
-			"  • Or:      --resume %s\n",
+			"Resume it next time with:  --resume %s\n",
 		sessionID, sessionID)
 }
 

--- a/cmd/rubichan/plain_interactive.go
+++ b/cmd/rubichan/plain_interactive.go
@@ -237,15 +237,19 @@ func (h *plainInteractiveHost) displayExitMessage() {
 		return
 	}
 
-	// Format exit message showing session ID and resume instructions
-	msg := fmt.Sprintf(
+	_, _ = fmt.Fprint(h.out, exitMessage(sessionID))
+}
+
+// exitMessage renders the saved-session notice. Split out from
+// displayExitMessage so the wording can be tested without standing up an
+// agent and its store, which is the only way to obtain a session ID.
+func exitMessage(sessionID string) string {
+	return fmt.Sprintf(
 		"\nSession saved: %s\n"+
 			"Resume your session next time:\n"+
 			"  • Type:    /resume\n"+
 			"  • Or:      --resume %s\n",
 		sessionID, sessionID)
-
-	_, _ = fmt.Fprint(h.out, msg)
 }
 
 func (h *plainInteractiveHost) handleCommand(ctx context.Context, line string) (bool, error) {

--- a/cmd/rubichan/plain_interactive_test.go
+++ b/cmd/rubichan/plain_interactive_test.go
@@ -198,3 +198,18 @@ func TestPlainInteractiveDisplayExitMessageNoAgent(t *testing.T) {
 	output := out.String()
 	assert.Empty(t, output, "exit message should be empty when no agent is available")
 }
+
+// TestExitMessageAdvertisesOnlyWhatPlainModeSupports pins that the banner does
+// not send the user to a command this mode declines to run. Plain mode has no
+// resume overlay, so /resume is a dead end here; --resume works because it is
+// applied at construction via agent.WithResumeSession, before any UI exists.
+//
+// The banner is the more damaging half of that gap: it prints as the user
+// leaves, so a false instruction is not discovered until their next session.
+func TestExitMessageAdvertisesOnlyWhatPlainModeSupports(t *testing.T) {
+	msg := exitMessage("sess-abc123")
+
+	assert.Contains(t, msg, "sess-abc123", "the user needs the ID to resume")
+	assert.Contains(t, msg, "--resume sess-abc123", "the flag is the path that works in plain mode")
+	assert.NotContains(t, msg, "/resume", "plain mode has no resume overlay; advertising it strands the user")
+}

--- a/cmd/rubichan/plain_interactive_test.go
+++ b/cmd/rubichan/plain_interactive_test.go
@@ -232,3 +232,62 @@ func TestPlainInteractiveResumeReportsUnavailable(t *testing.T) {
 	assert.Contains(t, out.String(), "not available in plain interactive mode")
 	assert.Contains(t, out.String(), "--resume", "point the user at the path that does work")
 }
+
+// unsupportedActionCommand returns an Action this host has no case for, standing
+// in for any overlay action added in future.
+type unsupportedActionCommand struct{ action commands.Action }
+
+func (c *unsupportedActionCommand) Name() string                      { return "futurecmd" }
+func (c *unsupportedActionCommand) Description() string               { return "an overlay command" }
+func (c *unsupportedActionCommand) Arguments() []commands.ArgumentDef { return nil }
+func (c *unsupportedActionCommand) Complete(_ context.Context, _ []string) []commands.Candidate {
+	return nil
+}
+func (c *unsupportedActionCommand) Execute(_ context.Context, _ []string) (commands.Result, error) {
+	return commands.Result{Action: c.action}, nil
+}
+
+// TestPlainInteractiveOverlayCommandsReportUnavailable covers the class, not
+// just the instances. /resume was one of five overlay actions reachable in plain
+// mode with no case and no Output; the others were silent for the same reason.
+// The default arm means a newly added Action cannot join them unnoticed.
+func TestPlainInteractiveOverlayCommandsReportUnavailable(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  commands.SlashCommand
+		line string
+	}{
+		{"about", commands.NewAboutCommand(), "/about"},
+		{"undo", commands.NewUndoOverlayCommand(), "/undo"},
+		{"an action added later", &unsupportedActionCommand{action: commands.ActionOpenModelPicker}, "/futurecmd"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := commands.NewRegistry()
+			require.NoError(t, reg.Register(tc.cmd))
+			out := &bytes.Buffer{}
+			host := newPlainInteractiveHost(bytes.NewBufferString(""), out, "gpt-test", 20, reg)
+
+			quit, err := host.handleCommand(context.Background(), tc.line)
+
+			require.NoError(t, err)
+			assert.False(t, quit)
+			assert.NotEmpty(t, out.String(), "a command that does nothing must at least say so")
+			assert.Contains(t, out.String(), "not available in plain interactive mode")
+		})
+	}
+}
+
+// TestPlainInteractiveOrdinaryCommandStaysQuiet guards the other side: the
+// default arm must not fire for ActionNone, which is what every ordinary
+// command returns.
+func TestPlainInteractiveOrdinaryCommandStaysQuiet(t *testing.T) {
+	reg := commands.NewRegistry()
+	require.NoError(t, reg.Register(&unsupportedActionCommand{action: commands.ActionNone}))
+	out := &bytes.Buffer{}
+	host := newPlainInteractiveHost(bytes.NewBufferString(""), out, "gpt-test", 20, reg)
+
+	_, err := host.handleCommand(context.Background(), "/futurecmd")
+
+	require.NoError(t, err)
+	assert.NotContains(t, out.String(), "not available in plain interactive mode")
+}

--- a/cmd/rubichan/plain_interactive_test.go
+++ b/cmd/rubichan/plain_interactive_test.go
@@ -259,6 +259,7 @@ func TestPlainInteractiveOverlayCommandsReportUnavailable(t *testing.T) {
 	}{
 		{"about", commands.NewAboutCommand(), "/about"},
 		{"undo", commands.NewUndoOverlayCommand(), "/undo"},
+		{"bare model opens the picker", commands.NewModelCommand(func(string) {}), "/model"},
 		{"an action added later", &unsupportedActionCommand{action: commands.ActionOpenModelPicker}, "/futurecmd"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/rubichan/plain_interactive_test.go
+++ b/cmd/rubichan/plain_interactive_test.go
@@ -213,3 +213,22 @@ func TestExitMessageAdvertisesOnlyWhatPlainModeSupports(t *testing.T) {
 	assert.Contains(t, msg, "--resume sess-abc123", "the flag is the path that works in plain mode")
 	assert.NotContains(t, msg, "/resume", "plain mode has no resume overlay; advertising it strands the user")
 }
+
+// TestPlainInteractiveResumeReportsUnavailable pins that /resume says something
+// rather than nothing. The command resolves and returns ActionResume with an
+// empty Output, so before this case existed the host printed nothing at all and
+// carried on — indistinguishable from success, and therefore unreportable by
+// the user who hit it.
+func TestPlainInteractiveResumeReportsUnavailable(t *testing.T) {
+	reg := commands.NewRegistry()
+	require.NoError(t, reg.Register(commands.NewResumeCommand()))
+	out := &bytes.Buffer{}
+	host := newPlainInteractiveHost(bytes.NewBufferString(""), out, "gpt-test", 20, reg)
+
+	quit, err := host.handleCommand(context.Background(), "/resume")
+
+	require.NoError(t, err)
+	assert.False(t, quit, "an unsupported command must not end the session")
+	assert.Contains(t, out.String(), "not available in plain interactive mode")
+	assert.Contains(t, out.String(), "--resume", "point the user at the path that does work")
+}

--- a/cmd/rubichan/shell.go
+++ b/cmd/rubichan/shell.go
@@ -367,7 +367,22 @@ func makeSlashCommandFunc(registry *commands.Registry) shell.SlashCommandFunc {
 			return "", false, err
 		}
 
-		quit := result.Action == commands.ActionQuit
-		return result.Output, quit, nil
+		switch result.Action {
+		case commands.ActionNone:
+			return result.Output, false, nil
+		case commands.ActionQuit:
+			return result.Output, true, nil
+		default:
+			// Every remaining action opens a TUI overlay, and those commands
+			// return an empty Output — so testing only for ActionQuit and
+			// returning Output meant bare /model printed nothing at all.
+			// A default rather than a case per action, so an action added later
+			// cannot become silent here the same way.
+			msg := "That command needs the full terminal UI and is not available in shell mode."
+			if result.Output != "" {
+				msg = result.Output + "\n" + msg
+			}
+			return msg, false, nil
+		}
 	}
 }

--- a/cmd/rubichan/shell_test.go
+++ b/cmd/rubichan/shell_test.go
@@ -75,3 +75,38 @@ func TestErrExitIsExported(t *testing.T) {
 	err := shell.ErrExit
 	assert.True(t, errors.Is(err, shell.ErrExit))
 }
+
+// TestMakeSlashCommandFuncReportsOverlayActions covers the same defect fixed in
+// plain interactive mode, in the third host. Shell mode registers /model, whose
+// argument-less form returns ActionOpenModelPicker with an empty Output; before
+// this, the wrapper tested only for ActionQuit and returned that empty string,
+// so bare /model printed nothing.
+func TestMakeSlashCommandFuncReportsOverlayActions(t *testing.T) {
+	t.Parallel()
+
+	registry := commands.NewRegistry()
+	require.NoError(t, registry.Register(commands.NewModelCommand(func(string) {})))
+
+	fn := makeSlashCommandFunc(registry)
+
+	output, quit, err := fn(context.Background(), "model", nil)
+	require.NoError(t, err)
+	assert.False(t, quit, "an unsupported command must not end the shell")
+	assert.NotEmpty(t, output, "a command that does nothing must at least say so")
+	assert.Contains(t, output, "not available in shell mode")
+}
+
+// TestMakeSlashCommandFuncStaysQuietForOrdinaryCommands guards the other side:
+// ActionNone must not trigger the unavailable message.
+func TestMakeSlashCommandFuncStaysQuietForOrdinaryCommands(t *testing.T) {
+	t.Parallel()
+
+	registry := commands.NewRegistry()
+	require.NoError(t, registry.Register(commands.NewHelpCommand(registry)))
+
+	fn := makeSlashCommandFunc(registry)
+
+	output, _, err := fn(context.Background(), "help", nil)
+	require.NoError(t, err)
+	assert.NotContains(t, output, "not available in shell mode")
+}


### PR DESCRIPTION
A user-facing defect found during #339's review (credit to @chatgpt-codex-connector, who spotted `/resume` while checking a reachability claim). Pre-existing — not caused by that deletion.

**It turned out `/resume` was one instance of a systematic gap**, which is what this PR ended up fixing.

## The bug

Plain interactive mode printed this on the way out:

```
Session saved: <id>
Resume your session next time:
  • Type:    /resume        <- does nothing in this mode
  • Or:      --resume <id>
```

`/resume` returns `commands.ActionResume`, which opens a selector overlay implemented **only** in the Bubble Tea TUI. `plainInteractiveHost.handleCommand` had no case for it, and `resumeCommand.Execute` returns an empty `Output` — so the command resolved, printed nothing, and the loop continued. **Silently.**

## Enumerating found four more

I originally shipped this fixing `/resume` alone and flagged in the PR body that I had *not* checked the other `Action` values. Doing that check found:

| | actions |
|---|---|
| registered **and handled** | `Quit`, `OpenConfig`, `OpenWiki` |
| registered **and silent** | `Resume`, `OpenAbout`, `InitKnowledgeGraph`, `OpenUndo`, `OpenModelPicker` |

All five return `Result{Action: ...}` with no `Output`, and all are reachable from plain mode: `about` and `init-knowledge-graph` are registered unconditionally at `main.go:1185-1186`, *before* `plainHost` is constructed at 1204 with that same registry; the later registrations share the same registry pointer with no mode guard.

So **`/about`, `/undo` and bare `/model` behaved exactly as `/resume` did.** `/model <name>` was never affected — it returns Output, and only the argument-less form opens the picker.

## Why the banner was the worst part

The silent command is discoverable: a user types it, sees nothing, investigates. The banner printed **as the user left**, so the false instruction wasn't testable until their next session — by which point they'd relied on it.

## Commits

| | |
|---|---|
| `3503650` `[STRUCTURAL]` | Extract Method: `exitMessage` from `displayExitMessage` |
| `a06e200` `[BEHAVIORAL]` | Stop the exit banner advertising `/resume` |
| `e808dad` `[BEHAVIORAL]` | Report that `/resume` is unavailable, and name what works |
| `445398a` `[BEHAVIORAL]` | Report every unhandled overlay action, not just resume |

The extraction came first out of necessity: `displayExitMessage` returns early unless `agent.SessionID()` is non-empty, and that's only assigned when the agent has a store — so asserting on the wording meant standing up SQLite, which is exactly where this environment's pre-existing `$HOME`-bound failures live. A pure function makes it a string comparison.

## The fix is a default arm, not four more cases

```go
switch result.Action {
case commands.ActionNone:
	// Ordinary command. Its Output, if any, was printed above.
...
default:
	fmt.Fprintln(h.out, "That command needs the full terminal UI and is not available in plain interactive mode.")
}
```

Enumerating the four would fix today's instances and leave the *next* `Action` to rejoin the silent set unnoticed. A default cannot. `ActionNone` is explicit so ordinary commands — which all return it — stay quiet.

## Verification

Every test written failing first. The `/resume` handler test's initial failure asserted against `""` — the silent no-op captured directly.

```
--- PASS: TestExitMessageAdvertisesOnlyWhatPlainModeSupports
--- PASS: TestPlainInteractiveResumeReportsUnavailable
--- PASS: TestPlainInteractiveOverlayCommandsReportUnavailable/about
--- PASS: TestPlainInteractiveOverlayCommandsReportUnavailable/undo
--- PASS: TestPlainInteractiveOverlayCommandsReportUnavailable/an_action_added_later
--- PASS: TestPlainInteractiveOrdinaryCommandStaysQuiet
```

Tests cover both directions — unhandled actions must speak, `ActionNone` must not. The "action added later" case uses a synthetic command, so the default arm is pinned against a future `Action` rather than only today's.

Full suite failure list identical to baseline (same 10 pre-existing environmental failures). `go build`, `go vet`, `gofmt` clean.

## For reviewers

**`--resume <id>` is now the banner's only offer**, so its mode-independence became load-bearing. I verified it: `main.go:1143` applies `agent.WithResumeSession` during agent construction in `runInteractive`, and `main.go:1456` hands that same agent to `plainHost` — the host is chosen *after* resume is applied. Worth a second look, since if that read is wrong the banner is useless rather than merely misleading.

**The default arm's message is deliberately generic.** `/resume` keeps a specific message naming `--resume <session-id>`, because there's a real alternative to point at. The others have none, so a generic message is honest; if any of them does have a plain-mode equivalent, it deserves its own case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated plain interactive mode guidance to use the `--resume <session-id>` option.
  * Clarified that session resume and other overlay actions are unavailable in plain mode.
  * Added fallback messaging for unsupported commands without ending the session.
  * Kept ordinary commands silent when no action is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->