### PR TITLE
ACP rebuild slice 1: a bidirectional connection (the capability the audit found missing)

### DIFF
--- a/internal/acp/capabilities.go
+++ b/internal/acp/capabilities.go
@@ -2,6 +2,7 @@ package acp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 )
@@ -98,6 +99,12 @@ func (cr *CapabilityRegistry) GetMethods() []string {
 	return methods
 }
 
+// ErrMethodNotFound reports that no handler is registered for a method. It is a
+// sentinel because callers must distinguish "nobody serves this" from "the
+// handler failed" to pick a JSON-RPC error code, and matching on message text
+// misclassifies any handler error that happens to mention a missing method.
+var ErrMethodNotFound = errors.New("acp: method not found")
+
 // Call invokes a registered method handler.
 func (cr *CapabilityRegistry) Call(method string, params json.RawMessage) (json.RawMessage, error) {
 	cr.mu.RLock()
@@ -105,7 +112,7 @@ func (cr *CapabilityRegistry) Call(method string, params json.RawMessage) (json.
 	cr.mu.RUnlock()
 
 	if !ok {
-		return nil, fmt.Errorf("method not found: %s", method)
+		return nil, fmt.Errorf("%w: %s", ErrMethodNotFound, method)
 	}
 	return handler(params)
 }

--- a/internal/acp/conn.go
+++ b/internal/acp/conn.go
@@ -7,10 +7,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"math"
-	"strings"
 	"sync"
 )
+
+// notificationBacklog bounds how far the peer may run ahead of the notification
+// handler before the read loop pauses. Generous enough that ordinary streaming
+// never blocks, small enough that a flood cannot grow without limit.
+const notificationBacklog = 256
 
 // Conn is a bidirectional ACP connection over a single byte stream.
 //
@@ -29,6 +34,13 @@ type Conn struct {
 	r *bufio.Scanner
 
 	registry *CapabilityRegistry
+
+	// notifications are served by a single worker in arrival order. ACP's
+	// session/update is a stream of turn events, so delivering them
+	// concurrently does not just interleave work, it renders the wrong turn.
+	// Requests keep their own goroutine each, because a request handler may
+	// call Request and must not block the read loop that carries its answer.
+	notifications chan Request
 
 	// writeMu serialises writes. Requests, responses and notifications share
 	// one stream, and an interleaved write corrupts the wire.
@@ -54,10 +66,11 @@ func NewConn(r io.Reader, w io.Writer, registry *CapabilityRegistry) *Conn {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, maxMessageSize), maxMessageSize)
 	return &Conn{
-		w:        w,
-		r:        scanner,
-		registry: registry,
-		pending:  make(map[int64]chan *Response),
+		w:             w,
+		r:             scanner,
+		registry:      registry,
+		pending:       make(map[int64]chan *Response),
+		notifications: make(chan Request, notificationBacklog),
 	}
 }
 
@@ -66,6 +79,20 @@ func NewConn(r io.Reader, w io.Writer, registry *CapabilityRegistry) *Conn {
 // on a connection that has gone away.
 func (c *Conn) Serve(ctx context.Context) error {
 	defer c.failPending()
+
+	notificationsDone := make(chan struct{})
+	go func() {
+		defer close(notificationsDone)
+		for n := range c.notifications {
+			if _, err := c.registry.Call(n.Method, n.Params); err != nil {
+				log.Printf("acp: notification %s failed: %v", n.Method, err)
+			}
+		}
+	}()
+	defer func() {
+		close(c.notifications)
+		<-notificationsDone
+	}()
 
 	lines := make(chan []byte)
 	scanErr := make(chan error, 1)
@@ -88,10 +115,20 @@ func (c *Conn) Serve(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case err := <-scanErr:
-			return err
 		case line, ok := <-lines:
 			if !ok {
+				// The producer sends its error before closing lines, so the
+				// value is already available. Reading it here rather than in a
+				// sibling select case matters: both would be ready at once and
+				// select picks at random, silently turning a read failure into
+				// a clean end of stream.
+				select {
+				case err := <-scanErr:
+					if err != nil {
+						return fmt.Errorf("read acp stream: %w", err)
+					}
+				default:
+				}
 				return nil
 			}
 			if len(line) == 0 {
@@ -125,13 +162,29 @@ func (c *Conn) dispatch(line []byte) {
 func (c *Conn) serveRequest(line []byte) {
 	var req Request
 	if err := json.Unmarshal(line, &req); err != nil {
+		// The peer may still be waiting on an id we can recover. Answering is
+		// what separates a malformed request from a hung one.
+		var probe struct {
+			ID any `json:"id"`
+		}
+		if json.Unmarshal(line, &probe) == nil && probe.ID != nil {
+			_ = c.write(Response{
+				JSONRPC: "2.0",
+				ID:      probe.ID,
+				Error:   &RPCError{Code: ErrorCodeInvalidRequest, Message: err.Error()},
+			})
+		}
 		return
 	}
 
 	// A request without an id is a notification: the peer wants no answer, and
 	// replying to one would put an unmatched response on the wire.
 	if req.ID == nil {
-		go func() { _, _ = c.registry.Call(req.Method, req.Params) }()
+		// Sending from the read loop is deliberate back-pressure: if the peer
+		// outruns the handler the loop pauses, which is preferable to an
+		// unbounded goroutine per notification. Handlers must therefore not
+		// call Request, since that would wait on the loop they are blocking.
+		c.notifications <- req
 		return
 	}
 
@@ -139,7 +192,7 @@ func (c *Conn) serveRequest(line []byte) {
 		result, err := c.registry.Call(req.Method, req.Params)
 		if err != nil {
 			code := ErrorCodeInternalError
-			if strings.Contains(err.Error(), "method not found") {
+			if errors.Is(err, ErrMethodNotFound) {
 				code = ErrorCodeMethodNotFound
 			}
 			_ = c.write(Response{
@@ -239,12 +292,14 @@ func (c *Conn) failPending() {
 func (c *Conn) write(msg any) error {
 	data, err := json.Marshal(msg)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal acp message: %w", err)
 	}
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
-	_, err = c.w.Write(append(data, '\n'))
-	return err
+	if _, err := c.w.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("write acp message: %w", err)
+	}
+	return nil
 }
 
 // marshalParams keeps an already-encoded payload as-is and encodes anything

--- a/internal/acp/conn.go
+++ b/internal/acp/conn.go
@@ -1,0 +1,263 @@
+package acp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+)
+
+// Conn is a bidirectional ACP connection over a single byte stream.
+//
+// It exists because the Agent Client Protocol is symmetric: the client sends
+// session/prompt, and *during* that turn the agent sends session/update
+// notifications and session/request_permission requests back. The previous
+// design could not express that — StdioTransport.Start and ResponseDispatcher
+// were two read loops over the same stream, so a process could serve requests
+// or await responses, never both.
+//
+// Conn runs one read loop and demultiplexes: a message carrying a method is an
+// inbound request or notification; a message carrying only an id is a response
+// to something this side sent.
+type Conn struct {
+	w io.Writer
+	r *bufio.Scanner
+
+	registry *CapabilityRegistry
+
+	// writeMu serialises writes. Requests, responses and notifications share
+	// one stream, and an interleaved write corrupts the wire.
+	writeMu sync.Mutex
+
+	mu      sync.Mutex
+	nextID  int64
+	pending map[int64]chan *Response
+}
+
+// NewConn creates a connection that reads from r, writes to w, and serves
+// inbound method calls out of registry.
+func NewConn(r io.Reader, w io.Writer, registry *CapabilityRegistry) *Conn {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, maxMessageSize), maxMessageSize)
+	return &Conn{
+		w:        w,
+		r:        scanner,
+		registry: registry,
+		pending:  make(map[int64]chan *Response),
+	}
+}
+
+// Serve runs the read loop until the stream ends, ctx is cancelled, or a write
+// fails. Every pending request is failed on exit so no caller is left waiting
+// on a connection that has gone away.
+func (c *Conn) Serve(ctx context.Context) error {
+	defer c.failPending()
+
+	lines := make(chan []byte)
+	scanErr := make(chan error, 1)
+	go func() {
+		defer close(lines)
+		for c.r.Scan() {
+			// Scan reuses its buffer, so the payload must be copied before it
+			// crosses the channel.
+			line := append([]byte(nil), c.r.Bytes()...)
+			select {
+			case lines <- line:
+			case <-ctx.Done():
+				return
+			}
+		}
+		scanErr <- c.r.Err()
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-scanErr:
+			return err
+		case line, ok := <-lines:
+			if !ok {
+				return nil
+			}
+			if len(line) == 0 {
+				continue
+			}
+			c.dispatch(line)
+		}
+	}
+}
+
+// dispatch routes one inbound message by shape: a method means the peer is
+// asking us something, no method means it is answering us.
+func (c *Conn) dispatch(line []byte) {
+	var probe struct {
+		Method string `json:"method"`
+	}
+	if err := json.Unmarshal(line, &probe); err != nil {
+		return
+	}
+	if probe.Method == "" {
+		c.routeResponse(line)
+		return
+	}
+	c.serveRequest(line)
+}
+
+// serveRequest answers an inbound method call. It runs in its own goroutine so
+// a handler that itself calls Request — session/prompt asking the client for
+// permission mid-turn — does not deadlock against the read loop that would
+// carry the answer.
+func (c *Conn) serveRequest(line []byte) {
+	var req Request
+	if err := json.Unmarshal(line, &req); err != nil {
+		return
+	}
+
+	// A request without an id is a notification: the peer wants no answer, and
+	// replying to one would put an unmatched response on the wire.
+	if req.ID == nil {
+		go func() { _, _ = c.registry.Call(req.Method, req.Params) }()
+		return
+	}
+
+	go func() {
+		result, err := c.registry.Call(req.Method, req.Params)
+		if err != nil {
+			code := ErrorCodeInternalError
+			if strings.Contains(err.Error(), "method not found") {
+				code = ErrorCodeMethodNotFound
+			}
+			_ = c.write(Response{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Error:   &RPCError{Code: code, Message: err.Error()},
+			})
+			return
+		}
+		_ = c.write(Response{JSONRPC: "2.0", ID: req.ID, Result: &result})
+	}()
+}
+
+// routeResponse hands a response to whichever Request call is waiting on its
+// ID. A response with no waiter is dropped: it is either a duplicate or a
+// reply to a request that has already timed out.
+func (c *Conn) routeResponse(line []byte) {
+	var resp Response
+	if err := json.Unmarshal(line, &resp); err != nil {
+		return
+	}
+	id, ok := numericID(resp.ID)
+	if !ok {
+		return
+	}
+
+	c.mu.Lock()
+	ch, waiting := c.pending[id]
+	delete(c.pending, id)
+	c.mu.Unlock()
+
+	if waiting {
+		ch <- &resp
+	}
+}
+
+// Request sends a method call to the peer and blocks until it answers, ctx is
+// cancelled, or the connection drops.
+func (c *Conn) Request(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	raw, err := marshalParams(params)
+	if err != nil {
+		return nil, fmt.Errorf("marshal params for %s: %w", method, err)
+	}
+
+	c.mu.Lock()
+	c.nextID++
+	id := c.nextID
+	ch := make(chan *Response, 1)
+	c.pending[id] = ch
+	c.mu.Unlock()
+
+	// Always reclaim the slot, including on the ctx and drop paths, so a
+	// cancelled call cannot leak an entry that nothing will ever remove.
+	defer func() {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+	}()
+
+	if err := c.write(Request{JSONRPC: "2.0", ID: id, Method: method, Params: raw}); err != nil {
+		return nil, fmt.Errorf("send %s: %w", method, err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case resp := <-ch:
+		if resp == nil {
+			return nil, fmt.Errorf("connection closed while awaiting response to %s", method)
+		}
+		if resp.Error != nil {
+			return nil, fmt.Errorf("%s failed: %s (code %d)", method, resp.Error.Message, resp.Error.Code)
+		}
+		if resp.Result == nil {
+			return nil, nil
+		}
+		return *resp.Result, nil
+	}
+}
+
+// failPending closes every waiting channel so Request calls return an error
+// rather than blocking forever once the connection is gone.
+func (c *Conn) failPending() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id, ch := range c.pending {
+		close(ch)
+		delete(c.pending, id)
+	}
+}
+
+func (c *Conn) write(msg any) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	_, err = c.w.Write(append(data, '\n'))
+	return err
+}
+
+// marshalParams keeps an already-encoded payload as-is and encodes anything
+// else, so callers may pass either.
+func marshalParams(params any) (json.RawMessage, error) {
+	if params == nil {
+		return nil, nil
+	}
+	if raw, ok := params.(json.RawMessage); ok {
+		return raw, nil
+	}
+	return json.Marshal(params)
+}
+
+// numericID normalises a JSON-RPC id to int64. Encoding a request turns the id
+// into a JSON number, and decoding the peer's response yields float64, so the
+// two must be reconciled before they can be matched.
+func numericID(id any) (int64, bool) {
+	switch v := id.(type) {
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	case float64:
+		return int64(v), true
+	case json.Number:
+		n, err := v.Int64()
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}

--- a/internal/acp/conn.go
+++ b/internal/acp/conn.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 	"sync"
 )
@@ -35,7 +37,16 @@ type Conn struct {
 	mu      sync.Mutex
 	nextID  int64
 	pending map[int64]chan *Response
+	// closed is set once Serve has stopped. Without it, a request registered
+	// after Serve returned would wait on a channel nothing will ever close,
+	// because failPending has already run. Guarded by mu, so registering and
+	// closing cannot interleave.
+	closed bool
 }
+
+// ErrConnClosed is returned by Request when the connection has stopped serving,
+// whether it was already down or dropped mid-call.
+var ErrConnClosed = errors.New("acp: connection closed")
 
 // NewConn creates a connection that reads from r, writes to w, and serves
 // inbound method calls out of registry.
@@ -174,6 +185,10 @@ func (c *Conn) Request(ctx context.Context, method string, params any) (json.Raw
 	}
 
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, fmt.Errorf("%s: %w", method, ErrConnClosed)
+	}
 	c.nextID++
 	id := c.nextID
 	ch := make(chan *Response, 1)
@@ -197,7 +212,7 @@ func (c *Conn) Request(ctx context.Context, method string, params any) (json.Raw
 		return nil, ctx.Err()
 	case resp := <-ch:
 		if resp == nil {
-			return nil, fmt.Errorf("connection closed while awaiting response to %s", method)
+			return nil, fmt.Errorf("awaiting response to %s: %w", method, ErrConnClosed)
 		}
 		if resp.Error != nil {
 			return nil, fmt.Errorf("%s failed: %s (code %d)", method, resp.Error.Message, resp.Error.Code)
@@ -214,6 +229,7 @@ func (c *Conn) Request(ctx context.Context, method string, params any) (json.Raw
 func (c *Conn) failPending() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.closed = true
 	for id, ch := range c.pending {
 		close(ch)
 		delete(c.pending, id)
@@ -246,6 +262,12 @@ func marshalParams(params any) (json.RawMessage, error) {
 // numericID normalises a JSON-RPC id to int64. Encoding a request turns the id
 // into a JSON number, and decoding the peer's response yields float64, so the
 // two must be reconciled before they can be matched.
+//
+// A float is accepted only when it is exactly an integer this side could have
+// sent. Truncating instead would be worse than refusing: an id of 1.5 would
+// become 1 and hand the peer's answer to whoever is waiting on request 1 — for
+// session/request_permission, an approval the user never gave, returned as a
+// valid result. Refusing merely drops a message no request is owed.
 func numericID(id any) (int64, bool) {
 	switch v := id.(type) {
 	case int64:
@@ -253,6 +275,12 @@ func numericID(id any) (int64, bool) {
 	case int:
 		return int64(v), true
 	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) || v != math.Trunc(v) {
+			return 0, false
+		}
+		if v < math.MinInt64 || v >= math.MaxInt64 {
+			return 0, false
+		}
 		return int64(v), true
 	case json.Number:
 		n, err := v.Int64()

--- a/internal/acp/conn.go
+++ b/internal/acp/conn.go
@@ -78,21 +78,29 @@ func NewConn(r io.Reader, w io.Writer, registry *CapabilityRegistry) *Conn {
 // fails. Every pending request is failed on exit so no caller is left waiting
 // on a connection that has gone away.
 func (c *Conn) Serve(ctx context.Context) error {
-	defer c.failPending()
-
-	notificationsDone := make(chan struct{})
 	go func() {
-		defer close(notificationsDone)
 		for n := range c.notifications {
 			if _, err := c.registry.Call(n.Method, n.Params); err != nil {
 				log.Printf("acp: notification %s failed: %v", n.Method, err)
 			}
 		}
 	}()
-	defer func() {
-		close(c.notifications)
-		<-notificationsDone
-	}()
+
+	// Defers run last-registered-first, and the order matters. failPending is
+	// registered last so it runs first: callers blocked in Request are released
+	// before anything else is torn down. Closing the notification channel then
+	// lets the worker drain and exit on its own.
+	//
+	// Serve deliberately does not wait for that worker. A handler that wedges
+	// would otherwise hold shutdown open indefinitely and keep every pending
+	// Request waiting on a connection that has already finished. Notifications
+	// are fire-and-forget, so letting the worker outlive Serve costs nothing;
+	// blocking on it costs the shutdown guarantee.
+	//
+	// The close is safe because only dispatch sends, and dispatch runs on this
+	// goroutine — once the loop below exits there are no further senders.
+	defer close(c.notifications)
+	defer c.failPending()
 
 	lines := make(chan []byte)
 	scanErr := make(chan error, 1)
@@ -134,14 +142,14 @@ func (c *Conn) Serve(ctx context.Context) error {
 			if len(line) == 0 {
 				continue
 			}
-			c.dispatch(line)
+			c.dispatch(ctx, line)
 		}
 	}
 }
 
 // dispatch routes one inbound message by shape: a method means the peer is
 // asking us something, no method means it is answering us.
-func (c *Conn) dispatch(line []byte) {
+func (c *Conn) dispatch(ctx context.Context, line []byte) {
 	var probe struct {
 		Method string `json:"method"`
 	}
@@ -152,14 +160,14 @@ func (c *Conn) dispatch(line []byte) {
 		c.routeResponse(line)
 		return
 	}
-	c.serveRequest(line)
+	c.serveRequest(ctx, line)
 }
 
 // serveRequest answers an inbound method call. It runs in its own goroutine so
 // a handler that itself calls Request — session/prompt asking the client for
 // permission mid-turn — does not deadlock against the read loop that would
 // carry the answer.
-func (c *Conn) serveRequest(line []byte) {
+func (c *Conn) serveRequest(ctx context.Context, line []byte) {
 	var req Request
 	if err := json.Unmarshal(line, &req); err != nil {
 		// The peer may still be waiting on an id we can recover. Answering is
@@ -184,7 +192,13 @@ func (c *Conn) serveRequest(line []byte) {
 		// outruns the handler the loop pauses, which is preferable to an
 		// unbounded goroutine per notification. Handlers must therefore not
 		// call Request, since that would wait on the loop they are blocking.
-		c.notifications <- req
+		// Cancellation-aware: if the peer outruns the handler *and* the
+		// connection is being torn down, an unconditional send would pin the
+		// read loop against a full channel that nothing will drain in time.
+		select {
+		case c.notifications <- req:
+		case <-ctx.Done():
+		}
 		return
 	}
 

--- a/internal/acp/conn_internal_test.go
+++ b/internal/acp/conn_internal_test.go
@@ -2,6 +2,7 @@ package acp
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,19 @@ func TestNumericID(t *testing.T) {
 		{"non-numeric json.Number", json.Number("seven"), 0, false},
 		{"string id is not correlatable here", "7", 0, false},
 		{"absent id", nil, 0, false},
+
+		// Truncation is worse than dropping. 1.5 must not become 1, or the
+		// peer's answer to request 1.5 is handed to whoever is waiting on
+		// request 1 — for session/request_permission that is an approval the
+		// user never gave, delivered as a valid result.
+		{"fractional must not truncate", 1.5, 0, false},
+		{"negative fractional must not truncate", -1.5, 0, false},
+		{"+Inf", math.Inf(1), 0, false},
+		{"-Inf", math.Inf(-1), 0, false},
+		{"NaN", math.NaN(), 0, false},
+		{"beyond int64 range", 1e19, 0, false},
+		{"integral float is fine", float64(7), 7, true},
+		{"fractional json.Number", json.Number("1.5"), 0, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got, ok := numericID(tc.in)

--- a/internal/acp/conn_internal_test.go
+++ b/internal/acp/conn_internal_test.go
@@ -1,0 +1,77 @@
+package acp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNumericID covers the type reconciliation that request/response
+// correlation depends on. Marshalling a request writes the id as a JSON number
+// and unmarshalling the peer's reply yields float64, so an id that survives the
+// round trip only matches if both forms normalise to the same key. The previous
+// dispatcher carried a whole normalizeID helper for this reason.
+func TestNumericID(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   any
+		want int64
+		ok   bool
+	}{
+		{"int64 as sent", int64(7), 7, true},
+		{"int", 7, 7, true},
+		{"float64 as decoded from JSON", float64(7), 7, true},
+		{"json.Number", json.Number("7"), 7, true},
+		{"non-numeric json.Number", json.Number("seven"), 0, false},
+		{"string id is not correlatable here", "7", 0, false},
+		{"absent id", nil, 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := numericID(tc.in)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestNumericIDRoundTripsThroughJSON is the case that actually bites: the id
+// this side writes must match the id that comes back after encode/decode.
+func TestNumericIDRoundTripsThroughJSON(t *testing.T) {
+	t.Parallel()
+
+	sent := Request{JSONRPC: "2.0", ID: int64(42), Method: "session/prompt"}
+	data, err := json.Marshal(sent)
+	require.NoError(t, err)
+
+	var back Response
+	require.NoError(t, json.Unmarshal(data, &back))
+
+	id, ok := numericID(back.ID)
+	require.True(t, ok, "an id must survive the wire round trip")
+	assert.Equal(t, int64(42), id, "otherwise responses correlate to nothing")
+}
+
+// TestMarshalParams pins that an already-encoded payload passes through
+// untouched rather than being double-encoded into a JSON string.
+func TestMarshalParams(t *testing.T) {
+	t.Parallel()
+
+	raw, err := marshalParams(json.RawMessage(`{"sessionId":"s1"}`))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"sessionId":"s1"}`, string(raw))
+
+	fromStruct, err := marshalParams(map[string]string{"sessionId": "s1"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"sessionId":"s1"}`, string(fromStruct))
+
+	none, err := marshalParams(nil)
+	require.NoError(t, err)
+	assert.Nil(t, none, "omitted params must stay absent, not become null")
+
+	_, err = marshalParams(make(chan int))
+	require.Error(t, err, "an unencodable payload must fail before it reaches the wire")
+}

--- a/internal/acp/conn_test.go
+++ b/internal/acp/conn_test.go
@@ -309,7 +309,7 @@ func TestConnRequestFailsWhenConnectionDrops(t *testing.T) {
 	select {
 	case err := <-errs:
 		require.Error(t, err, "a dropped connection must fail the caller, not strand it")
-		assert.Contains(t, err.Error(), "connection closed")
+		assert.ErrorIs(t, err, acp.ErrConnClosed)
 	case <-time.After(2 * time.Second):
 		t.Fatal("Request stranded after the connection dropped")
 	}
@@ -397,5 +397,35 @@ func TestConnRequestSurfacesPeerError(t *testing.T) {
 		assert.Contains(t, err.Error(), "path is required")
 	case <-time.After(2 * time.Second):
 		t.Fatal("peer error never surfaced")
+	}
+}
+
+// TestConnRequestAfterServeExitsFailsFast covers the window failPending alone
+// does not close: a request registered *after* Serve has already returned has
+// nothing left to fail it, so it waits on a channel no one will ever touch.
+// With a background context that is a permanent hang.
+func TestConnRequestAfterServeExitsFailsFast(t *testing.T) {
+	t.Parallel()
+
+	connR, peerW := io.Pipe()
+	c := acp.NewConn(connR, io.Discard, acp.NewCapabilityRegistry())
+
+	served := make(chan struct{})
+	go func() { defer close(served); _ = c.Serve(context.Background()) }()
+
+	require.NoError(t, peerW.Close())
+	<-served // Serve has exited and already run failPending.
+
+	errs := make(chan error, 1)
+	go func() {
+		_, err := c.Request(context.Background(), "session/request_permission", nil)
+		errs <- err
+	}()
+
+	select {
+	case err := <-errs:
+		require.Error(t, err, "a request on a dead connection must fail, not wait forever")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Request stranded: registered after Serve exited, so nothing will ever fail it")
 	}
 }

--- a/internal/acp/conn_test.go
+++ b/internal/acp/conn_test.go
@@ -482,3 +482,57 @@ func TestConnDeliversNotificationsInOrder(t *testing.T) {
 		}
 	}
 }
+
+// TestConnShutdownIsNotHeldByABlockedNotification pins that one wedged handler
+// cannot hold the whole connection open. The notification worker was drained
+// before failPending ran — defers are LIFO and failPending was registered first
+// — so a handler that never returns kept Serve from returning and left every
+// pending Request waiting on a connection that was already finished.
+func TestConnShutdownIsNotHeldByABlockedNotification(t *testing.T) {
+	t.Parallel()
+
+	wedged := make(chan struct{})
+	entered := make(chan struct{})
+	t.Cleanup(func() { close(wedged) })
+
+	registry := acp.NewCapabilityRegistry()
+	registry.RegisterMethod("session/update", func(json.RawMessage) (json.RawMessage, error) {
+		close(entered)
+		<-wedged // never returns while the test runs
+		return nil, nil
+	})
+
+	connR, peerW := io.Pipe()
+	c := acp.NewConn(connR, io.Discard, registry)
+	ctx, cancel := context.WithCancel(context.Background())
+	served := make(chan error, 1)
+	go func() { served <- c.Serve(ctx) }()
+
+	_, err := peerW.Write([]byte(`{"jsonrpc":"2.0","method":"session/update"}` + "\n"))
+	require.NoError(t, err)
+	<-entered // the handler is now wedged
+
+	// A caller is waiting on the peer when the connection is torn down.
+	errs := make(chan error, 1)
+	go func() {
+		_, err := c.Request(context.Background(), "session/request_permission", nil)
+		errs <- err
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-served:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve blocked on a wedged notification handler")
+	}
+
+	select {
+	case err := <-errs:
+		assert.ErrorIs(t, err, acp.ErrConnClosed,
+			"a pending caller must be released even when a handler is stuck")
+	case <-time.After(2 * time.Second):
+		t.Fatal("pending Request was never released")
+	}
+}

--- a/internal/acp/conn_test.go
+++ b/internal/acp/conn_test.go
@@ -1,0 +1,401 @@
+package acp_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/julianshen/rubichan/internal/acp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// peer is the far side of a Conn: it reads what the Conn writes and writes what
+// the Conn reads. Tests drive it directly, standing in for an editor.
+type peer struct {
+	toConn   *io.PipeWriter
+	fromConn *json.Decoder
+}
+
+// newConnPair wires a Conn to a peer over two pipes and serves the Conn until
+// the test ends.
+func newConnPair(t *testing.T, registry *acp.CapabilityRegistry) (*acp.Conn, *peer) {
+	t.Helper()
+
+	connR, peerW := io.Pipe()
+	peerR, connW := io.Pipe()
+
+	c := acp.NewConn(connR, connW, registry)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = c.Serve(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		_ = peerW.Close()
+		_ = connW.Close()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("Serve did not return after cancel")
+		}
+	})
+
+	return c, &peer{toConn: peerW, fromConn: json.NewDecoder(peerR)}
+}
+
+// TestConnRequestAwaitsPeerResponse is the capability the old transport could
+// not express: the agent originating a request and blocking on the client's
+// answer. session/request_permission is the reason it matters — a tool approval
+// is a round trip that happens *during* a turn, so a buffered request/response
+// server cannot carry it.
+func TestConnRequestAwaitsPeerResponse(t *testing.T) {
+	t.Parallel()
+
+	c, p := newConnPair(t, acp.NewCapabilityRegistry())
+
+	type reply struct {
+		result json.RawMessage
+		err    error
+	}
+	replies := make(chan reply, 1)
+	go func() {
+		res, err := c.Request(context.Background(), "session/request_permission",
+			map[string]any{"sessionId": "sess-1"})
+		replies <- reply{res, err}
+	}()
+
+	// The peer sees a well-formed JSON-RPC request carrying an ID.
+	var got acp.Request
+	p.decode(t, &got)
+	assert.Equal(t, "2.0", got.JSONRPC)
+	assert.Equal(t, "session/request_permission", got.Method)
+	require.NotNil(t, got.ID, "an agent-initiated request must be correlatable")
+
+	// The peer answers it.
+	_, err := p.toConn.Write(append(mustJSON(t, acp.Response{
+		JSONRPC: "2.0",
+		ID:      got.ID,
+		Result:  rawPtr(t, `{"outcome":{"outcome":"selected","optionId":"allow_once"}}`),
+	}), '\n'))
+	require.NoError(t, err)
+
+	select {
+	case r := <-replies:
+		require.NoError(t, r.err)
+		assert.JSONEq(t, `{"outcome":{"outcome":"selected","optionId":"allow_once"}}`, string(r.result))
+	case <-time.After(2 * time.Second):
+		t.Fatal("Request never returned; the response was not correlated back to the caller")
+	}
+}
+
+// decode reads one message from the Conn, failing the test rather than hanging
+// if none arrives. A dropped reply is a real failure mode here, so it must
+// surface as a failure and not a CI timeout.
+func (p *peer) decode(t *testing.T, v any) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- p.fromConn.Decode(v) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("no message from Conn within 2s")
+	}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+func rawPtr(t *testing.T, s string) *json.RawMessage {
+	t.Helper()
+	require.True(t, json.Valid([]byte(s)), "test fixture must be valid JSON")
+	raw := json.RawMessage(s)
+	return &raw
+}
+
+// TestConnServesInboundRequests is the other half of bidirectional dispatch:
+// the same loop that correlates our responses must also answer the peer's
+// calls. Without it a Conn could talk but not listen, which is the mirror of
+// the defect it replaces.
+func TestConnServesInboundRequests(t *testing.T) {
+	t.Parallel()
+
+	registry := acp.NewCapabilityRegistry()
+	registry.RegisterMethod("session/prompt", func(params json.RawMessage) (json.RawMessage, error) {
+		var got struct {
+			SessionID string `json:"sessionId"`
+		}
+		if err := json.Unmarshal(params, &got); err != nil {
+			return nil, err
+		}
+		return json.RawMessage(`{"stopReason":"end_turn","echo":"` + got.SessionID + `"}`), nil
+	})
+
+	_, p := newConnPair(t, registry)
+
+	_, err := p.toConn.Write(append(mustJSON(t, acp.Request{
+		JSONRPC: "2.0",
+		ID:      int64(7),
+		Method:  "session/prompt",
+		Params:  json.RawMessage(`{"sessionId":"sess-9"}`),
+	}), '\n'))
+	require.NoError(t, err)
+
+	var resp acp.Response
+	p.decode(t, &resp)
+	assert.Equal(t, float64(7), resp.ID, "the reply must carry the request's id")
+	require.Nil(t, resp.Error)
+	require.NotNil(t, resp.Result)
+	assert.JSONEq(t, `{"stopReason":"end_turn","echo":"sess-9"}`, string(*resp.Result))
+}
+
+// TestConnReportsUnknownInboundMethod pins that an unserved method produces a
+// JSON-RPC error rather than silence. A peer that gets no answer blocks; the
+// mode adapters deleted in #339 failed exactly this way, calling methods the
+// server never registered.
+func TestConnReportsUnknownInboundMethod(t *testing.T) {
+	t.Parallel()
+
+	_, p := newConnPair(t, acp.NewCapabilityRegistry())
+
+	_, err := p.toConn.Write(append(mustJSON(t, acp.Request{
+		JSONRPC: "2.0",
+		ID:      int64(3),
+		Method:  "agent/codeReview",
+	}), '\n'))
+	require.NoError(t, err)
+
+	var resp acp.Response
+	p.decode(t, &resp)
+	require.NotNil(t, resp.Error, "an unserved method must be reported, not ignored")
+	assert.Equal(t, acp.ErrorCodeMethodNotFound, resp.Error.Code)
+}
+
+// TestConnHandlerCanCallBackDuringRequest is the whole point of the slice.
+// While serving session/prompt, the handler asks the peer for permission and
+// waits for the answer — a round trip *inside* another round trip. The old
+// StdioTransport could not do this at all: its read loop was occupied handling
+// the outer request, so the inner reply could never be read, and the handler
+// would deadlock against the loop that was waiting for it to return.
+//
+// This is why serveRequest dispatches into a goroutine. Without that, this test
+// hangs.
+func TestConnHandlerCanCallBackDuringRequest(t *testing.T) {
+	t.Parallel()
+
+	registry := acp.NewCapabilityRegistry()
+	var c *acp.Conn
+	registry.RegisterMethod("session/prompt", func(_ json.RawMessage) (json.RawMessage, error) {
+		granted, err := c.Request(context.Background(), "session/request_permission",
+			map[string]any{"sessionId": "sess-1"})
+		if err != nil {
+			return nil, err
+		}
+		var out struct {
+			Outcome struct {
+				OptionID string `json:"optionId"`
+			} `json:"outcome"`
+		}
+		if err := json.Unmarshal(granted, &out); err != nil {
+			return nil, err
+		}
+		return json.RawMessage(`{"stopReason":"end_turn","granted":"` + out.Outcome.OptionID + `"}`), nil
+	})
+
+	c, p := newConnPair(t, registry)
+
+	// Client opens the turn.
+	_, err := p.toConn.Write(append(mustJSON(t, acp.Request{
+		JSONRPC: "2.0", ID: int64(1), Method: "session/prompt",
+	}), '\n'))
+	require.NoError(t, err)
+
+	// Mid-turn, the agent asks for permission.
+	var ask acp.Request
+	p.decode(t, &ask)
+	require.Equal(t, "session/request_permission", ask.Method,
+		"the agent must be able to originate a request while still serving one")
+	require.NotNil(t, ask.ID)
+
+	// Client answers.
+	_, err = p.toConn.Write(append(mustJSON(t, acp.Response{
+		JSONRPC: "2.0", ID: ask.ID,
+		Result: rawPtr(t, `{"outcome":{"outcome":"selected","optionId":"allow_once"}}`),
+	}), '\n'))
+	require.NoError(t, err)
+
+	// Only now does the turn complete, carrying the permission decision.
+	var done acp.Response
+	p.decode(t, &done)
+	assert.Equal(t, float64(1), done.ID, "the turn's own id, not the permission request's")
+	require.Nil(t, done.Error)
+	require.NotNil(t, done.Result)
+	assert.JSONEq(t, `{"stopReason":"end_turn","granted":"allow_once"}`, string(*done.Result))
+}
+
+// TestConnNotificationGetsNoReply pins the comment in serveRequest: a request
+// without an id is a notification, and answering one would put an unmatched
+// response on the wire that the peer's dispatcher would log and drop.
+func TestConnNotificationGetsNoReply(t *testing.T) {
+	t.Parallel()
+
+	called := make(chan struct{}, 1)
+	registry := acp.NewCapabilityRegistry()
+	registry.RegisterMethod("session/cancel", func(json.RawMessage) (json.RawMessage, error) {
+		called <- struct{}{}
+		return nil, nil
+	})
+
+	_, p := newConnPair(t, registry)
+
+	_, err := p.toConn.Write([]byte(`{"jsonrpc":"2.0","method":"session/cancel"}` + "\n"))
+	require.NoError(t, err)
+
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("notification was not delivered to its handler")
+	}
+
+	// Nothing should come back. Give the connection a moment to get it wrong.
+	replied := make(chan struct{})
+	go func() {
+		var any map[string]any
+		if err := p.fromConn.Decode(&any); err == nil {
+			close(replied)
+		}
+	}()
+	select {
+	case <-replied:
+		t.Fatal("a notification must not be answered")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestConnRequestFailsWhenConnectionDrops pins failPending. Without it a caller
+// blocked in Request waits forever on a stream that has already gone away —
+// the stranding failure this codebase has hit before.
+func TestConnRequestFailsWhenConnectionDrops(t *testing.T) {
+	t.Parallel()
+
+	connR, peerW := io.Pipe()
+	// io.Discard, not a pipe: an io.Pipe write blocks until something reads it,
+	// and this test never reads the Conn's output, so a pipe here would stall
+	// Request inside write() and never exercise the drop path at all.
+	c := acp.NewConn(connR, io.Discard, acp.NewCapabilityRegistry())
+
+	served := make(chan struct{})
+	go func() { defer close(served); _ = c.Serve(context.Background()) }()
+
+	errs := make(chan error, 1)
+	go func() {
+		_, err := c.Request(context.Background(), "session/request_permission", nil)
+		errs <- err
+	}()
+
+	// Let the request register before the stream ends.
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, peerW.Close())
+
+	select {
+	case err := <-errs:
+		require.Error(t, err, "a dropped connection must fail the caller, not strand it")
+		assert.Contains(t, err.Error(), "connection closed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Request stranded after the connection dropped")
+	}
+	<-served
+}
+
+// TestConnRequestHonoursContextCancellation covers the caller giving up — a
+// user pressing Ctrl-C at an approval prompt.
+func TestConnRequestHonoursContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	// Reads block forever (nothing is ever sent) and writes go nowhere, which is
+	// exactly the state a caller is in while waiting on an approval prompt.
+	blocked, stop := io.Pipe()
+	t.Cleanup(func() { _ = stop.Close() })
+	c := acp.NewConn(blocked, io.Discard, acp.NewCapabilityRegistry())
+	go func() { _ = c.Serve(context.Background()) }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errs := make(chan error, 1)
+	go func() {
+		_, err := c.Request(ctx, "session/request_permission", nil)
+		errs <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errs:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelling the context did not release Request")
+	}
+}
+
+// TestConnSurvivesMalformedInput pins that garbage on the wire does not kill
+// the loop. A connection that dies on one bad line takes the session with it.
+func TestConnSurvivesMalformedInput(t *testing.T) {
+	t.Parallel()
+
+	registry := acp.NewCapabilityRegistry()
+	registry.RegisterMethod("ping", func(json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`"pong"`), nil
+	})
+
+	_, p := newConnPair(t, registry)
+
+	_, err := p.toConn.Write([]byte("not json at all\n"))
+	require.NoError(t, err)
+	_, err = p.toConn.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n"))
+	require.NoError(t, err)
+
+	var resp acp.Response
+	p.decode(t, &resp)
+	require.NotNil(t, resp.Result)
+	assert.JSONEq(t, `"pong"`, string(*resp.Result))
+}
+
+// TestConnRequestSurfacesPeerError pins that a JSON-RPC error response becomes
+// a Go error rather than an empty success — the shape that let the deleted
+// adapters look like they worked.
+func TestConnRequestSurfacesPeerError(t *testing.T) {
+	t.Parallel()
+
+	c, p := newConnPair(t, acp.NewCapabilityRegistry())
+
+	errs := make(chan error, 1)
+	go func() {
+		_, err := c.Request(context.Background(), "fs/read_text_file", nil)
+		errs <- err
+	}()
+
+	var ask acp.Request
+	p.decode(t, &ask)
+	_, err := p.toConn.Write(append(mustJSON(t, acp.Response{
+		JSONRPC: "2.0", ID: ask.ID,
+		Error: &acp.RPCError{Code: acp.ErrorCodeInvalidParams, Message: "path is required"},
+	}), '\n'))
+	require.NoError(t, err)
+
+	select {
+	case err := <-errs:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path is required")
+	case <-time.After(2 * time.Second):
+		t.Fatal("peer error never surfaced")
+	}
+}

--- a/internal/acp/conn_test.go
+++ b/internal/acp/conn_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"strconv"
 	"testing"
 	"time"
 
@@ -269,8 +270,8 @@ func TestConnNotificationGetsNoReply(t *testing.T) {
 	// Nothing should come back. Give the connection a moment to get it wrong.
 	replied := make(chan struct{})
 	go func() {
-		var any map[string]any
-		if err := p.fromConn.Decode(&any); err == nil {
+		var reply map[string]any
+		if err := p.fromConn.Decode(&reply); err == nil {
 			close(replied)
 		}
 	}()
@@ -324,9 +325,19 @@ func TestConnRequestHonoursContextCancellation(t *testing.T) {
 	// Reads block forever (nothing is ever sent) and writes go nowhere, which is
 	// exactly the state a caller is in while waiting on an approval prompt.
 	blocked, stop := io.Pipe()
-	t.Cleanup(func() { _ = stop.Close() })
 	c := acp.NewConn(blocked, io.Discard, acp.NewCapabilityRegistry())
-	go func() { _ = c.Serve(context.Background()) }()
+	serveCtx, stopServe := context.WithCancel(context.Background())
+	served := make(chan struct{})
+	go func() { defer close(served); _ = c.Serve(serveCtx) }()
+	t.Cleanup(func() {
+		stopServe()
+		_ = stop.Close()
+		select {
+		case <-served:
+		case <-time.After(2 * time.Second):
+			t.Error("Serve did not return after cancel")
+		}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errs := make(chan error, 1)
@@ -427,5 +438,47 @@ func TestConnRequestAfterServeExitsFailsFast(t *testing.T) {
 		require.Error(t, err, "a request on a dead connection must fail, not wait forever")
 	case <-time.After(2 * time.Second):
 		t.Fatal("Request stranded: registered after Serve exited, so nothing will ever fail it")
+	}
+}
+
+// TestConnDeliversNotificationsInOrder pins that notifications arrive at their
+// handler in the order the peer sent them. session/update is a stream of turn
+// events — agent_message_chunk, tool_call, tool_call_update — so reordering
+// does not lose data, it renders the wrong turn. One goroutine per notification
+// leaves the order to the scheduler.
+func TestConnDeliversNotificationsInOrder(t *testing.T) {
+	t.Parallel()
+
+	const count = 50
+	seen := make(chan string, count)
+	registry := acp.NewCapabilityRegistry()
+	registry.RegisterMethod("session/update", func(params json.RawMessage) (json.RawMessage, error) {
+		var got struct {
+			Seq string `json:"seq"`
+		}
+		if err := json.Unmarshal(params, &got); err != nil {
+			return nil, err
+		}
+		seen <- got.Seq
+		return nil, nil
+	})
+
+	_, p := newConnPair(t, registry)
+
+	for i := 0; i < count; i++ {
+		_, err := p.toConn.Write([]byte(
+			`{"jsonrpc":"2.0","method":"session/update","params":{"seq":"` +
+				strconv.Itoa(i) + `"}}` + "\n"))
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < count; i++ {
+		select {
+		case got := <-seen:
+			require.Equal(t, strconv.Itoa(i), got,
+				"notification %d arrived out of order; a reordered session/update stream renders the wrong turn", i)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d of %d notifications were delivered", i, count)
+		}
 	}
 }


### PR DESCRIPTION
First slice of rebuilding `internal/acp` against the [real Agent Client Protocol](https://agentclientprotocol.com), following #338's audit and #339's deletion.

Adds `acp.Conn`. Nothing else changes; no production path is touched yet.

## Why this first

ACP is symmetric. A client sends `session/prompt`, and **while that turn is still running** the agent sends `session/update` notifications and `session/request_permission` requests *back* to the client. Everything else in the rebuild depends on that being possible.

The old design couldn't express it, and not by oversight:

```
StdioTransport.Start()      → read loop that serves inbound requests
ResponseDispatcher.Start()  → read loop that correlates our responses
```

Two loops, one stream. A process could serve requests **or** await its own responses, never both. `Conn` runs a single loop and demultiplexes on message shape — a `method` means the peer is asking, no `method` means the peer is answering.

## The load-bearing detail

`serveRequest` dispatches into a goroutine. A handler that calls `Request` *while serving a request* — which is exactly what mid-turn approval is — would otherwise deadlock against the very loop that has to deliver its answer.

`TestConnHandlerCanCallBackDuringRequest` **fails by hanging** without it. That's why it's a test and not a comment:

```
client → session/prompt ────────────────┐
         agent → session/request_permission
         client → {"optionId":"allow_once"}
client ← {"stopReason":"end_turn","granted":"allow_once"}
```

## Spec fidelity

Fetched from `agentclientprotocol.com` rather than written from memory. One thing that check earned: the schema page states `protocolVersion` is a **string**; the initialization page states it is a **single integer** identifying the major version, currently `1`. The integer is correct. That disagreement is exactly why slice 2 (`initialize`) will re-verify rather than trust these notes.

Also noted for later: the `ContentBlock` variant list came back partial, so the prompt payload must be re-checked against the schema before it's implemented.

## Behaviour pinned

| test | what it protects |
|---|---|
| `RequestAwaitsPeerResponse` | agent-originated request correlates back to its caller |
| `ServesInboundRequests` | the same loop still answers the peer |
| `ReportsUnknownInboundMethod` | unserved method → JSON-RPC error, not silence |
| `HandlerCanCallBackDuringRequest` | **mid-turn round trip** |
| `NotificationGetsNoReply` | no id → no response on the wire |
| `RequestFailsWhenConnectionDrops` | dropped stream fails callers rather than stranding them |
| `RequestHonoursContextCancellation` | Ctrl-C at an approval prompt releases the caller |
| `SurvivesMalformedInput` | one bad line doesn't kill the session |
| `RequestSurfacesPeerError` | JSON-RPC error → Go error, not empty success |

Two behaviours are carried over deliberately from the old dispatcher because both were real: id normalisation (marshalling writes a JSON number, unmarshalling the reply yields `float64`) and failing pending requests on drop.

## Verification

`conn.go` averages **93.5% statement coverage** across its functions; the whole package is race-clean under `-race`. Full suite failure list identical to baseline. `go build`, `go vet`, `gofmt` clean.

Two tests initially failed, and both were **harness** bugs rather than defects: an `io.Pipe` write blocks until read, so a `Conn` whose output nothing reads stalls inside `write()` before reaching its `select`. Both now write to `io.Discard`. The peer helper decodes with a timeout, so a dropped reply fails in two seconds rather than hanging CI — the first version of those tests hung, which is a bad test even when it's a correct Red.

## What this does *not* do

`Conn` does **not** yet replace `StdioTransport`, `ResponseDispatcher` or `Server`. It calls the registry directly and does not serve `initialize` or `shutdown`, so it isn't a full substitute until slice 2 adds them.

I'm flagging that plainly because shipping a second transport alongside the old one is the exact pattern #338 and #339 spent two PRs deleting. The difference is intent and a stated end date: the old trio goes in slice 2, not "eventually". If you'd rather not carry two transports even for one slice, say so and I'll fold the removal in here instead.

## For reviewers

- **The goroutine in `serveRequest` is the risky part.** It means handlers run concurrently and out of order. ACP permits that, but if any handler assumes serialisation it will now be wrong.
- **`routeResponse` drops responses with no waiter.** That's deliberate — duplicate or post-timeout replies — but it means a correlation bug would manifest as silence, which is the failure mode this whole campaign keeps rediscovering. Worth deciding whether it should log.
- **Ids are per-connection and monotonic.** If a peer echoes an id we never sent, we ignore it; if it reuses one still pending, the first waiter wins.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bidirectional ACP communication over a single connection.
  * Supports requests, responses, notifications, callbacks, cancellation, and connection shutdown.
  * Provides clear handling for unknown methods, malformed messages, and peer-reported errors.

* **Tests**
  * Added comprehensive coverage for request handling, callbacks, notifications, cancellations, connection failures, malformed input, and parameter encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->