### PR TITLE
Clear APIKeySource when a config-sourced API key is removed

### DIFF
--- a/internal/tui/bootstrap.go
+++ b/internal/tui/bootstrap.go
@@ -148,21 +148,22 @@ func (b *BootstrapForm) Config() *config.Config { return b.cfg }
 // Save persists the config. It copies the OpenAI key into the correct config
 // entry if the user selected the OpenAI provider.
 func (b *BootstrapForm) Save() error {
-	if b.cfg.Provider.Default == "anthropic" {
-		switch {
-		case b.cfg.Provider.Anthropic.APIKey != "":
-			b.cfg.Provider.Anthropic.APIKeySource = "config"
-		case b.origAnthropicAPIKeySource == "config":
-			b.cfg.Provider.Anthropic.APIKeySource = "env"
-		}
+	// Not gated on Provider.Default — see the matching comment in
+	// ConfigForm.Save() (configform.go): a key can be typed or cleared
+	// while its provider's group was visible, then the selection changed
+	// before the wizard finishes, and reconciliation must still apply to
+	// whichever provider's key actually changed.
+	switch {
+	case b.cfg.Provider.Anthropic.APIKey != "":
+		b.cfg.Provider.Anthropic.APIKeySource = "config"
+	case b.origAnthropicAPIKeySource == "config":
+		b.cfg.Provider.Anthropic.APIKeySource = "env"
 	}
-	if b.cfg.Provider.Default == "zai" {
-		switch {
-		case b.cfg.Provider.Zai.APIKey != "":
-			b.cfg.Provider.Zai.APIKeySource = "config"
-		case b.origZaiAPIKeySource == "config":
-			b.cfg.Provider.Zai.APIKeySource = "env"
-		}
+	switch {
+	case b.cfg.Provider.Zai.APIKey != "":
+		b.cfg.Provider.Zai.APIKeySource = "config"
+	case b.origZaiAPIKeySource == "config":
+		b.cfg.Provider.Zai.APIKeySource = "env"
 	}
 	if b.cfg.Provider.Default == "openai" && b.openaiKey != "" {
 		baseURL := b.openaiBaseURL

--- a/internal/tui/bootstrap.go
+++ b/internal/tui/bootstrap.go
@@ -39,6 +39,17 @@ type BootstrapForm struct {
 	savePath      string
 	openaiKey     string
 	openaiBaseURL string
+
+	// origAnthropicAPIKeySource/origZaiAPIKeySource capture each
+	// provider's APIKeySource as cfg started (from config.DefaultConfig()
+	// today, always "env" for Anthropic and unset for Z.ai — see the
+	// matching field in ConfigForm for the full rationale). Kept here too
+	// so Save()'s logic — and its "clear a config-sourced key resets the
+	// source" behavior — stays identical between the first-run wizard and
+	// the in-session /config editor, even though only the latter can load
+	// an existing config-sourced key to begin with.
+	origAnthropicAPIKeySource string
+	origZaiAPIKeySource       string
 }
 
 // NewBootstrapForm creates a multi-step setup wizard.
@@ -48,8 +59,10 @@ func NewBootstrapForm(savePath string) *BootstrapForm {
 	// openaiKey is a staging area. After the form completes, Save() copies
 	// it into the correct OpenAI-compatible provider config entry.
 	bf := &BootstrapForm{
-		cfg:      cfg,
-		savePath: savePath,
+		cfg:                       cfg,
+		savePath:                  savePath,
+		origAnthropicAPIKeySource: cfg.Provider.Anthropic.APIKeySource,
+		origZaiAPIKeySource:       cfg.Provider.Zai.APIKeySource,
 	}
 
 	providerGroup := huh.NewGroup(
@@ -135,11 +148,21 @@ func (b *BootstrapForm) Config() *config.Config { return b.cfg }
 // Save persists the config. It copies the OpenAI key into the correct config
 // entry if the user selected the OpenAI provider.
 func (b *BootstrapForm) Save() error {
-	if b.cfg.Provider.Default == "anthropic" && b.cfg.Provider.Anthropic.APIKey != "" {
-		b.cfg.Provider.Anthropic.APIKeySource = "config"
+	if b.cfg.Provider.Default == "anthropic" {
+		switch {
+		case b.cfg.Provider.Anthropic.APIKey != "":
+			b.cfg.Provider.Anthropic.APIKeySource = "config"
+		case b.origAnthropicAPIKeySource == "config":
+			b.cfg.Provider.Anthropic.APIKeySource = "env"
+		}
 	}
-	if b.cfg.Provider.Default == "zai" && b.cfg.Provider.Zai.APIKey != "" {
-		b.cfg.Provider.Zai.APIKeySource = "config"
+	if b.cfg.Provider.Default == "zai" {
+		switch {
+		case b.cfg.Provider.Zai.APIKey != "":
+			b.cfg.Provider.Zai.APIKeySource = "config"
+		case b.origZaiAPIKeySource == "config":
+			b.cfg.Provider.Zai.APIKeySource = "env"
+		}
 	}
 	if b.cfg.Provider.Default == "openai" && b.openaiKey != "" {
 		baseURL := b.openaiBaseURL

--- a/internal/tui/configform.go
+++ b/internal/tui/configform.go
@@ -162,28 +162,32 @@ func (c *ConfigForm) Save() error {
 		c.cfg.Agent.MaxTurns = v
 	}
 
-	if c.cfg.Provider.Default == "anthropic" {
-		switch {
-		case c.cfg.Provider.Anthropic.APIKey != "":
-			c.cfg.Provider.Anthropic.APIKeySource = "config"
-		case c.origAnthropicAPIKeySource == "config":
-			// Key was previously config-sourced and has now been
-			// explicitly cleared — reset to "env" (this app's own
-			// default for "no key configured") rather than leaving
-			// APIKeySource="config" pointing at an empty value, which
-			// ResolveAPIKey rejects outright.
-			c.cfg.Provider.Anthropic.APIKeySource = "env"
-		}
-		// else: key was already blank (e.g. env-sourced) and still is —
-		// leave APIKeySource exactly as it was.
+	// Anthropic/Zai key-source reconciliation runs unconditionally, not
+	// gated on which provider is currently selected: huh's WithHideFunc
+	// only hides a group's UI, it doesn't stop the user from clearing a
+	// field while that group was visible and then navigating back to
+	// switch the provider selection before finishing the form. Gating
+	// this on Provider.Default would skip reconciling whichever
+	// provider's group the user isn't on by the time Save() runs, even
+	// though its key may have just been cleared.
+	switch {
+	case c.cfg.Provider.Anthropic.APIKey != "":
+		c.cfg.Provider.Anthropic.APIKeySource = "config"
+	case c.origAnthropicAPIKeySource == "config":
+		// Key was previously config-sourced and has now been explicitly
+		// cleared — reset to "env" (this app's own default for "no key
+		// configured") rather than leaving APIKeySource="config"
+		// pointing at an empty value, which ResolveAPIKey rejects
+		// outright.
+		c.cfg.Provider.Anthropic.APIKeySource = "env"
 	}
-	if c.cfg.Provider.Default == "zai" {
-		switch {
-		case c.cfg.Provider.Zai.APIKey != "":
-			c.cfg.Provider.Zai.APIKeySource = "config"
-		case c.origZaiAPIKeySource == "config":
-			c.cfg.Provider.Zai.APIKeySource = "env"
-		}
+	// else: key was already blank (e.g. env-sourced) and still is — leave
+	// APIKeySource exactly as it was.
+	switch {
+	case c.cfg.Provider.Zai.APIKey != "":
+		c.cfg.Provider.Zai.APIKeySource = "config"
+	case c.origZaiAPIKeySource == "config":
+		c.cfg.Provider.Zai.APIKeySource = "env"
 	}
 	if c.cfg.Provider.Default == "openai" {
 		existing, found := findOpenAICompatibleEntry(c.cfg, "openai")

--- a/internal/tui/configform.go
+++ b/internal/tui/configform.go
@@ -18,14 +18,27 @@ type ConfigForm struct {
 	maxTurnsStr   string
 	openaiKey     string // staging field, mirrors BootstrapForm; copied into cfg.Provider.OpenAI on Save
 	openaiBaseURL string // staging field, mirrors BootstrapForm
+
+	// origAnthropicAPIKeySource/origZaiAPIKeySource capture each
+	// provider's APIKeySource as loaded, before the form can mutate the
+	// directly-bound APIKey field. Save() needs this to tell "the key
+	// field is blank because it was always env-sourced" (leave
+	// APIKeySource untouched) apart from "the key field is blank because
+	// the user just cleared a previously config-sourced key" (reset
+	// APIKeySource, or it's left pointing at a config value that no
+	// longer exists).
+	origAnthropicAPIKeySource string
+	origZaiAPIKeySource       string
 }
 
 // NewConfigForm creates a config editor form populated from the given config.
 func NewConfigForm(cfg *config.Config, savePath string) *ConfigForm {
 	cf := &ConfigForm{
-		cfg:         cfg,
-		savePath:    savePath,
-		maxTurnsStr: fmt.Sprintf("%d", cfg.Agent.MaxTurns),
+		cfg:                       cfg,
+		savePath:                  savePath,
+		maxTurnsStr:               fmt.Sprintf("%d", cfg.Agent.MaxTurns),
+		origAnthropicAPIKeySource: cfg.Provider.Anthropic.APIKeySource,
+		origZaiAPIKeySource:       cfg.Provider.Zai.APIKeySource,
 	}
 
 	if oc, ok := findOpenAICompatibleEntry(cfg, "openai"); ok {
@@ -149,11 +162,28 @@ func (c *ConfigForm) Save() error {
 		c.cfg.Agent.MaxTurns = v
 	}
 
-	if c.cfg.Provider.Default == "anthropic" && c.cfg.Provider.Anthropic.APIKey != "" {
-		c.cfg.Provider.Anthropic.APIKeySource = "config"
+	if c.cfg.Provider.Default == "anthropic" {
+		switch {
+		case c.cfg.Provider.Anthropic.APIKey != "":
+			c.cfg.Provider.Anthropic.APIKeySource = "config"
+		case c.origAnthropicAPIKeySource == "config":
+			// Key was previously config-sourced and has now been
+			// explicitly cleared — reset to "env" (this app's own
+			// default for "no key configured") rather than leaving
+			// APIKeySource="config" pointing at an empty value, which
+			// ResolveAPIKey rejects outright.
+			c.cfg.Provider.Anthropic.APIKeySource = "env"
+		}
+		// else: key was already blank (e.g. env-sourced) and still is —
+		// leave APIKeySource exactly as it was.
 	}
-	if c.cfg.Provider.Default == "zai" && c.cfg.Provider.Zai.APIKey != "" {
-		c.cfg.Provider.Zai.APIKeySource = "config"
+	if c.cfg.Provider.Default == "zai" {
+		switch {
+		case c.cfg.Provider.Zai.APIKey != "":
+			c.cfg.Provider.Zai.APIKeySource = "config"
+		case c.origZaiAPIKeySource == "config":
+			c.cfg.Provider.Zai.APIKeySource = "env"
+		}
 	}
 	if c.cfg.Provider.Default == "openai" {
 		existing, found := findOpenAICompatibleEntry(c.cfg, "openai")

--- a/internal/tui/configform_test.go
+++ b/internal/tui/configform_test.go
@@ -177,6 +177,80 @@ func TestConfigFormSaveOpenAIBaseURLOnlyEditWithBlankKeyPersists(t *testing.T) {
 	assert.Empty(t, loaded.Provider.OpenAI[0].APIKey)
 }
 
+func TestConfigFormSaveClearingConfigSourcedAnthropicKeyResetsSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "anthropic"
+	// Simulate an existing on-disk config with a previously-stored key —
+	// APIKeySource must be captured at NewConfigForm construction time,
+	// before the field is cleared below, to distinguish this from a key
+	// that was always env-sourced (see the sibling test).
+	cfg.Provider.Anthropic.APIKeySource = "config"
+	cfg.Provider.Anthropic.APIKey = "sk-ant-old"
+
+	form := NewConfigForm(cfg, path)
+	// Simulate the user clearing the field in the UI.
+	cfg.Provider.Anthropic.APIKey = ""
+	require.NoError(t, form.Save())
+
+	loaded, err := config.Load(path)
+	require.NoError(t, err)
+	assert.Empty(t, loaded.Provider.Anthropic.APIKey)
+	assert.Equal(t, "env", loaded.Provider.Anthropic.APIKeySource, "clearing a config-sourced key must reset APIKeySource, not leave it pointing at an empty value")
+}
+
+func TestConfigFormSaveClearingConfigSourcedZaiKeyResetsSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "zai"
+	cfg.Provider.Zai.APIKeySource = "config"
+	cfg.Provider.Zai.APIKey = "zai-old-key"
+
+	form := NewConfigForm(cfg, path)
+	cfg.Provider.Zai.APIKey = ""
+	require.NoError(t, form.Save())
+
+	loaded, err := config.Load(path)
+	require.NoError(t, err)
+	assert.Empty(t, loaded.Provider.Zai.APIKey)
+	assert.Equal(t, "env", loaded.Provider.Zai.APIKeySource, "clearing a config-sourced key must reset APIKeySource, not leave it pointing at an empty value")
+}
+
+func TestConfigFormSaveLeavesEnvSourcedAnthropicKeyUntouched(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "anthropic"
+	cfg.Provider.Anthropic.APIKeySource = "env"
+	cfg.Provider.Anthropic.APIKey = ""
+
+	form := NewConfigForm(cfg, path)
+	// Field is never touched — blank means "use the env var", not "clear it".
+	require.NoError(t, form.Save())
+
+	loaded, err := config.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "env", loaded.Provider.Anthropic.APIKeySource, "an untouched env-sourced key must not be reset")
+}
+
+func TestConfigFormSaveLeavesEnvSourcedZaiKeyUntouched(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "zai"
+	cfg.Provider.Zai.APIKeySource = "env"
+	cfg.Provider.Zai.APIKey = ""
+
+	form := NewConfigForm(cfg, path)
+	require.NoError(t, form.Save())
+
+	loaded, err := config.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "env", loaded.Provider.Zai.APIKeySource, "an untouched env-sourced key must not be reset")
+}
+
 func TestConfigFormSaveOpenAIPreservesExtraHeadersOnUpdate(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")

--- a/internal/tui/configform_test.go
+++ b/internal/tui/configform_test.go
@@ -251,6 +251,33 @@ func TestConfigFormSaveLeavesEnvSourcedZaiKeyUntouched(t *testing.T) {
 	assert.Equal(t, "env", loaded.Provider.Zai.APIKeySource, "an untouched env-sourced key must not be reset")
 }
 
+func TestConfigFormSaveClearingKeyThenSwitchingProviderStillResetsSource(t *testing.T) {
+	// Reproduces a realistic multi-step edit: the user clears a
+	// config-sourced Anthropic key, then navigates back to the provider
+	// group and switches the selection to Z.ai before finishing the form.
+	// Provider.Default at Save() time is "zai", not "anthropic" — the
+	// reconciliation must still apply to Anthropic's now-stale
+	// APIKeySource, since it isn't gated on which provider ends up
+	// selected.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	cfg := config.DefaultConfig()
+	cfg.Provider.Default = "anthropic"
+	cfg.Provider.Anthropic.APIKeySource = "config"
+	cfg.Provider.Anthropic.APIKey = "sk-ant-old"
+
+	form := NewConfigForm(cfg, path)
+	cfg.Provider.Anthropic.APIKey = "" // cleared while still on the Anthropic group
+	cfg.Provider.Default = "zai"       // then switched away before finishing
+	require.NoError(t, form.Save())
+
+	loaded, err := config.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "zai", loaded.Provider.Default)
+	assert.Empty(t, loaded.Provider.Anthropic.APIKey)
+	assert.Equal(t, "env", loaded.Provider.Anthropic.APIKeySource, "clearing a key must reset its APIKeySource even if a different provider ends up selected by the time the form completes")
+}
+
 func TestConfigFormSaveOpenAIPreservesExtraHeadersOnUpdate(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")


### PR DESCRIPTION
## Summary

Fixes #342. When a user explicitly clears a previously config-sourced Anthropic or Z.ai API key (in `/config` or, in principle, the bootstrap wizard), `APIKeySource` stayed `"config"` even though the key was now empty — `config.ResolveAPIKey` then rejects that combination outright (`"api_key_source is 'config' but no api_key value provided"`), breaking the provider on next use.

**Root cause:** `configform.go`/`bootstrap.go`'s `Save()` only ever *set* `APIKeySource = "config"` when a key was present — never reset it when the key became empty. The Anthropic/Z.ai key fields bind directly to `cfg.Provider.*.APIKey` (no staging field, unlike OpenAI-compatible's `openaiKey`), so clearing the field already empties the bound value before `Save()` runs; the `!= ""` check then skips the whole block.

**Fix:** capture each provider's original `APIKeySource` at form-construction time, before any edits — `Save()` can't tell "blank because always env-sourced" apart from "blank because a config-sourced key was just cleared" from the current field value alone. Three-way branch: key present → `"config"`; key blank *and* it was previously `"config"` → reset to `"env"` (this app's own default for "no key configured"); key blank and it wasn't `"config"` → leave untouched (preserves the existing, correct env-key behavior).

Applied identically to `bootstrap.go` for consistency with `configform.go`, per the issue's stated affected areas — though the exact scenario isn't reachable there today, since `NewBootstrapForm` always starts from a fresh `config.DefaultConfig()` rather than loading an existing on-disk config. No new test was added there for that reason (there's no way to get a pre-existing `"config"`-sourced key into the wizard's starting state via its current API); the existing bootstrap test suite serves as regression proof that the structural change is a no-op for it today.

## Test plan

- [x] New tests prove the fix for both providers: `TestConfigFormSaveClearingConfigSourcedAnthropicKeyResetsSource`, `TestConfigFormSaveClearingConfigSourcedZaiKeyResetsSource` — RED confirmed against pre-fix code (`APIKeySource` stayed `"config"`), GREEN after
- [x] New tests prove the "don't touch env-sourced keys" constraint is preserved: `TestConfigFormSaveLeavesEnvSourcedAnthropicKeyUntouched`, `TestConfigFormSaveLeavesEnvSourcedZaiKeyUntouched`
- [x] `go build ./...`, `gofmt -l .`, `go vet ./...` — clean
- [x] `go test ./internal/tui/...` — all green, including every pre-existing `configform_test.go`/`bootstrap_test.go` test unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key configuration handling in the setup and configuration screens.
  * Clearing a saved API key now correctly removes its configuration source.
  * Existing environment-sourced API keys remain unchanged when not edited.
* **Tests**
  * Added coverage for clearing saved keys and preserving environment-based keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->