### PR TITLE
Make Conversation safe for concurrent use, and get internal/agent race-clean

### DIFF
--- a/internal/agent/activity_summarizer_test.go
+++ b/internal/agent/activity_summarizer_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -38,13 +37,20 @@ func TestSummaryHandleStop(t *testing.T) {
 func TestStartAgentSummarization(t *testing.T) {
 	oldInterval := summaryInterval
 	summaryInterval = 50 * time.Millisecond
-	defer func() { summaryInterval = oldInterval }()
+	// Restored via Cleanup rather than defer so it is ordered against the
+	// summarizer's Stop, which is also a Cleanup. Cleanups run last-registered
+	// first, so registering the restore here and Stop below means Stop wins:
+	// the summarizer is halted before the global it reads is written back. A
+	// defer would run before every Cleanup and restore the interval underneath
+	// a still-running scheduleNext.
+	t.Cleanup(func() { summaryInterval = oldInterval })
 
-	// The summarizer invokes onSummary from its own goroutine, so the capture
-	// it writes needs a lock. time.Sleep below orders the two in wall-clock
-	// terms but establishes no happens-before edge.
-	var mu sync.Mutex
-	var summaryReceived string
+	// The summarizer invokes onSummary from its own goroutine. A buffered
+	// channel both carries the value and supplies the happens-before edge, so
+	// the test waits for the callback to actually run instead of sleeping and
+	// hoping. Buffered and non-blocking to send, so a late tick after the
+	// assertion cannot wedge the summarizer goroutine.
+	received := make(chan string, 4)
 	callModel := func(ctx context.Context, messages []provider.Message, systemPrompt string) (string, error) {
 		return "Reading test.go", nil
 	}
@@ -56,21 +62,23 @@ func TestStartAgentSummarization(t *testing.T) {
 		}
 	}
 	onSummary := func(taskID, summary string) {
-		mu.Lock()
-		defer mu.Unlock()
-		summaryReceived = summary
+		select {
+		case received <- summary:
+		default:
+		}
 	}
 
 	handle := StartAgentSummarization("task-1", callModel, "system", getMessages, onSummary)
 	require.NotNil(t, handle)
+	// Registered before the assertion so a failure still stops the summarizer.
+	t.Cleanup(handle.Stop)
 
-	time.Sleep(150 * time.Millisecond)
-	mu.Lock()
-	got := summaryReceived
-	mu.Unlock()
-	require.Equal(t, "Reading test.go", got)
-
-	handle.Stop()
+	select {
+	case got := <-received:
+		require.Equal(t, "Reading test.go", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("summarizer produced no summary")
+	}
 }
 
 func TestSummarizerNotEnoughMessages(t *testing.T) {
@@ -151,7 +159,9 @@ func TestFilterIncompleteToolCallsNoToolUse(t *testing.T) {
 func TestSummarizerPreviousSummaryTracking(t *testing.T) {
 	oldInterval := summaryInterval
 	summaryInterval = 50 * time.Millisecond
-	defer func() { summaryInterval = oldInterval }()
+	// Cleanup, not defer — see TestStartAgentSummarization for why the ordering
+	// against handle.Stop matters.
+	t.Cleanup(func() { summaryInterval = oldInterval })
 
 	callCount := 0
 	callModel := func(ctx context.Context, messages []provider.Message, systemPrompt string) (string, error) {
@@ -169,25 +179,30 @@ func TestSummarizerPreviousSummaryTracking(t *testing.T) {
 		}
 	}
 
-	// Same as above: onSummary runs on the summarizer's goroutine.
-	var mu sync.Mutex
-	var summaries []string
+	// Same as above: onSummary runs on the summarizer's goroutine, so the test
+	// waits for two callbacks to actually complete rather than sleeping for a
+	// duration it hopes is long enough.
+	received := make(chan string, 8)
 	onSummary := func(taskID, summary string) {
-		mu.Lock()
-		defer mu.Unlock()
-		summaries = append(summaries, summary)
+		select {
+		case received <- summary:
+		default:
+		}
 	}
 
 	handle := StartAgentSummarization("task-1", callModel, "system", getMessages, onSummary)
 	require.NotNil(t, handle)
+	t.Cleanup(handle.Stop)
 
-	time.Sleep(200 * time.Millisecond)
-	mu.Lock()
-	got := append([]string(nil), summaries...)
-	mu.Unlock()
-	require.GreaterOrEqual(t, len(got), 2)
+	var got []string
+	for len(got) < 2 {
+		select {
+		case s := <-received:
+			got = append(got, s)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d summaries arrived, want 2", len(got))
+		}
+	}
 	require.Equal(t, "First summary", got[0])
 	require.Equal(t, "Second summary", got[1])
-
-	handle.Stop()
 }

--- a/internal/agent/activity_summarizer_test.go
+++ b/internal/agent/activity_summarizer_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,6 +40,10 @@ func TestStartAgentSummarization(t *testing.T) {
 	summaryInterval = 50 * time.Millisecond
 	defer func() { summaryInterval = oldInterval }()
 
+	// The summarizer invokes onSummary from its own goroutine, so the capture
+	// it writes needs a lock. time.Sleep below orders the two in wall-clock
+	// terms but establishes no happens-before edge.
+	var mu sync.Mutex
 	var summaryReceived string
 	callModel := func(ctx context.Context, messages []provider.Message, systemPrompt string) (string, error) {
 		return "Reading test.go", nil
@@ -51,6 +56,8 @@ func TestStartAgentSummarization(t *testing.T) {
 		}
 	}
 	onSummary := func(taskID, summary string) {
+		mu.Lock()
+		defer mu.Unlock()
 		summaryReceived = summary
 	}
 
@@ -58,7 +65,10 @@ func TestStartAgentSummarization(t *testing.T) {
 	require.NotNil(t, handle)
 
 	time.Sleep(150 * time.Millisecond)
-	require.Equal(t, "Reading test.go", summaryReceived)
+	mu.Lock()
+	got := summaryReceived
+	mu.Unlock()
+	require.Equal(t, "Reading test.go", got)
 
 	handle.Stop()
 }
@@ -159,8 +169,12 @@ func TestSummarizerPreviousSummaryTracking(t *testing.T) {
 		}
 	}
 
+	// Same as above: onSummary runs on the summarizer's goroutine.
+	var mu sync.Mutex
 	var summaries []string
 	onSummary := func(taskID, summary string) {
+		mu.Lock()
+		defer mu.Unlock()
 		summaries = append(summaries, summary)
 	}
 
@@ -168,9 +182,12 @@ func TestSummarizerPreviousSummaryTracking(t *testing.T) {
 	require.NotNil(t, handle)
 
 	time.Sleep(200 * time.Millisecond)
-	require.GreaterOrEqual(t, len(summaries), 2)
-	require.Equal(t, "First summary", summaries[0])
-	require.Equal(t, "Second summary", summaries[1])
+	mu.Lock()
+	got := append([]string(nil), summaries...)
+	mu.Unlock()
+	require.GreaterOrEqual(t, len(got), 2)
+	require.Equal(t, "First summary", got[0])
+	require.Equal(t, "Second summary", got[1])
 
 	handle.Stop()
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1179,7 +1179,25 @@ func (a *Agent) ContextWindowStatus() ContextWindowStatus {
 
 // ForceCompact triggers manual compaction and returns before/after metrics.
 // The error return is always nil currently — reserved for future strategy errors.
+//
+// It waits for any turn in flight. Compaction is a read-modify-write across two
+// Conversation calls — snapshot with Messages, transform, replace with
+// LoadFromMessages — and Conversation's lock makes each of those atomic without
+// making the trio one transaction. A message appended by the turn goroutine
+// between the snapshot and the write-back is not in the snapshot, so the
+// write-back destroys it. /compact is reachable from the TUI and the CLI during
+// a turn, which makes that a user-visible way to lose an assistant reply.
+//
+// Blocking rather than failing keeps this consistent with every other external
+// mutator here — Clear and the session/model setters all take turnMu.
+//
+// This must not be applied to agentCompactor.ForceCompact: that backs the
+// compact_context tool, which the model invokes during tool execution, on the
+// turn goroutine, while turnMu is already held. Taking the lock there would
+// self-deadlock and hang the turn forever holding it.
 func (a *Agent) ForceCompact(ctx context.Context) (agentsdk.CompactResult, error) {
+	a.turnMu.Lock()
+	defer a.turnMu.Unlock()
 	result := a.context.ForceCompact(ctx, a.conversation)
 	return result, nil
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1319,12 +1319,13 @@ func TestRunLoop_MaxTokens_WithToolCalls_DoesNotRetry(t *testing.T) {
 	assert.Equal(t, 0, recoveryEvents, "should not emit recovery events when max_tokens has tool calls")
 }
 
-type maxTokensWithToolProvider struct {
-	callCount int
-}
+// maxTokensWithToolProvider carries no call counter on purpose. Stream is
+// reached from the turn goroutine and, concurrently, from the background
+// session-memory task, so an unsynchronized field here races — and this test
+// asserts on emitted recovery events, never on a count.
+type maxTokensWithToolProvider struct{}
 
 func (m *maxTokensWithToolProvider) Stream(_ context.Context, _ provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
-	m.callCount++
 	ch := make(chan provider.StreamEvent, 4)
 	ch <- provider.StreamEvent{Type: "text_delta", Text: "partial response"}
 	ch <- provider.StreamEvent{

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -167,14 +167,14 @@ func (cm *ContextManager) Compact(ctx context.Context, conv *Conversation) error
 		messageBudget = 0
 	}
 	// Compute signals once; inject into strategies that support dynamic adjustment.
-	signals := ComputeConversationSignals(conv.messages)
+	signals := ComputeConversationSignals(conv.Messages())
 	for _, s := range cm.strategies {
 		if sa, ok := s.(SignalAware); ok {
 			sa.SetSignals(signals)
 		}
 	}
 
-	beforeTokens := estimateMessageTokens(conv.messages)
+	beforeTokens := estimateMessageTokens(conv.Messages())
 	anyStrategySucceeded := false
 
 	for i, s := range cm.strategies {
@@ -183,20 +183,20 @@ func (cm *ContextManager) Compact(ctx context.Context, conv *Conversation) error
 		if i > 0 && !cm.ExceedsBudget(conv) {
 			break
 		}
-		result, err := s.Compact(ctx, conv.messages, messageBudget)
+		result, err := s.Compact(ctx, conv.Messages(), messageBudget)
 		if err != nil {
 			continue
 		}
-		conv.messages = result
+		conv.LoadFromMessages(result)
 		anyStrategySucceeded = true
 	}
 
 	// Apply collapse store projection after strategies run.
 	if cm.collapseStore != nil && cm.collapseStore.IsEnabled() && cm.collapseStore.HasCommits() {
-		conv.messages = cm.collapseStore.ProjectView(conv.messages)
+		conv.LoadFromMessages(cm.collapseStore.ProjectView(conv.Messages()))
 	}
 
-	afterTokens := estimateMessageTokens(conv.messages)
+	afterTokens := estimateMessageTokens(conv.Messages())
 	shrank := afterTokens < beforeTokens
 
 	// Real progress requires BOTH a non-erroring strategy AND an actual
@@ -219,7 +219,7 @@ func (cm *ContextManager) Compact(ctx context.Context, conv *Conversation) error
 // a ~4 chars per token heuristic with +10 overhead per content block.
 func (cm *ContextManager) EstimateTokens(conv *Conversation) int {
 	total := len(conv.SystemPrompt())/4 + 10
-	total += estimateMessageTokens(conv.messages)
+	total += estimateMessageTokens(conv.Messages())
 	return total
 }
 
@@ -253,7 +253,7 @@ func (cm *ContextManager) MeasureUsage(conv *Conversation, systemPrompt, skillPr
 		toolTokens += len(td.Name)/4 + len(td.Description)/4 + len(td.InputSchema)/4 + 30
 	}
 
-	convTokens := estimateMessageTokens(conv.messages)
+	convTokens := estimateMessageTokens(conv.Messages())
 
 	cm.mu.Lock()
 	cm.budget.SkillPrompts = skillTokens
@@ -284,10 +284,10 @@ func (cm *ContextManager) Budget() ContextBudget {
 func (cm *ContextManager) ForceCompact(ctx context.Context, conv *Conversation) CompactResult {
 	result := CompactResult{
 		BeforeTokens:   cm.EstimateTokens(conv),
-		BeforeMsgCount: len(conv.messages),
+		BeforeMsgCount: conv.Len(),
 	}
 
-	if len(conv.messages) == 0 {
+	if conv.Len() == 0 {
 		result.AfterTokens = cm.EstimateTokens(conv)
 		result.AfterMsgCount = 0
 		return result
@@ -301,7 +301,7 @@ func (cm *ContextManager) ForceCompact(ctx context.Context, conv *Conversation) 
 		messageBudget = 0
 	}
 
-	signals := ComputeConversationSignals(conv.messages)
+	signals := ComputeConversationSignals(conv.Messages())
 	for _, s := range cm.strategies {
 		if sa, ok := s.(SignalAware); ok {
 			sa.SetSignals(signals)
@@ -309,9 +309,9 @@ func (cm *ContextManager) ForceCompact(ctx context.Context, conv *Conversation) 
 	}
 
 	for _, s := range cm.strategies {
-		tokensBefore := estimateMessageTokens(conv.messages)
-		countBefore := len(conv.messages)
-		msgs, err := s.Compact(ctx, conv.messages, messageBudget)
+		tokensBefore := estimateMessageTokens(conv.Messages())
+		countBefore := conv.Len()
+		msgs, err := s.Compact(ctx, conv.Messages(), messageBudget)
 		if err != nil {
 			continue
 		}
@@ -321,7 +321,7 @@ func (cm *ContextManager) ForceCompact(ctx context.Context, conv *Conversation) 
 			result.StrategiesRun = append(result.StrategiesRun, s.Name())
 		}
 		// If strategy supports Snip, capture the result for telemetry.
-		// Use msgs (post-Compact) rather than conv.messages (pre-Compact)
+		// Use msgs (post-Compact) rather than conv.Messages() (pre-Compact)
 		// to ensure SnipResult reflects the actual compacted state.
 		if snipper, ok := s.(interface {
 			Snip([]Message, int) SnipResult
@@ -331,16 +331,16 @@ func (cm *ContextManager) ForceCompact(ctx context.Context, conv *Conversation) 
 				result.SnipResults = append(result.SnipResults, snip)
 			}
 		}
-		conv.messages = msgs
+		conv.LoadFromMessages(msgs)
 	}
 
 	// Apply collapse store projection.
 	if cm.collapseStore != nil && cm.collapseStore.IsEnabled() && cm.collapseStore.HasCommits() {
-		conv.messages = cm.collapseStore.ProjectView(conv.messages)
+		conv.LoadFromMessages(cm.collapseStore.ProjectView(conv.Messages()))
 	}
 
 	result.AfterTokens = cm.EstimateTokens(conv)
-	result.AfterMsgCount = len(conv.messages)
+	result.AfterMsgCount = conv.Len()
 	return result
 }
 

--- a/internal/agent/conversation.go
+++ b/internal/agent/conversation.go
@@ -42,6 +42,18 @@ func (c *Conversation) SystemPrompt() string {
 }
 
 // Messages returns a copy of all messages in the conversation.
+//
+// The copy is shallow: the returned slice is independent, but each message's
+// Content slice and Metadata map still alias the conversation's own. Callers
+// must treat everything reachable from a returned Message as read-only. A
+// caller that mutates a Content element or a Metadata entry writes through to
+// the conversation, outside c.mu, and races every other holder of that message.
+//
+// This is an ownership rule the type states rather than enforces. Deep-cloning
+// each message at every egress would enforce it, at the cost of copying every
+// content block on a path that runs before each LLM request — and no current
+// reader mutates. If that stops being true, clone at ingress and egress rather
+// than hoping.
 func (c *Conversation) Messages() []provider.Message {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/internal/agent/conversation.go
+++ b/internal/agent/conversation.go
@@ -1,12 +1,30 @@
 package agent
 
 import (
+	"sync"
+
 	"github.com/julianshen/rubichan/internal/provider"
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 )
 
 // Conversation manages the message history for an agent session.
+//
+// It is safe for concurrent use. That is a requirement, not a courtesy: a turn
+// runs its loop on its own goroutine while the periodic summarizer reads the
+// same conversation from a timer goroutine, so reads and writes genuinely
+// overlap for the length of every turn.
+//
+// The lock makes each method atomic, which is what memory safety needs. It
+// does not make a read-then-write pair across two calls atomic — a caller that
+// reads Messages, transforms them and writes them back can still lose a
+// concurrent append in between. Compaction does exactly that, and is safe today
+// only because it runs before the turn goroutine starts. Anything new that
+// mutates from a second goroutine needs a method that holds the lock across the
+// whole operation, not two calls in a row.
 type Conversation struct {
+	// mu guards messages. systemPrompt is written once by NewConversation and
+	// never again, so SystemPrompt reads it without locking.
+	mu           sync.RWMutex
 	systemPrompt string
 	messages     []provider.Message
 }
@@ -25,6 +43,8 @@ func (c *Conversation) SystemPrompt() string {
 
 // Messages returns a copy of all messages in the conversation.
 func (c *Conversation) Messages() []provider.Message {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	cp := make([]provider.Message, len(c.messages))
 	copy(cp, c.messages)
 	return cp
@@ -32,16 +52,22 @@ func (c *Conversation) Messages() []provider.Message {
 
 // Len returns the number of messages without allocating a copy.
 func (c *Conversation) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return len(c.messages)
 }
 
 // AddUser appends a user message to the conversation.
 func (c *Conversation) AddUser(text string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.messages = append(c.messages, provider.NewUserMessage(text))
 }
 
 // AddAssistant appends an assistant message with the given content blocks.
 func (c *Conversation) AddAssistant(blocks []provider.ContentBlock) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.messages = append(c.messages, provider.Message{
 		Role:    "assistant",
 		Content: blocks,
@@ -50,6 +76,8 @@ func (c *Conversation) AddAssistant(blocks []provider.ContentBlock) {
 
 // AddToolResult appends a tool result message to the conversation.
 func (c *Conversation) AddToolResult(toolUseID, content string, isError bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.messages = append(c.messages, provider.NewToolResultMessage(toolUseID, content, isError))
 }
 
@@ -59,6 +87,8 @@ func (c *Conversation) AddSystem(text string) {
 	if text == "" {
 		return
 	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.messages = append(c.messages, provider.Message{
 		Role:    "system",
 		Content: []provider.ContentBlock{{Type: "text", Text: text}},
@@ -68,6 +98,8 @@ func (c *Conversation) AddSystem(text string) {
 // LoadFromMessages replaces the current message history with the given messages.
 // The system prompt is preserved. This is used when resuming a saved session.
 func (c *Conversation) LoadFromMessages(msgs []provider.Message) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.messages = make([]provider.Message, len(msgs))
 	copy(c.messages, msgs)
 }
@@ -77,6 +109,8 @@ func (c *Conversation) LoadFromMessages(msgs []provider.Message) {
 // slice to avoid retaining the drained messages in the backing array.
 // Ensures the kept slice starts on a non-tool_result boundary.
 func (c *Conversation) DrainMessages(minPairsToKeep int) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if len(c.messages) <= minPairsToKeep*2 {
 		return false
 	}
@@ -98,6 +132,8 @@ func (c *Conversation) DrainMessages(minPairsToKeep int) bool {
 
 // Clear removes all messages but preserves the system prompt.
 func (c *Conversation) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.messages = nil
 }
 
@@ -106,6 +142,15 @@ func (c *Conversation) Clear() {
 // (preserving indices for history) but their content is replaced
 // with a marker and skipped when building API requests.
 func (c *Conversation) Tombstone(startIdx, endIdx int, reason agentsdk.TombstoneReason) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tombstoneLocked(startIdx, endIdx, reason)
+}
+
+// tombstoneLocked is Tombstone's body, split out because
+// TombstoneSinceLastAssistant needs it while already holding the lock and Go's
+// mutexes are not reentrant.
+func (c *Conversation) tombstoneLocked(startIdx, endIdx int, reason agentsdk.TombstoneReason) {
 	if startIdx < 0 {
 		startIdx = 0
 	}
@@ -132,11 +177,19 @@ func (c *Conversation) Tombstone(startIdx, endIdx int, reason agentsdk.Tombstone
 // non-tombstoned assistant message. Used when model fallback occurs
 // mid-stream to prevent partial responses from polluting the fallback
 // model's context.
+//
+// The scan and the write happen under one lock. Splitting them would let a
+// concurrent append land between choosing the boundary and applying it, and the
+// new message would be tombstoned despite arriving after the failure this is
+// cleaning up.
 func (c *Conversation) TombstoneSinceLastAssistant(reason agentsdk.TombstoneReason) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	// Find the last complete assistant message
 	lastAssistantIdx := -1
 	for i := len(c.messages) - 1; i >= 0; i-- {
-		if c.messages[i].Role == "assistant" && !c.isTombstoned(i) {
+		if c.messages[i].Role == "assistant" && !c.isTombstonedLocked(i) {
 			lastAssistantIdx = i
 			break
 		}
@@ -144,20 +197,21 @@ func (c *Conversation) TombstoneSinceLastAssistant(reason agentsdk.TombstoneReas
 
 	if lastAssistantIdx < 0 {
 		// No complete assistant message — tombstone everything
-		c.Tombstone(0, len(c.messages), reason)
+		c.tombstoneLocked(0, len(c.messages), reason)
 		return len(c.messages)
 	}
 
 	// Tombstone messages after the last assistant
 	startIdx := lastAssistantIdx + 1
-	c.Tombstone(startIdx, len(c.messages), reason)
+	c.tombstoneLocked(startIdx, len(c.messages), reason)
 	return len(c.messages) - startIdx
 }
 
-// isTombstoned reports whether the message at idx is tombstoned.
+// isTombstonedLocked reports whether the message at idx is tombstoned.
 // Out-of-bounds and empty-content messages are conservatively treated
 // as not tombstoned to avoid false positives during filtering.
-func (c *Conversation) isTombstoned(idx int) bool {
+// Callers must hold c.mu.
+func (c *Conversation) isTombstonedLocked(idx int) bool {
 	if idx < 0 || idx >= len(c.messages) {
 		return false
 	}

--- a/internal/agent/conversation_test.go
+++ b/internal/agent/conversation_test.go
@@ -1,10 +1,14 @@
 package agent
 
 import (
+	"context"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/julianshen/rubichan/internal/config"
 	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -158,4 +162,58 @@ func TestConversationIsSafeForConcurrentUse(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+// TestForceCompactWaitsForActiveTurn pins that user-initiated compaction is
+// serialized with the turn goroutine.
+//
+// Conversation's lock makes each method atomic, which stops the memory race but
+// not a lost update: ContextManager.ForceCompact reads a snapshot with
+// Messages(), transforms it, and writes it back with LoadFromMessages(). A
+// message appended between those two calls is absent from the snapshot and is
+// destroyed by the write-back. /compact is reachable from the TUI and the CLI
+// while a turn is running, so this is a user-visible way to lose an assistant
+// reply.
+//
+// Every other external mutator — Clear, and the session/model setters — already
+// takes turnMu. ForceCompact was the one that did not.
+//
+// Note this deliberately does not apply to agentCompactor.ForceCompact, which
+// backs the compact_context tool. That runs during tool execution, on the turn
+// goroutine, while turnMu is already held; taking it there would self-deadlock.
+func TestForceCompactWaitsForActiveTurn(t *testing.T) {
+	cfg := &config.Config{
+		Provider: config.ProviderConfig{Model: "test-model"},
+		Agent:    config.AgentConfig{MaxTurns: 5, ContextBudget: 100000},
+	}
+	a := New(&mockProvider{events: []provider.StreamEvent{
+		{Type: "text_delta", Text: "ok"},
+		{Type: "stop"},
+	}}, tools.NewRegistry(), autoApprove, cfg)
+
+	// Stand in for a turn in flight: Turn holds turnMu from before it spawns
+	// its goroutine until that goroutine's deferred unlock.
+	a.turnMu.Lock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = a.ForceCompact(context.Background())
+	}()
+
+	select {
+	case <-done:
+		a.turnMu.Unlock()
+		t.Fatal("ForceCompact completed while a turn held turnMu: an append racing its " +
+			"read-modify-write would be silently discarded")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	a.turnMu.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ForceCompact did not proceed once the turn released turnMu")
+	}
 }

--- a/internal/agent/conversation_test.go
+++ b/internal/agent/conversation_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/julianshen/rubichan/internal/provider"
@@ -122,4 +123,39 @@ func TestConversationClear(t *testing.T) {
 
 	assert.Empty(t, conv.Messages())
 	assert.Equal(t, "my system prompt", conv.SystemPrompt(), "system prompt should be preserved after clear")
+}
+
+// TestConversationIsSafeForConcurrentUse pins that a Conversation may be read
+// while it is being written.
+//
+// This is not a hypothetical pairing invented to justify a lock. Agent.Turn
+// runs its loop on its own goroutine, and for the length of that turn the
+// periodic summarizer reads the same Conversation from a timer goroutine —
+// see the closure passed to StartAgentSummarization in agent.go, which calls
+// conversation.Messages(). Writer and reader are both production code, and
+// they overlap by design.
+func TestConversationIsSafeForConcurrentUse(t *testing.T) {
+	conv := NewConversation("system")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			conv.AddAssistant([]provider.ContentBlock{{Type: "text", Text: "reply"}})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			// Messages copies, so a torn read here corrupts the copy the
+			// summarizer is about to send to the model, not just this test.
+			_ = conv.Messages()
+			_ = conv.Len()
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
Fixes the data race I found while working #345 and flagged there as deserving its own PR.

Tidy-First: the encapsulation the lock depends on, then the lock, then the test defects that were keeping `-race` red independently, then the review fixes.

| | |
|---|---|
| `28c2fdd` `[STRUCTURAL]` | Encapsulate Field: route `context.go` through `Conversation`&#39;s API |
| `704cfc3` `[BEHAVIORAL]` | Make `Conversation` safe for concurrent use |
| `b193356` `[BEHAVIORAL]` | Fix three test-only races that kept `-race` red |
| `d0107cd` `[BEHAVIORAL]` | Serialize user-initiated compaction with the active turn |
| `2e5ed40` `[BEHAVIORAL]` | Wait for the summarizer callback instead of sleeping for it |
| `da5b8a8` `[STRUCTURAL]` | State `Messages`&#39; ownership rule on the method that hands it out |

## What I described in #345 was one race out of three

I reported this as &#34;a data race between `AddAssistant` and `Messages`, roughly 1 run in 5.&#34; A single `-race` run on `main` produces **three** races, and only one is that pair. The other two are in `activity_summarizer_test.go` and are a different defect entirely. The description was accurate about the race I&#39;d looked at and wrong about the state of the package.

## The production race is real, and the test isn&#39;t at fault

`agent.go` hands the periodic summarizer a closure that calls `a.conversation.Messages()`, and the summarizer runs it on a timer goroutine. Meanwhile `Agent.Turn` runs its loop — and `AddAssistant` — on a goroutine of its own. Both are production code, and they overlap for the length of every turn where summarization is on. `Conversation` had no synchronization whatsoever.

## Why the lock needed a structural commit first

`ContextManager` reached past `Conversation`&#39;s methods into `conv.messages` directly at **19 sites, three of them writes**. A mutex inside `Conversation`&#39;s methods would have guarded nothing against the busiest caller in the package. So `28c2fdd` routes those through `Messages()`/`Len()`/`LoadFromMessages()` with no behaviour change — tests pass identically before and after — and only then does the lock mean something.

## Two things the obvious patch gets wrong

**Go&#39;s mutexes are not reentrant.** `TombstoneSinceLastAssistant` calls both `Tombstone` and `isTombstoned`. Locking each in place deadlocks the model-fallback path. Both bodies are split into `*Locked` variants, and the scan and write now happen under **one** lock — splitting them would let a message arriving after the failure be tombstoned by the cleanup for that failure.

**`systemPrompt` doesn&#39;t need the lock.** It&#39;s written once by `NewConversation` and never again; the two `systemPrompt` writes in `agent.go` are to a local variable, not this field. `SystemPrompt()` stays lock-free.

## The lost update the lock does *not* fix — found in review, fixed in `d0107cd`

Each method is atomic. A read-then-write **pair across two calls** is not, and `ContextManager.ForceCompact` is exactly that: snapshot via `Messages()`, transform, replace via `LoadFromMessages()`. A message the turn goroutine appends in between is absent from the snapshot, so the write-back destroys it. `/compact` is reachable from the TUI and the CLI mid-turn, making this a user-visible way to lose an assistant reply.

I originally scoped this out as a design call. CodeRabbit pushed back, correctly. `Agent.ForceCompact` now takes `turnMu` — which is what `Clear` and the session/model setters already do — so external compaction waits for the turn.

**It is deliberately not applied to `agentCompactor.ForceCompact`**, which the review also asked for. That backs the `compact_context` tool, invoked by the model during tool execution — on the turn goroutine, while `turnMu` is already held (`Turn` locks at agent.go:1080, releases in the goroutine defer at :1136). Taking a non-reentrant mutex there self-deadlocks and hangs the turn *still holding the lock*, wedging every later turn. CodeRabbit verified this independently and withdrew that half of its request.

## A test my change made fail, reported as such

`TestRunLoop_MaxTokens_WithToolCalls_DoesNotRetry` started racing after the mutex landed. Measured rather than assumed:

```
pre-mutex:   0/20 runs raced
post-mutex:  2/20 runs raced
```

The lock didn&#39;t create it — `maxTokensWithToolProvider.Stream` increments an unsynchronized `callCount` while being called from both the turn goroutine and the background session-memory task. But the changed scheduling exposed it, and that&#39;s mine to say out loud rather than fold into &#34;fixed some test races.&#34; The field is **deleted** rather than locked: no assertion ever reads it, and synchronizing a value with no purpose is worse than removing it.

## A review suggestion that needed a correction of its own

The review asked to replace the summarizer tests&#39; `time.Sleep` with a callback signal and move `handle.Stop` to `t.Cleanup`. The first half is right — sleep gives no happens-before edge. The second half **alone introduces a race**: cleanups run *after* the test body&#39;s defers, so `Stop`-as-`Cleanup` lands after the deferred restore of the package-level `summaryInterval`, and the global is written back while `scheduleNext` still reads it. 5 failures out of 5 under `-race`.

`2e5ed40` makes the restore a `Cleanup` too — they run last-registered-first, so registering restore *before* `Stop` puts `Stop` first.

## Shallow copy: rule stated, not enforced

`Messages()` returns a shallow copy — each message&#39;s `Content` slice and `Metadata` map still alias the conversation&#39;s. Deep-cloning at every egress would enforce read-only ownership, at the cost of copying every content block on a path that runs before each LLM request. CodeRabbit&#39;s own scan found no built-in reader that mutates `Content`, `Metadata`, or `ContentBlock.Input`, and it endorsed the tradeoff. `da5b8a8` writes the rule onto `Messages()` — including what to do if it stops holding — rather than paying for a guarantee against a caller that doesn&#39;t exist.

## Verification at `da5b8a8`

- `internal/agent` **race-clean over 3 consecutive full-package runs**; the two summarizer tests clean over 5 (was 3 races per run on `main`).
- Full-suite failures **identical to baseline** — the same 10 environmental tests (`$HOME`/SQLite writes, and chmod tests defeated by running as uid 0).
- `go build`, `go vet`, `gofmt` clean.
- `conversation.go`: every method 100% covered except three pre-existing bounds-clamp branches (`tombstoneLocked` 77.8%, `isTombstonedLocked` 60%, `AddSystem`/`DrainMessages` 80%). The diff confirms those bodies were moved verbatim — renamed, not changed — so I&#39;ve left them rather than widen a race fix into a coverage pass.

## Still open

**The `Messages()` copy cost.** Field reads became copies at 19 sites, including `MeasureUsage`, which runs before each LLM request. I judged it negligible next to the call it precedes and declined to optimise speculatively. If compaction turns out to be hot enough to care, the answer is a read-under-lock accessor, not a bare field.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_



## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when conversations are read and updated concurrently.
  * Reduced the risk of inconsistent conversation state during compaction, summarization, and token usage tracking.
  * Improved stability for concurrent streaming and recovery scenarios.

* **Tests**
  * Added coverage for simultaneous conversation reads and writes to help prevent concurrency-related regressions.

