### PR TITLE
Default Zai's APIKeySource to "env" like Anthropic's

### DIFF
--- a/internal/config/apikey_test.go
+++ b/internal/config/apikey_test.go
@@ -118,7 +118,7 @@ func TestHasUsableCredentialsForProviderZaiDefaultConfigPicksUpEnv(t *testing.T)
 	cfg.Provider.Default = "zai"
 
 	t.Setenv("Z_AI_API_KEY", "zai-env-key")
-	assert.True(t, HasUsableCredentialsForProvider(cfg, "zai"))
+	assert.True(t, HasUsableCredentialsForProvider(cfg, cfg.Provider.Default))
 }
 
 func TestHasUsableCredentialsNilConfig(t *testing.T) {

--- a/internal/config/apikey_test.go
+++ b/internal/config/apikey_test.go
@@ -107,6 +107,20 @@ func TestHasUsableCredentialsForProviderZaiEnv(t *testing.T) {
 	assert.True(t, HasUsableCredentialsForProvider(cfg, "zai"))
 }
 
+// TestHasUsableCredentialsForProviderZaiDefaultConfigPicksUpEnv reproduces
+// the real-world path: a user sets provider.default = "zai" but never adds
+// an explicit api_key_source under [provider.zai], relying on
+// DefaultConfig()'s own default (as Anthropic users already can). Without a
+// default, Zai.APIKeySource stays "" and ResolveAPIKey's default case
+// rejects it outright, so Z_AI_API_KEY is never consulted.
+func TestHasUsableCredentialsForProviderZaiDefaultConfigPicksUpEnv(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Provider.Default = "zai"
+
+	t.Setenv("Z_AI_API_KEY", "zai-env-key")
+	assert.True(t, HasUsableCredentialsForProvider(cfg, "zai"))
+}
+
 func TestHasUsableCredentialsNilConfig(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -415,6 +415,9 @@ func DefaultConfig() *Config {
 			Anthropic: AnthropicProviderConfig{
 				APIKeySource: "env",
 			},
+			Zai: ZaiProviderConfig{
+				APIKeySource: "env",
+			},
 		},
 		Agent: AgentConfig{
 			MaxTurns:               50,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,6 +17,8 @@ func TestDefaultConfig(t *testing.T) {
 	// Model defaulting is provider-dependent and resolved by
 	// cmd/rubichan's loadConfig() after the provider is finalized, not here.
 	assert.Empty(t, cfg.Provider.Model)
+	assert.Equal(t, "env", cfg.Provider.Anthropic.APIKeySource)
+	assert.Equal(t, "env", cfg.Provider.Zai.APIKeySource, "Zai must default to \"env\" like Anthropic, or ResolveAPIKey rejects it outright regardless of Z_AI_API_KEY")
 	assert.Equal(t, 50, cfg.Agent.MaxTurns)
 	assert.Equal(t, "prompt", cfg.Agent.ApprovalMode)
 	assert.Equal(t, 100000, cfg.Agent.ContextBudget)


### PR DESCRIPTION
## Summary
- `DefaultConfig()` set `Anthropic.APIKeySource = "env"` but left `Zai.APIKeySource` at its zero value `""`
- `ResolveAPIKey`'s `default:` case rejects an empty source outright, so a config with `provider.default = "zai"` and no explicit `api_key_source` under `[provider.zai]` never consulted `Z_AI_API_KEY`, even when set
- Adds `Zai: ZaiProviderConfig{APIKeySource: "env"}` to `DefaultConfig()`, matching Anthropic

Fixes #347.

## Test plan
- [x] `TestDefaultConfig` now asserts both `Anthropic.APIKeySource` and `Zai.APIKeySource` default to `"env"` — failed before the fix (`Zai.APIKeySource` was `""`)
- [x] New `TestHasUsableCredentialsForProviderZaiDefaultConfigPicksUpEnv` reproduces the real-world path (default config, `provider.default = "zai"`, `Z_AI_API_KEY` set, no explicit `api_key_source`) — failed before the fix
- [x] `go test ./...` — 7125 passed
- [x] `gofmt -l .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017a1q8jd79P6FyPLBxbKR64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zai provider configurations now default to reading credentials from the environment.
  * Default configurations correctly recognize `Z_AI_API_KEY` as a usable credential source.

* **Tests**
  * Added coverage to verify default API key source behavior for Zai and Anthropic providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->