### PR TITLE
ACP slice 3: conduct a whole turn over session/new and session/prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,19 +26,22 @@ All three modes share a common **Agent Core** (`internal/agent/`) with mode-spec
 
 Public SDK lives in `pkg/skillsdk/` — stable interface for skill authors. Everything in `internal/` is private.
 
-## ACP Protocol Integration — dormant, no production caller
+## ACP Protocol Integration — a working protocol layer, still no production caller
 
 **This section previously described ACP as "the standardized backbone for agent-mode communication." That was aspirational, not descriptive.** A Phase 3 audit (see `docs/MODULAR_CORE_REDESIGN.md`) established that the mode adapters that were supposed to be ACP's consumers could not complete a single operation against the server, and they have since been deleted.
 
 Current state, so nobody plans against the old claim:
 
-- **`internal/acp` has no production caller.** `agent.NewACPServer` is constructed only in tests. `grep -rn "NewACPServer" --include=*.go . | grep -v _test.go` returns its own definition and nothing else.
+- **`internal/acp` still has no production caller.** `agent.ServeACP` is the composition root — registry, connection and session wiring in one call — but nothing in `cmd/rubichan/main.go` invokes it. There is no `--acp` flag. `grep -rn "ServeACP" --include=*.go . | grep -v _test.go` returns its own definition and nothing else.
 - **The three execution modes do not use ACP.** All are implemented inline in `cmd/rubichan/main.go`, but they do not share a shape: interactive and headless bind directly to `internal/agent`, while `--wiki` calls `runWikiHeadless`, which drives `internal/wiki.Run` and never constructs an agent at all. Do not look for a wiki agent integration point; there isn't one.
-- **Registered methods are `agent/prompt`, `tool/execute`, `skill/{invoke,list,manifest}`, `security/{scan,approve}`, plus `initialize` and `shutdown`.** `tool/execute` is an explicit `not_implemented` stub.
+- **Registered methods are `initialize`, `session/new`, `session/prompt`, `agent/prompt`, `tool/execute`, `skill/{invoke,list,manifest}`, `security/{scan,approve}`, and `shutdown`.** `tool/execute` is an explicit `not_implemented` stub. `agent/prompt` predates the session methods and is not an ACP method at all — `session/prompt` is the spec-defined one.
+- **A turn can now be conducted end to end.** `session/new` mints a session against an absolute cwd; `session/prompt` decodes content, runs the turn, streams `session/update` notifications, and closes with a `stopReason`. `internal/agent/acp_serve_internal_test.go` drives that whole sequence over a pipe.
+- **Server-initiated dispatch exists in one direction only.** `Conn.Notify` sends notifications — that is what carries `session/update` — so streaming output works. There is still no mid-turn `session/request_permission`: `Conn.Request` can express it, but nothing calls it.
+- **A turn cannot be cancelled.** `Handler` takes only `params`, so there is no request context to derive from and `session/cancel` is unimplementable until a context is threaded through every handler in the package.
+- **Declared capabilities are all false, and that is enforced, not just documented.** `acpAgentCapabilities()` is the single source: the handshake publishes it and `session/prompt` gates incoming content on it. So `image`, `audio` and `resource` content blocks are refused, and `session/new` refuses `mcpServers` and `additionalDirectories` rather than accepting and ignoring them.
 - **The method constants in `types.go` are largely unwired**, in two degrees. `tools/list`, `tools/call` and `resources/list` are referenced only by `methods_test.go`, which round-trips them through JSON. `resources/read`, `prompts/list`, `prompts/call` and `sampling/createMessage` have **no reference anywhere in the tree** — not even a test. None of the seven is registered or sent.
-- **There is no server-initiated dispatch.** `Notification` and `notifications/{progress,log}` are declared but never constructed; `ResponseDispatcher` correlates strictly by request ID and drops unmatched messages. So no streaming output and no mid-turn approval.
 
-Do not treat ACP as a live interface, and do not add capabilities to it on the assumption that something consumes them. Whether it should be revived against a real protocol or removed is an open decision.
+Do not add capabilities to ACP on the assumption that something consumes them — flip a capability flag on in the same change that registers the method behind it, never before. Whether ACP should get a mode that actually calls `ServeACP`, or be removed, is still an open decision.
 
 Note also that `internal/acp` is **not** the repository's MCP support: that lives in `internal/tools/mcp` and `internal/skills/mcpbackend`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Rubichan is a Go-based AI Coding Agent specified in `spec.md` (v1.1, Feb 2026). It is currently in the **specification phase** — no implementation code exists yet. The spec defines a terminal-first CLI tool with three execution modes: Interactive (Bubble Tea TUI), Headless (CI/CD pipes), and Wiki Generator (batch documentation).
+Rubichan is a Go-based AI Coding Agent originally specified in `spec.md` (v1.1, Feb 2026). The spec defines a terminal-first CLI tool with three execution modes: Interactive (Bubble Tea TUI), Headless (CI/CD pipes), and Wiki Generator (batch documentation).
+
+**The project is implemented, not in the specification phase.** This line previously said "no implementation code exists yet", which stopped being true long ago and contradicted the rest of this file. Where `spec.md` and the code disagree, the code is what ships — check it before planning against the spec.
 
 The spec is the single source of truth. Always consult `spec.md` before making architectural decisions.
 

--- a/internal/acp/conn.go
+++ b/internal/acp/conn.go
@@ -304,9 +304,15 @@ func (c *Conn) Request(ctx context.Context, method string, params any) (json.Raw
 // session/update carries every agent_message_chunk, tool_call and plan entry
 // while session/prompt is still running.
 //
-// It refuses once the connection has stopped serving. Unlike Request there is
-// no response to wait on, so without this check a caller could not tell a
-// delivered update from one written into a closed stream.
+// It refuses sends *observed* to be after close, and that is the whole of the
+// guarantee. The closed check and the write are not one atomic step: Serve can
+// return in the window between them, so a nil error means the write did not
+// fail, not that the peer received anything.
+//
+// Closing the window would mean holding a lock across the write and having
+// failPending take it too — which lets one stalled peer block every Request on
+// the connection. A dropped update during teardown is the cheaper failure, so
+// the race is accepted and stated rather than papered over.
 func (c *Conn) Notify(method string, params any) error {
 	raw, err := marshalParams(params)
 	if err != nil {

--- a/internal/acp/conn.go
+++ b/internal/acp/conn.go
@@ -299,6 +299,33 @@ func (c *Conn) Request(ctx context.Context, method string, params any) (json.Raw
 	}
 }
 
+// Notify sends a one-way message to the peer: no id, so no answer is expected
+// and none may be sent. This is the direction ACP streams a turn on —
+// session/update carries every agent_message_chunk, tool_call and plan entry
+// while session/prompt is still running.
+//
+// It refuses once the connection has stopped serving. Unlike Request there is
+// no response to wait on, so without this check a caller could not tell a
+// delivered update from one written into a closed stream.
+func (c *Conn) Notify(method string, params any) error {
+	raw, err := marshalParams(params)
+	if err != nil {
+		return fmt.Errorf("marshal params for %s: %w", method, err)
+	}
+
+	c.mu.Lock()
+	closed := c.closed
+	c.mu.Unlock()
+	if closed {
+		return fmt.Errorf("%s: %w", method, ErrConnClosed)
+	}
+
+	if err := c.write(Notification{JSONRPC: "2.0", Method: method, Params: raw}); err != nil {
+		return fmt.Errorf("send %s: %w", method, err)
+	}
+	return nil
+}
+
 // failPending closes every waiting channel so Request calls return an error
 // rather than blocking forever once the connection is gone.
 func (c *Conn) failPending() {

--- a/internal/acp/conn_test.go
+++ b/internal/acp/conn_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -535,4 +536,47 @@ func TestConnShutdownIsNotHeldByABlockedNotification(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("pending Request was never released")
 	}
+}
+
+// TestConnNotifySendsNoID is the agent->client direction ACP carries every
+// session/update on. A notification is distinguished from a request purely by
+// the absence of an id: send one with an id and the peer is obliged to answer
+// something nothing is waiting for, which leaves an unmatched response on a
+// stream that correlates strictly by id.
+func TestConnNotifySendsNoID(t *testing.T) {
+	t.Parallel()
+
+	c, p := newConnPair(t, acp.NewCapabilityRegistry())
+
+	// Sent from a goroutine because the pair is joined by an io.Pipe, which is
+	// unbuffered: the write blocks until this test reads it.
+	sent := make(chan error, 1)
+	go func() {
+		sent <- c.Notify("session/update", map[string]any{
+			"sessionId": "sess-1",
+			"update":    map[string]any{"sessionUpdate": "agent_message_chunk"},
+		})
+	}()
+
+	var got map[string]any
+	p.decode(t, &got)
+	require.NoError(t, <-sent)
+
+	assert.Equal(t, "2.0", got["jsonrpc"])
+	assert.Equal(t, "session/update", got["method"])
+	_, hasID := got["id"]
+	assert.False(t, hasID, "a notification carries no id; an id makes it a request")
+}
+
+// TestConnNotifyFailsOnceClosed keeps a caller from believing a turn update was
+// delivered after the connection went away. Notify has no response to wait on,
+// so a silent success is indistinguishable from a delivered message.
+func TestConnNotifyFailsOnceClosed(t *testing.T) {
+	t.Parallel()
+
+	c := acp.NewConn(strings.NewReader(""), io.Discard, acp.NewCapabilityRegistry())
+	require.NoError(t, c.Serve(context.Background()))
+
+	err := c.Notify("session/update", map[string]any{"sessionId": "sess-1"})
+	assert.ErrorIs(t, err, acp.ErrConnClosed)
 }

--- a/internal/acp/content.go
+++ b/internal/acp/content.go
@@ -1,0 +1,130 @@
+package acp
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ContentBlockType names a ContentBlock variant. The wire discriminator is the
+// "type" field, and the set is closed: a block whose type is none of these is
+// not a block this agent can act on.
+type ContentBlockType string
+
+const (
+	ContentText         ContentBlockType = "text"
+	ContentImage        ContentBlockType = "image"
+	ContentAudio        ContentBlockType = "audio"
+	ContentResource     ContentBlockType = "resource"
+	ContentResourceLink ContentBlockType = "resource_link"
+)
+
+// ContentBlock is one element of a session/prompt payload.
+//
+// ACP models this as a tagged union, so the fields carried depend on Type. It
+// is flattened into one struct rather than five because the variants are small
+// and a client sends them interleaved in a single array; the union is enforced
+// by validation rather than by the type system.
+//
+// Note that audio has no uri field while image does — mirroring the two is an
+// easy way to accept a payload the spec does not define.
+type ContentBlock struct {
+	Type ContentBlockType `json:"type"`
+
+	// Text is required for the text variant.
+	Text string `json:"text,omitempty"`
+
+	// URI and Name are required for resource_link. URI is also optional on
+	// image.
+	URI  string `json:"uri,omitempty"`
+	Name string `json:"name,omitempty"`
+
+	MimeType    string `json:"mimeType,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Size        *int64 `json:"size,omitempty"`
+
+	// Data carries base64 payload bytes for image and audio.
+	Data string `json:"data,omitempty"`
+
+	// Resource carries the embedded body of the resource variant.
+	Resource json.RawMessage `json:"resource,omitempty"`
+
+	Annotations json.RawMessage `json:"annotations,omitempty"`
+}
+
+// DecodePromptContent parses a session/prompt content array and rejects any
+// block this agent has not declared it can accept.
+//
+// The gate reads caps rather than a fixed list so that the handshake and this
+// decoder cannot drift: declaring promptCapabilities.image is what makes an
+// image block admissible, and nothing else is. Rejecting is the honest failure
+// — silently dropping an attachment leaves the client believing the agent read
+// something it never saw.
+func DecodePromptContent(raw json.RawMessage, caps PromptCapabilities) ([]ContentBlock, error) {
+	var blocks []ContentBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return nil, fmt.Errorf("%w: prompt: %v", ErrInvalidParams, err)
+	}
+
+	for i, b := range blocks {
+		if err := checkAdmissible(b.Type, caps); err != nil {
+			return nil, fmt.Errorf("%w: prompt[%d]: %v", ErrInvalidParams, i, err)
+		}
+		if err := checkRequiredFields(b); err != nil {
+			return nil, fmt.Errorf("%w: prompt[%d]: %v", ErrInvalidParams, i, err)
+		}
+	}
+	return blocks, nil
+}
+
+// checkRequiredFields enforces the fields the spec marks required on the
+// variants this agent accepts. Absence cannot be detected after decoding —
+// a missing string is indistinguishable from an empty one — so it is checked
+// here or not at all.
+//
+// Only the ungated variants are covered: the others cannot reach this point
+// while undeclared, and the slice that declares one is the slice that learns
+// what its required fields mean.
+func checkRequiredFields(b ContentBlock) error {
+	switch b.Type {
+	case ContentText:
+		if b.Text == "" {
+			return fmt.Errorf("text content requires a non-empty text field")
+		}
+	case ContentResourceLink:
+		if b.URI == "" {
+			return fmt.Errorf("resource_link requires a uri")
+		}
+		if b.Name == "" {
+			return fmt.Errorf("resource_link requires a name")
+		}
+	}
+	return nil
+}
+
+// checkAdmissible reports whether a variant may appear in a prompt given what
+// the agent declared. text and resource_link carry no capability of their own
+// and are always admissible.
+func checkAdmissible(t ContentBlockType, caps PromptCapabilities) error {
+	switch t {
+	case ContentText, ContentResourceLink:
+		return nil
+	case ContentImage:
+		if !caps.Image {
+			return fmt.Errorf("image content requires promptCapabilities.image, which this agent does not declare")
+		}
+		return nil
+	case ContentAudio:
+		if !caps.Audio {
+			return fmt.Errorf("audio content requires promptCapabilities.audio, which this agent does not declare")
+		}
+		return nil
+	case ContentResource:
+		if !caps.EmbeddedContext {
+			return fmt.Errorf("resource content requires promptCapabilities.embeddedContext, which this agent does not declare")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown content type %q", t)
+	}
+}

--- a/internal/acp/content.go
+++ b/internal/acp/content.go
@@ -66,6 +66,15 @@ func DecodePromptContent(raw json.RawMessage, caps PromptCapabilities) ([]Conten
 		return nil, fmt.Errorf("%w: prompt: %v", ErrInvalidParams, err)
 	}
 
+	// null and [] both decode without error into no content at all. Neither is
+	// a prompt, and letting either through starts a turn against an empty
+	// string: the conversation gains an empty user message and the model is
+	// paid to answer nothing. They differ only in whether the slice is nil,
+	// which is not a distinction any client meant to draw.
+	if len(blocks) == 0 {
+		return nil, fmt.Errorf("%w: prompt must contain at least one content block", ErrInvalidParams)
+	}
+
 	for i, b := range blocks {
 		if err := checkAdmissible(b.Type, caps); err != nil {
 			return nil, fmt.Errorf("%w: prompt[%d]: %v", ErrInvalidParams, i, err)

--- a/internal/acp/content_test.go
+++ b/internal/acp/content_test.go
@@ -1,0 +1,116 @@
+package acp_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/acp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPromptContentAcceptsTheUngatedVariants pins the two ContentBlock variants
+// an agent may always receive. text and resource_link carry no promptCapability
+// of their own, so a client may send them against a handshake that declared
+// nothing — which is exactly what this agent's handshake declares today.
+func TestPromptContentAcceptsTheUngatedVariants(t *testing.T) {
+	t.Parallel()
+
+	blocks, err := acp.DecodePromptContent(json.RawMessage(`[
+		{"type":"text","text":"summarise this repo"},
+		{"type":"resource_link","uri":"file:///src/main.go","name":"main.go"}
+	]`), acp.PromptCapabilities{})
+	require.NoError(t, err)
+
+	require.Len(t, blocks, 2)
+	assert.Equal(t, acp.ContentText, blocks[0].Type)
+	assert.Equal(t, "summarise this repo", blocks[0].Text)
+	assert.Equal(t, acp.ContentResourceLink, blocks[1].Type)
+	assert.Equal(t, "file:///src/main.go", blocks[1].URI)
+	assert.Equal(t, "main.go", blocks[1].Name)
+}
+
+// TestPromptContentRejectsUndeclaredVariants is the honesty check between the
+// handshake and the handler. image, audio and resource are each gated on a
+// promptCapability. Accepting one this agent never declared is the same defect
+// as declaring a capability no method backs — it just points the other way, and
+// leaves the client believing an attachment was read when it was dropped.
+func TestPromptContentRejectsUndeclaredVariants(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{"image", `[{"type":"image","data":"aGk=","mimeType":"image/png"}]`},
+		{"audio", `[{"type":"audio","data":"aGk=","mimeType":"audio/wav"}]`},
+		{"resource", `[{"type":"resource","resource":{"text":"hi","uri":"file:///a"}}]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := acp.DecodePromptContent(json.RawMessage(tc.raw), acp.PromptCapabilities{})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, acp.ErrInvalidParams,
+				"the client's payload is wrong and it can correct it; -32602, not -32603")
+			assert.Contains(t, err.Error(), tc.name)
+		})
+	}
+}
+
+// TestPromptContentAcceptsDeclaredVariants is the other half: the gate must key
+// off what was actually declared, not off a hardcoded list. Otherwise flipping a
+// capability on in the handshake would silently fail to flip it on here.
+func TestPromptContentAcceptsDeclaredVariants(t *testing.T) {
+	t.Parallel()
+
+	caps := acp.PromptCapabilities{Image: true, Audio: true, EmbeddedContext: true}
+
+	blocks, err := acp.DecodePromptContent(json.RawMessage(`[
+		{"type":"image","data":"aGk=","mimeType":"image/png"},
+		{"type":"audio","data":"aGk=","mimeType":"audio/wav"},
+		{"type":"resource","resource":{"text":"hi","uri":"file:///a"}}
+	]`), caps)
+	require.NoError(t, err)
+	assert.Len(t, blocks, 3)
+}
+
+// TestPromptContentRequiresTheVariantsOwnFields checks the fields the spec marks
+// required on the two variants this agent actually accepts. A resource_link
+// missing its name still decodes into a valid Go struct — the zero value is a
+// legal empty string — so nothing but an explicit check catches it, and the
+// agent would otherwise be handed a reference it cannot describe to the user.
+func TestPromptContentRequiresTheVariantsOwnFields(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"text without text", `[{"type":"text"}]`, "text"},
+		{"resource_link without uri", `[{"type":"resource_link","name":"main.go"}]`, "uri"},
+		{"resource_link without name", `[{"type":"resource_link","uri":"file:///a"}]`, "name"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := acp.DecodePromptContent(json.RawMessage(tc.raw), acp.PromptCapabilities{})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, acp.ErrInvalidParams)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// TestPromptContentRejectsUnknownVariant keeps the union closed. An unrecognised
+// type is not a forward-compatible no-op: the block carried instruction or
+// context the agent is about to answer without.
+func TestPromptContentRejectsUnknownVariant(t *testing.T) {
+	t.Parallel()
+
+	_, err := acp.DecodePromptContent(json.RawMessage(`[{"type":"video","uri":"file:///a.mp4"}]`),
+		acp.PromptCapabilities{Image: true, Audio: true, EmbeddedContext: true})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, acp.ErrInvalidParams)
+}

--- a/internal/acp/content_test.go
+++ b/internal/acp/content_test.go
@@ -114,3 +114,14 @@ func TestPromptContentRejectsUnknownVariant(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, acp.ErrInvalidParams)
 }
+
+// TestPromptContentRejectsMalformedArray covers the decode failure itself. A
+// prompt that is not an array of blocks is the client's mistake, and answering
+// -32603 would tell it the agent is broken and retrying is pointless.
+func TestPromptContentRejectsMalformedArray(t *testing.T) {
+	t.Parallel()
+
+	_, err := acp.DecodePromptContent(json.RawMessage(`{"not":"an array"}`), acp.PromptCapabilities{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, acp.ErrInvalidParams)
+}

--- a/internal/acp/content_test.go
+++ b/internal/acp/content_test.go
@@ -125,3 +125,32 @@ func TestPromptContentRejectsMalformedArray(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, acp.ErrInvalidParams)
 }
+
+// TestPromptContentRejectsAnEmptyPrompt covers the two payloads that decode
+// cleanly into no content at all. Both would otherwise reach the model as an
+// empty string: a turn is started, a conversation gains an empty user message,
+// and real tokens are spent answering nothing.
+//
+// null and [] are treated alike deliberately. They differ only in whether the
+// resulting slice is nil, which is not a distinction a client meant to draw,
+// and neither carries the prompt the method exists to deliver.
+func TestPromptContentRejectsAnEmptyPrompt(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{"null", `null`},
+		{"empty array", `[]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := acp.DecodePromptContent(json.RawMessage(tc.raw), acp.PromptCapabilities{})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, acp.ErrInvalidParams)
+			assert.Contains(t, err.Error(), "at least one")
+		})
+	}
+}

--- a/internal/acp/handshake.go
+++ b/internal/acp/handshake.go
@@ -1,0 +1,47 @@
+package acp
+
+import "sync"
+
+// Handshake records whether initialize has completed on a connection.
+//
+// ACP requires the handshake before any other request: it is where the protocol
+// version is agreed and both sides declare capabilities. A session opened
+// without it belongs to a peer whose contract is unknown — the agent would be
+// running turns for a client whose protocol version it never agreed and whose
+// capabilities it never learned.
+//
+// It is a shared object rather than a flag on either config because two
+// registrations need it: RegisterInitialize marks it, RegisterSession reads it,
+// and neither can see the other's state.
+type Handshake struct {
+	mu       sync.RWMutex
+	complete bool
+}
+
+// NewHandshake returns a handshake that has not happened yet.
+func NewHandshake() *Handshake {
+	return &Handshake{}
+}
+
+// MarkComplete records a successful initialize.
+func (h *Handshake) MarkComplete() {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.complete = true
+}
+
+// IsComplete reports whether initialize has succeeded. A nil Handshake reports
+// true: it means the caller did not ask for the ordering to be enforced, which
+// is what keeps this optional for tests and for registries that serve no
+// session methods.
+func (h *Handshake) IsComplete() bool {
+	if h == nil {
+		return true
+	}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.complete
+}

--- a/internal/acp/initialize.go
+++ b/internal/acp/initialize.go
@@ -95,6 +95,10 @@ type InitializeConfig struct {
 	AgentInfo    AgentInfo
 	Capabilities AgentCapabilities
 	AuthMethods  []AuthMethod
+	// Handshake, when set, is marked complete once this handshake succeeds.
+	// The session methods read it to enforce ACP's ordering rule.
+	Handshake *Handshake
+
 	// OnInitialized receives the peer's capabilities once negotiated, so the
 	// agent can avoid requesting things the client never offered.
 	OnInitialized func(ClientCapabilities, AgentInfo)
@@ -141,6 +145,10 @@ func RegisterInitialize(registry *CapabilityRegistry, cfg InitializeConfig) {
 		if result.AuthMethods == nil {
 			result.AuthMethods = []AuthMethod{}
 		}
+
+		// Marked before the result is marshalled but after every validation
+		// above, so a rejected handshake does not unlock the session methods.
+		cfg.Handshake.MarkComplete()
 
 		if cfg.OnInitialized != nil {
 			cfg.OnInitialized(req.ClientCapabilities, cfg.AgentInfo)

--- a/internal/acp/session.go
+++ b/internal/acp/session.go
@@ -1,0 +1,201 @@
+package acp
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sync"
+)
+
+// StopReason tells the client why a turn ended. ACP closes session/prompt with
+// exactly one of these; there is no "unknown".
+type StopReason string
+
+const (
+	StopEndTurn         StopReason = "end_turn"
+	StopMaxTokens       StopReason = "max_tokens"
+	StopMaxTurnRequests StopReason = "max_turn_requests"
+	StopRefusal         StopReason = "refusal"
+	StopCancelled       StopReason = "cancelled"
+)
+
+// PromptRequest is one turn's worth of work, handed to the agent.
+//
+// Cwd travels with it rather than being looked up by the handler because the
+// session owns it: a turn is executed against the directory its session was
+// opened for, and passing it explicitly keeps that from being re-derived
+// somewhere it could disagree.
+type PromptRequest struct {
+	SessionID string
+	Cwd       string
+	Prompt    []ContentBlock
+}
+
+// PromptFunc executes a turn and reports why it stopped.
+//
+// An error means the agent failed, which is distinct from a turn that ended for
+// a protocol reason: StopRefusal says the model declined, an error says the
+// attempt broke. Conflating them tells the client a lie in whichever direction
+// it is collapsed.
+type PromptFunc func(ctx context.Context, req PromptRequest) (StopReason, error)
+
+// SessionConfig supplies what the session methods need from the agent.
+type SessionConfig struct {
+	// Capabilities is the same value the handshake answers with. It is shared
+	// rather than restated so the content this agent accepts cannot drift from
+	// the content it claims to accept.
+	Capabilities AgentCapabilities
+
+	// Prompt runs a turn. A nil Prompt means session/prompt is unserved, and
+	// the method reports that rather than pretending to have run.
+	Prompt PromptFunc
+}
+
+// NewSessionParams is the client's request to open a session.
+type NewSessionParams struct {
+	Cwd string `json:"cwd"`
+	// MCPServers is decoded as a slice, not a raw blob, so that its length is
+	// the number of servers requested. Measuring a json.RawMessage instead
+	// measures bytes, and the empty list "[]" is two of them.
+	MCPServers            []json.RawMessage `json:"mcpServers,omitempty"`
+	AdditionalDirectories []string          `json:"additionalDirectories,omitempty"`
+}
+
+// NewSessionResult identifies the session the client may now prompt.
+type NewSessionResult struct {
+	SessionID string `json:"sessionId"`
+}
+
+// PromptParams is one session/prompt call.
+type PromptParams struct {
+	SessionID string          `json:"sessionId"`
+	Prompt    json.RawMessage `json:"prompt"`
+}
+
+// PromptResult closes a turn.
+type PromptResult struct {
+	StopReason StopReason `json:"stopReason"`
+}
+
+// session is the state a sessionId stands for.
+type session struct {
+	cwd string
+}
+
+// sessionStore holds live sessions. Sessions are reached from handler
+// goroutines — Conn serves each inbound request on its own — so every access is
+// guarded.
+type sessionStore struct {
+	mu       sync.RWMutex
+	sessions map[string]session
+}
+
+func (s *sessionStore) add(id string, sess session) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions[id] = sess
+}
+
+func (s *sessionStore) get(id string) (session, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[id]
+	return sess, ok
+}
+
+// RegisterSession wires session/new and session/prompt into a registry.
+func RegisterSession(registry *CapabilityRegistry, cfg SessionConfig) {
+	store := &sessionStore{sessions: make(map[string]session)}
+
+	registry.RegisterMethod(MethodSessionNew, func(params json.RawMessage) (json.RawMessage, error) {
+		var req NewSessionParams
+		if err := json.Unmarshal(params, &req); err != nil {
+			return nil, fmt.Errorf("session/new: %w: %v", ErrInvalidParams, err)
+		}
+		// The spec requires an absolute cwd. A relative one resolves against
+		// two different working directories on the two sides of the connection,
+		// so it names two different places while looking like agreement.
+		if req.Cwd == "" {
+			return nil, fmt.Errorf("session/new: %w: cwd is required", ErrInvalidParams)
+		}
+		if !filepath.IsAbs(req.Cwd) {
+			return nil, fmt.Errorf("session/new: %w: cwd must be an absolute path, got %q", ErrInvalidParams, req.Cwd)
+		}
+
+		// Both of these ask the agent to do something it has no implementation
+		// for. Taking them and doing nothing would leave the client prompting in
+		// the belief that its MCP tools are connected and its extra directories
+		// are readable — the same silence as dropping an undeclared content
+		// block, and just as invisible from the far side.
+		//
+		// Empty is not a request, so an empty list is accepted: a client that
+		// always sends "mcpServers":[] is asking for nothing.
+		if len(req.MCPServers) > 0 {
+			return nil, fmt.Errorf("session/new: %w: mcpServers is not supported; this agent connects no MCP servers on a client's behalf", ErrInvalidParams)
+		}
+		if len(req.AdditionalDirectories) > 0 {
+			return nil, fmt.Errorf("session/new: %w: additionalDirectories is not supported; this agent works only in cwd", ErrInvalidParams)
+		}
+
+		id, err := newSessionID()
+		if err != nil {
+			return nil, fmt.Errorf("session/new: %w", err)
+		}
+		store.add(id, session{cwd: req.Cwd})
+
+		return json.Marshal(NewSessionResult{SessionID: id})
+	})
+
+	registry.RegisterMethod(MethodSessionPrompt, func(params json.RawMessage) (json.RawMessage, error) {
+		var req PromptParams
+		if err := json.Unmarshal(params, &req); err != nil {
+			return nil, fmt.Errorf("session/prompt: %w: %v", ErrInvalidParams, err)
+		}
+
+		sess, ok := store.get(req.SessionID)
+		if !ok {
+			return nil, fmt.Errorf("session/prompt: %w: unknown sessionId %q", ErrInvalidParams, req.SessionID)
+		}
+
+		blocks, err := DecodePromptContent(req.Prompt, cfg.Capabilities.Prompt)
+		if err != nil {
+			return nil, fmt.Errorf("session/prompt: %w", err)
+		}
+
+		if cfg.Prompt == nil {
+			return nil, fmt.Errorf("session/prompt: no prompt handler is registered")
+		}
+
+		// context.Background, and that is a real limitation rather than a
+		// convenience: Handler takes only params, so there is no request context
+		// to derive from and no way to cancel a running turn. ACP's
+		// session/cancel notification therefore cannot be honoured yet. Fixing
+		// it means threading a context through Handler — every handler in the
+		// package — which is a structural change and not this slice's.
+		stop, err := cfg.Prompt(context.Background(), PromptRequest{
+			SessionID: req.SessionID,
+			Cwd:       sess.cwd,
+			Prompt:    blocks,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("session/prompt: %w", err)
+		}
+
+		return json.Marshal(PromptResult{StopReason: stop})
+	})
+}
+
+// newSessionID mints an opaque, unguessable session identifier. A counter would
+// be simpler, but session ids appear in client logs and in any shared
+// transcript, and a predictable one invites a peer to address a session it was
+// never given.
+func newSessionID() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate session id: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}

--- a/internal/acp/session.go
+++ b/internal/acp/session.go
@@ -225,10 +225,30 @@ func RegisterSession(registry *CapabilityRegistry, cfg SessionConfig) {
 		// for any other directory cannot be served. Validating that cwd was
 		// absolute and then ignoring it was worse than not validating at all:
 		// it made the field look honoured.
-		if filepath.Clean(req.Cwd) != filepath.Clean(cfg.WorkingDir) {
+		// Both sides are resolved to absolute form first. The agent's working
+		// directory may itself be relative — WithWorkingDir stores what it is
+		// given and construction only fills it from os.Getwd when empty — while
+		// ACP requires the client's cwd to be absolute. Comparing with Clean
+		// alone preserves that difference and would reject every valid request
+		// for the very directory the tools operate in.
+		//
+		// Empty is checked before resolving, not after: filepath.Abs("")
+		// returns the process's own directory, which would quietly turn "the
+		// caller never said which directory it serves" into "serve wherever
+		// this process happens to be running".
+		if cfg.WorkingDir == "" {
+			return nil, fmt.Errorf(
+				"session/new: %w: this agent was wired without a working directory, so it can serve no session",
+				ErrInvalidParams)
+		}
+		served, err := filepath.Abs(cfg.WorkingDir)
+		if err != nil {
+			return nil, fmt.Errorf("session/new: resolve agent working directory %q: %w", cfg.WorkingDir, err)
+		}
+		if filepath.Clean(req.Cwd) != served {
 			return nil, fmt.Errorf(
 				"session/new: %w: this agent serves only %q, not %q; its working directory is fixed at startup",
-				ErrInvalidParams, cfg.WorkingDir, req.Cwd)
+				ErrInvalidParams, served, req.Cwd)
 		}
 
 		// ACP defines a session as an independent context with its own history.

--- a/internal/acp/session.go
+++ b/internal/acp/session.go
@@ -49,6 +49,16 @@ type SessionConfig struct {
 	// the content it claims to accept.
 	Capabilities AgentCapabilities
 
+	// WorkingDir is the only directory this agent can serve a session for. The
+	// agent freezes its working directory at construction, so a session opened
+	// against anything else would run every file and shell tool somewhere the
+	// client did not ask for.
+	//
+	// An empty value therefore refuses every session/new rather than accepting
+	// all of them: it means the caller never said which directory it serves,
+	// and guessing is what this field exists to prevent.
+	WorkingDir string
+
 	// Prompt runs a turn. A nil Prompt means session/prompt is unserved, and
 	// the method reports that rather than pretending to have run.
 	Prompt PromptFunc
@@ -89,7 +99,10 @@ type session struct {
 // goroutines — Conn serves each inbound request on its own — so every access is
 // guarded.
 type sessionStore struct {
-	mu       sync.RWMutex
+	mu sync.RWMutex
+	// claimed marks the single session slot as taken, including the window
+	// between reserving it and the session actually existing.
+	claimed  bool
 	sessions map[string]session
 }
 
@@ -97,6 +110,33 @@ func (s *sessionStore) add(id string, sess session) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sessions[id] = sess
+}
+
+// claimSole reserves the single session this agent can host, or reports that it
+// is already taken. Checking and claiming happen under one lock: two
+// session/new calls arriving together would otherwise both observe an empty
+// store and both succeed.
+//
+// The claim is a flag rather than a placeholder entry in the map, so a lookup
+// can never find a session that was only reserved.
+func (s *sessionStore) claimSole() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.claimed {
+		return fmt.Errorf("%w: this agent hosts one session at a time and already has one; close it or open a second connection",
+			ErrInvalidParams)
+	}
+	s.claimed = true
+	return nil
+}
+
+// releaseSole undoes a claim whose session was never created. Without it, a
+// failure between claiming and adding would leave the connection permanently
+// unable to open the session it is allowed.
+func (s *sessionStore) releaseSole() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.claimed = false
 }
 
 func (s *sessionStore) get(id string) (session, bool) {
@@ -140,8 +180,28 @@ func RegisterSession(registry *CapabilityRegistry, cfg SessionConfig) {
 			return nil, fmt.Errorf("session/new: %w: additionalDirectories is not supported; this agent works only in cwd", ErrInvalidParams)
 		}
 
+		// The agent's working directory is frozen at construction, so a session
+		// for any other directory cannot be served. Validating that cwd was
+		// absolute and then ignoring it was worse than not validating at all:
+		// it made the field look honoured.
+		if filepath.Clean(req.Cwd) != filepath.Clean(cfg.WorkingDir) {
+			return nil, fmt.Errorf(
+				"session/new: %w: this agent serves only %q, not %q; its working directory is fixed at startup",
+				ErrInvalidParams, cfg.WorkingDir, req.Cwd)
+		}
+
+		// ACP defines a session as an independent context with its own history.
+		// This agent owns exactly one conversation, so a second session id would
+		// hand the client something that looks isolated and silently shares the
+		// first session's history, tool state and workspace. Refusing is the
+		// honest position until a session can own its own agent state.
+		if err := store.claimSole(); err != nil {
+			return nil, fmt.Errorf("session/new: %w", err)
+		}
+
 		id, err := newSessionID()
 		if err != nil {
+			store.releaseSole()
 			return nil, fmt.Errorf("session/new: %w", err)
 		}
 		store.add(id, session{cwd: req.Cwd})

--- a/internal/acp/session.go
+++ b/internal/acp/session.go
@@ -59,6 +59,11 @@ type SessionConfig struct {
 	// and guessing is what this field exists to prevent.
 	WorkingDir string
 
+	// Handshake gates the session methods on initialize having completed. A
+	// nil value disables the check, which is what a registry serving no
+	// handshake wants.
+	Handshake *Handshake
+
 	// Prompt runs a turn. A nil Prompt means session/prompt is unserved, and
 	// the method reports that rather than pretending to have run.
 	Prompt PromptFunc
@@ -93,6 +98,10 @@ type PromptResult struct {
 // session is the state a sessionId stands for.
 type session struct {
 	cwd string
+	// active marks a turn in flight. ACP allows one turn per session: a second
+	// would interleave its session/update stream with the first's and append to
+	// the same conversation in an order neither client asked for.
+	active bool
 }
 
 // sessionStore holds live sessions. Sessions are reached from handler
@@ -139,6 +148,35 @@ func (s *sessionStore) releaseSole() {
 	s.claimed = false
 }
 
+// beginTurn marks a session busy, or reports that it already is. Test and set
+// happen under one lock so two prompts arriving together cannot both find the
+// session idle.
+func (s *sessionStore) beginTurn(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[id]
+	if !ok {
+		return fmt.Errorf("%w: unknown sessionId %q", ErrInvalidParams, id)
+	}
+	if sess.active {
+		return fmt.Errorf("%w: session %q already has an active turn; wait for it to finish or cancel it", ErrInvalidParams, id)
+	}
+	sess.active = true
+	s.sessions[id] = sess
+	return nil
+}
+
+// endTurn releases a session for the next prompt. Deferred by the handler, so a
+// turn that fails or panics does not leave the session permanently busy.
+func (s *sessionStore) endTurn(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if sess, ok := s.sessions[id]; ok {
+		sess.active = false
+		s.sessions[id] = sess
+	}
+}
+
 func (s *sessionStore) get(id string) (session, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -151,6 +189,9 @@ func RegisterSession(registry *CapabilityRegistry, cfg SessionConfig) {
 	store := &sessionStore{sessions: make(map[string]session)}
 
 	registry.RegisterMethod(MethodSessionNew, func(params json.RawMessage) (json.RawMessage, error) {
+		if !cfg.Handshake.IsComplete() {
+			return nil, fmt.Errorf("session/new: %w: initialize must complete first", ErrInvalidParams)
+		}
 		var req NewSessionParams
 		if err := json.Unmarshal(params, &req); err != nil {
 			return nil, fmt.Errorf("session/new: %w: %v", ErrInvalidParams, err)
@@ -210,6 +251,9 @@ func RegisterSession(registry *CapabilityRegistry, cfg SessionConfig) {
 	})
 
 	registry.RegisterMethod(MethodSessionPrompt, func(params json.RawMessage) (json.RawMessage, error) {
+		if !cfg.Handshake.IsComplete() {
+			return nil, fmt.Errorf("session/prompt: %w: initialize must complete first", ErrInvalidParams)
+		}
 		var req PromptParams
 		if err := json.Unmarshal(params, &req); err != nil {
 			return nil, fmt.Errorf("session/prompt: %w: %v", ErrInvalidParams, err)
@@ -228,6 +272,14 @@ func RegisterSession(registry *CapabilityRegistry, cfg SessionConfig) {
 		if cfg.Prompt == nil {
 			return nil, fmt.Errorf("session/prompt: no prompt handler is registered")
 		}
+
+		// ACP allows one turn per session. Claimed after validation so a
+		// rejected payload does not occupy the session, and released on every
+		// exit so a failed turn does not wedge it shut.
+		if err := store.beginTurn(req.SessionID); err != nil {
+			return nil, fmt.Errorf("session/prompt: %w", err)
+		}
+		defer store.endTurn(req.SessionID)
 
 		// context.Background, and that is a real limitation rather than a
 		// convenience: Handler takes only params, so there is no request context

--- a/internal/acp/session_test.go
+++ b/internal/acp/session_test.go
@@ -15,29 +15,30 @@ import (
 func sessionConfig(prompt acp.PromptFunc) acp.SessionConfig {
 	return acp.SessionConfig{
 		Capabilities: acp.AgentCapabilities{},
+		WorkingDir:   "/repo",
 		Prompt:       prompt,
 	}
 }
 
-// TestSessionNewMintsDistinctIDs covers the method every ACP conversation opens
-// with. The ids must differ: session/prompt routes by id, so a collision would
-// deliver one client's turn into another's conversation.
-func TestSessionNewMintsDistinctIDs(t *testing.T) {
+// TestSessionNewMintsASessionID covers the method every ACP conversation opens
+// with.
+//
+// This previously asserted that two calls yield different ids. That assertion
+// is gone because a second session/new is now refused outright — see
+// TestSessionNewRefusesASecondSession for why an id that lies about isolation
+// is worse than no id at all.
+func TestSessionNewMintsASessionID(t *testing.T) {
 	t.Parallel()
 
 	registry := acp.NewCapabilityRegistry()
 	acp.RegisterSession(registry, sessionConfig(nil))
 
-	newSession := func() string {
-		raw, err := registry.Call("session/new", json.RawMessage(`{"cwd":"/repo","mcpServers":[]}`))
-		require.NoError(t, err)
-		var got acp.NewSessionResult
-		require.NoError(t, json.Unmarshal(raw, &got))
-		require.NotEmpty(t, got.SessionID)
-		return got.SessionID
-	}
+	raw, err := registry.Call("session/new", json.RawMessage(`{"cwd":"/repo","mcpServers":[]}`))
+	require.NoError(t, err)
 
-	assert.NotEqual(t, newSession(), newSession())
+	var got acp.NewSessionResult
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.NotEmpty(t, got.SessionID)
 }
 
 // TestSessionNewRequiresAnAbsoluteCwd pins the spec's constraint on cwd. A
@@ -315,4 +316,67 @@ func TestSessionMethodsRejectMalformedParams(t *testing.T) {
 			assert.ErrorIs(t, err, acp.ErrInvalidParams)
 		})
 	}
+}
+
+// TestSessionNewRefusesADirectoryItCannotServe is the fix for accepting a cwd
+// and then ignoring it. The agent's working directory is frozen when it is
+// constructed, so a session opened for anywhere else would run every file and
+// shell tool against the startup directory while the client believed otherwise.
+//
+// Validating that cwd is absolute and then discarding it was worse than not
+// validating at all: it looked like the field had been honoured.
+func TestSessionNewRefusesADirectoryItCannotServe(t *testing.T) {
+	t.Parallel()
+
+	cfg := sessionConfig(nil)
+	cfg.WorkingDir = "/repo"
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, cfg)
+
+	_, err := registry.Call("session/new", json.RawMessage(`{"cwd":"/other-project","mcpServers":[]}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, acp.ErrInvalidParams)
+	assert.Contains(t, err.Error(), "/other-project")
+	assert.Contains(t, err.Error(), "/repo", "the client needs to know which directory it can have")
+}
+
+// TestSessionNewAcceptsItsOwnDirectory covers the matching case, including a
+// non-canonical spelling of the same path.
+func TestSessionNewAcceptsItsOwnDirectory(t *testing.T) {
+	t.Parallel()
+
+	// A fresh registry per spelling: the single-session limit would refuse the
+	// second call regardless of its cwd, which would hide what is under test.
+	for _, cwd := range []string{"/repo", "/repo/", "/repo/./"} {
+		cfg := sessionConfig(nil)
+		cfg.WorkingDir = "/repo"
+		registry := acp.NewCapabilityRegistry()
+		acp.RegisterSession(registry, cfg)
+
+		_, err := registry.Call("session/new", json.RawMessage(`{"cwd":"`+cwd+`","mcpServers":[]}`))
+		assert.NoError(t, err, "cwd %q names the agent's own directory", cwd)
+	}
+}
+
+// TestSessionNewRefusesASecondSession pins the session-isolation limit. ACP
+// says a session is an independent context with its own history; this agent
+// owns exactly one conversation, so a second session id would hand the client
+// a fresh-looking session that silently shares the first one's history.
+//
+// Refusing is the honest position until sessions get their own agent state.
+func TestSessionNewRefusesASecondSession(t *testing.T) {
+	t.Parallel()
+
+	cfg := sessionConfig(nil)
+	cfg.WorkingDir = "/repo"
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, cfg)
+
+	_, err := registry.Call("session/new", json.RawMessage(`{"cwd":"/repo","mcpServers":[]}`))
+	require.NoError(t, err)
+
+	_, err = registry.Call("session/new", json.RawMessage(`{"cwd":"/repo","mcpServers":[]}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "one session",
+		"the client must learn the limit, not receive an id that lies about isolation")
 }

--- a/internal/acp/session_test.go
+++ b/internal/acp/session_test.go
@@ -222,3 +222,56 @@ func TestSessionPromptReportsRefusalWithoutInventingOne(t *testing.T) {
 	assert.NotErrorIs(t, err, acp.ErrInvalidParams,
 		"the agent failed, not the client's payload; -32603, not -32602")
 }
+
+// TestSessionUpdateShapes pins the wire shape of the notifications a turn
+// streams back. The discriminator is a field named sessionUpdate, not the
+// JSON-RPC method, and a client demultiplexes on it — so a wrong or missing
+// discriminator is a silently ignored update rather than a loud failure.
+func TestSessionUpdateShapes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("agent message chunk", func(t *testing.T) {
+		t.Parallel()
+
+		got := decodeUpdate(t, acp.NewSessionNotification("sess-1",
+			acp.AgentMessageChunk("hello")))
+		assert.Equal(t, "sess-1", got["sessionId"])
+		update := got["update"].(map[string]any)
+		assert.Equal(t, "agent_message_chunk", update["sessionUpdate"])
+		content := update["content"].(map[string]any)
+		assert.Equal(t, "text", content["type"])
+		assert.Equal(t, "hello", content["text"])
+	})
+
+	t.Run("tool call", func(t *testing.T) {
+		t.Parallel()
+
+		got := decodeUpdate(t, acp.NewSessionNotification("sess-1",
+			acp.ToolCall("call-1", "read_file")))
+		update := got["update"].(map[string]any)
+		assert.Equal(t, "tool_call", update["sessionUpdate"])
+		assert.Equal(t, "call-1", update["toolCallId"])
+		assert.Equal(t, "read_file", update["title"])
+		assert.Equal(t, "pending", update["status"])
+	})
+
+	t.Run("tool call update carries a terminal status", func(t *testing.T) {
+		t.Parallel()
+
+		got := decodeUpdate(t, acp.NewSessionNotification("sess-1",
+			acp.ToolCallUpdate("call-1", acp.ToolCallFailed)))
+		update := got["update"].(map[string]any)
+		assert.Equal(t, "tool_call_update", update["sessionUpdate"])
+		assert.Equal(t, "call-1", update["toolCallId"])
+		assert.Equal(t, "failed", update["status"])
+	})
+}
+
+func decodeUpdate(t *testing.T, n acp.SessionNotification) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(n)
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	return got
+}

--- a/internal/acp/session_test.go
+++ b/internal/acp/session_test.go
@@ -275,3 +275,44 @@ func decodeUpdate(t *testing.T, n acp.SessionNotification) map[string]any {
 	require.NoError(t, json.Unmarshal(raw, &got))
 	return got
 }
+
+// TestSessionPromptWithNoHandlerSaysSo covers a registry wired without a prompt
+// handler. Answering a stop reason would report a turn that never ran; the
+// client is told the method is unserved instead.
+func TestSessionPromptWithNoHandlerSaysSo(t *testing.T) {
+	t.Parallel()
+
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, sessionConfig(nil))
+
+	raw, err := registry.Call("session/new", json.RawMessage(`{"cwd":"/repo","mcpServers":[]}`))
+	require.NoError(t, err)
+	var created acp.NewSessionResult
+	require.NoError(t, json.Unmarshal(raw, &created))
+
+	_, err = registry.Call("session/prompt", json.RawMessage(
+		`{"sessionId":"`+created.SessionID+`","prompt":[{"type":"text","text":"hi"}]}`))
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, acp.ErrInvalidParams,
+		"the client's payload was fine; the agent is the one missing a handler")
+}
+
+// TestSessionMethodsRejectMalformedParams covers the decode failure both
+// methods share. Malformed JSON is the client's to fix, so it must not surface
+// as an internal error.
+func TestSessionMethodsRejectMalformedParams(t *testing.T) {
+	t.Parallel()
+
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, sessionConfig(nil))
+
+	for _, method := range []string{"session/new", "session/prompt"} {
+		t.Run(method, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := registry.Call(method, json.RawMessage(`{"cwd":`))
+			require.Error(t, err)
+			assert.ErrorIs(t, err, acp.ErrInvalidParams)
+		})
+	}
+}

--- a/internal/acp/session_test.go
+++ b/internal/acp/session_test.go
@@ -1,0 +1,224 @@
+package acp_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/acp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sessionConfig is a session setup that accepts nothing beyond text, matching
+// what this agent's handshake actually declares.
+func sessionConfig(prompt acp.PromptFunc) acp.SessionConfig {
+	return acp.SessionConfig{
+		Capabilities: acp.AgentCapabilities{},
+		Prompt:       prompt,
+	}
+}
+
+// TestSessionNewMintsDistinctIDs covers the method every ACP conversation opens
+// with. The ids must differ: session/prompt routes by id, so a collision would
+// deliver one client's turn into another's conversation.
+func TestSessionNewMintsDistinctIDs(t *testing.T) {
+	t.Parallel()
+
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, sessionConfig(nil))
+
+	newSession := func() string {
+		raw, err := registry.Call("session/new", json.RawMessage(`{"cwd":"/repo","mcpServers":[]}`))
+		require.NoError(t, err)
+		var got acp.NewSessionResult
+		require.NoError(t, json.Unmarshal(raw, &got))
+		require.NotEmpty(t, got.SessionID)
+		return got.SessionID
+	}
+
+	assert.NotEqual(t, newSession(), newSession())
+}
+
+// TestSessionNewRequiresAnAbsoluteCwd pins the spec's constraint on cwd. A
+// relative path is not merely unusual: the agent and the client resolve it
+// against different working directories, so it names two different places while
+// looking like agreement.
+func TestSessionNewRequiresAnAbsoluteCwd(t *testing.T) {
+	t.Parallel()
+
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, sessionConfig(nil))
+
+	for _, tc := range []struct {
+		name   string
+		params string
+	}{
+		{"relative", `{"cwd":"repo/src","mcpServers":[]}`},
+		{"absent", `{"mcpServers":[]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := registry.Call("session/new", json.RawMessage(tc.params))
+			require.Error(t, err)
+			assert.ErrorIs(t, err, acp.ErrInvalidParams)
+			assert.Contains(t, err.Error(), "cwd")
+		})
+	}
+}
+
+// TestSessionNewRefusesWorkItCannotDo covers the two session/new inputs this
+// agent has no implementation for. Accepting either silently is the same defect
+// as accepting an undeclared content block: the client goes on to prompt
+// believing its MCP tools are connected and its extra directories are in scope,
+// and nothing ever tells it otherwise.
+//
+// Empty is not refused — a client that always sends "mcpServers":[] is asking
+// for nothing and should get a session.
+func TestSessionNewRefusesWorkItCannotDo(t *testing.T) {
+	t.Parallel()
+
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, sessionConfig(nil))
+
+	for _, tc := range []struct {
+		name   string
+		params string
+		want   string
+	}{
+		{
+			"mcp servers",
+			`{"cwd":"/repo","mcpServers":[{"name":"fs","command":"srv"}]}`,
+			"mcpServers",
+		},
+		{
+			"additional directories",
+			`{"cwd":"/repo","mcpServers":[],"additionalDirectories":["/other"]}`,
+			"additionalDirectories",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := registry.Call("session/new", json.RawMessage(tc.params))
+			require.Error(t, err)
+			assert.ErrorIs(t, err, acp.ErrInvalidParams)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// TestSessionNewAcceptsEmptyOptionalLists is the other side of the refusal: the
+// common client payload must still open a session.
+func TestSessionNewAcceptsEmptyOptionalLists(t *testing.T) {
+	t.Parallel()
+
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, sessionConfig(nil))
+
+	_, err := registry.Call("session/new", json.RawMessage(
+		`{"cwd":"/repo","mcpServers":[],"additionalDirectories":[]}`))
+	assert.NoError(t, err)
+}
+
+// TestSessionPromptRejectsUnknownSession is the routing check. An id the agent
+// never minted has no conversation behind it, and answering it as though it did
+// would run the turn against a fresh context the client believes is its own.
+func TestSessionPromptRejectsUnknownSession(t *testing.T) {
+	t.Parallel()
+
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, sessionConfig(nil))
+
+	_, err := registry.Call("session/prompt", json.RawMessage(
+		`{"sessionId":"never-minted","prompt":[{"type":"text","text":"hi"}]}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, acp.ErrInvalidParams)
+	assert.Contains(t, err.Error(), "never-minted")
+}
+
+// TestSessionPromptRunsTheTurn is the point of the slice: a prompt reaches the
+// agent, with the session's cwd attached, and its stop reason reaches the
+// client.
+func TestSessionPromptRunsTheTurn(t *testing.T) {
+	t.Parallel()
+
+	var gotReq acp.PromptRequest
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, sessionConfig(
+		func(_ context.Context, req acp.PromptRequest) (acp.StopReason, error) {
+			gotReq = req
+			return acp.StopEndTurn, nil
+		}))
+
+	raw, err := registry.Call("session/new", json.RawMessage(`{"cwd":"/repo","mcpServers":[]}`))
+	require.NoError(t, err)
+	var created acp.NewSessionResult
+	require.NoError(t, json.Unmarshal(raw, &created))
+
+	raw, err = registry.Call("session/prompt", json.RawMessage(
+		`{"sessionId":"`+created.SessionID+`","prompt":[{"type":"text","text":"summarise this"}]}`))
+	require.NoError(t, err)
+
+	var got acp.PromptResult
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, acp.StopEndTurn, got.StopReason)
+
+	assert.Equal(t, created.SessionID, gotReq.SessionID)
+	assert.Equal(t, "/repo", gotReq.Cwd)
+	require.Len(t, gotReq.Prompt, 1)
+	assert.Equal(t, "summarise this", gotReq.Prompt[0].Text)
+}
+
+// TestSessionPromptRejectsUndeclaredContent wires the capability gate into the
+// method that receives client content. The decoder is tested on its own; this
+// pins that session/prompt actually calls it rather than decoding the array
+// itself and skipping the check.
+func TestSessionPromptRejectsUndeclaredContent(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, sessionConfig(
+		func(context.Context, acp.PromptRequest) (acp.StopReason, error) {
+			called = true
+			return acp.StopEndTurn, nil
+		}))
+
+	raw, err := registry.Call("session/new", json.RawMessage(`{"cwd":"/repo","mcpServers":[]}`))
+	require.NoError(t, err)
+	var created acp.NewSessionResult
+	require.NoError(t, json.Unmarshal(raw, &created))
+
+	_, err = registry.Call("session/prompt", json.RawMessage(
+		`{"sessionId":"`+created.SessionID+`","prompt":[{"type":"image","data":"aGk=","mimeType":"image/png"}]}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, acp.ErrInvalidParams)
+	assert.False(t, called, "an inadmissible prompt must not reach the agent at all")
+}
+
+// TestSessionPromptReportsRefusalWithoutInventingOne separates the two ways a
+// turn can end badly. A handler error is the agent failing; it must not be
+// dressed up as a StopReason, which would tell the client the model declined
+// when in fact the agent broke.
+func TestSessionPromptReportsRefusalWithoutInventingOne(t *testing.T) {
+	t.Parallel()
+
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, sessionConfig(
+		func(context.Context, acp.PromptRequest) (acp.StopReason, error) {
+			return "", assert.AnError
+		}))
+
+	raw, err := registry.Call("session/new", json.RawMessage(`{"cwd":"/repo","mcpServers":[]}`))
+	require.NoError(t, err)
+	var created acp.NewSessionResult
+	require.NoError(t, json.Unmarshal(raw, &created))
+
+	_, err = registry.Call("session/prompt", json.RawMessage(
+		`{"sessionId":"`+created.SessionID+`","prompt":[{"type":"text","text":"hi"}]}`))
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, acp.ErrInvalidParams,
+		"the agent failed, not the client's payload; -32603, not -32602")
+}

--- a/internal/acp/session_test.go
+++ b/internal/acp/session_test.go
@@ -3,6 +3,7 @@ package acp_test
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 
 	"github.com/julianshen/rubichan/internal/acp"
@@ -379,4 +380,79 @@ func TestSessionNewRefusesASecondSession(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "one session",
 		"the client must learn the limit, not receive an id that lies about isolation")
+}
+
+// TestSessionMethodsRequireTheHandshake pins ACP's ordering rule: initialize
+// comes first. A client that skips it has negotiated no protocol version and
+// declared no capabilities, so serving it a session means running turns for a
+// peer whose contract is unknown.
+func TestSessionMethodsRequireTheHandshake(t *testing.T) {
+	t.Parallel()
+
+	handshake := acp.NewHandshake()
+	cfg := sessionConfig(func(context.Context, acp.PromptRequest) (acp.StopReason, error) {
+		return acp.StopEndTurn, nil
+	})
+	cfg.Handshake = handshake
+
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, cfg)
+
+	_, err := registry.Call("session/new", json.RawMessage(`{"cwd":"/repo","mcpServers":[]}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "initialize")
+
+	handshake.MarkComplete()
+
+	_, err = registry.Call("session/new", json.RawMessage(`{"cwd":"/repo","mcpServers":[]}`))
+	assert.NoError(t, err, "once the handshake is done the session opens normally")
+}
+
+// TestSessionPromptRefusesASecondConcurrentTurn pins ACP's one-turn-per-session
+// rule. A session has a single conversation; two turns running against it would
+// interleave their session/update streams and append to the same history in an
+// order neither client asked for.
+func TestSessionPromptRefusesASecondConcurrentTurn(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	// Only the first turn blocks. The third call at the end of this test reuses
+	// the same handler, so signalling unconditionally would re-close a closed
+	// channel and re-block on a drained one.
+	var once sync.Once
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, sessionConfig(
+		func(context.Context, acp.PromptRequest) (acp.StopReason, error) {
+			once.Do(func() {
+				close(started)
+				<-release
+			})
+			return acp.StopEndTurn, nil
+		}))
+
+	raw, err := registry.Call("session/new", json.RawMessage(`{"cwd":"/repo","mcpServers":[]}`))
+	require.NoError(t, err)
+	var created acp.NewSessionResult
+	require.NoError(t, json.Unmarshal(raw, &created))
+
+	prompt := json.RawMessage(`{"sessionId":"` + created.SessionID + `","prompt":[{"type":"text","text":"hi"}]}`)
+
+	first := make(chan error, 1)
+	go func() {
+		_, err := registry.Call("session/prompt", prompt)
+		first <- err
+	}()
+	<-started
+
+	_, err = registry.Call("session/prompt", prompt)
+	require.Error(t, err, "the session already has a turn in flight")
+	assert.Contains(t, err.Error(), "active turn")
+
+	close(release)
+	require.NoError(t, <-first)
+
+	// The guard must clear, or the session would be usable exactly once.
+	_, err = registry.Call("session/prompt", prompt)
+	assert.NoError(t, err, "a finished turn releases the session")
 }

--- a/internal/acp/session_test.go
+++ b/internal/acp/session_test.go
@@ -223,6 +223,11 @@ func TestSessionPromptReportsRefusalWithoutInventingOne(t *testing.T) {
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, acp.ErrInvalidParams,
 		"the agent failed, not the client's payload; -32603, not -32602")
+	// Pinned positively as well: NotErrorIs alone passes for any error that is
+	// not ErrInvalidParams, so a regression returning some unrelated failure
+	// would still satisfy it.
+	assert.ErrorIs(t, err, assert.AnError,
+		"the handler's own failure must reach the caller")
 }
 
 // TestSessionUpdateShapes pins the wire shape of the notifications a turn
@@ -238,9 +243,9 @@ func TestSessionUpdateShapes(t *testing.T) {
 		got := decodeUpdate(t, acp.NewSessionNotification("sess-1",
 			acp.AgentMessageChunk("hello")))
 		assert.Equal(t, "sess-1", got["sessionId"])
-		update := got["update"].(map[string]any)
+		update := requireObject(t, got["update"])
 		assert.Equal(t, "agent_message_chunk", update["sessionUpdate"])
-		content := update["content"].(map[string]any)
+		content := requireObject(t, update["content"])
 		assert.Equal(t, "text", content["type"])
 		assert.Equal(t, "hello", content["text"])
 	})
@@ -250,7 +255,7 @@ func TestSessionUpdateShapes(t *testing.T) {
 
 		got := decodeUpdate(t, acp.NewSessionNotification("sess-1",
 			acp.ToolCall("call-1", "read_file")))
-		update := got["update"].(map[string]any)
+		update := requireObject(t, got["update"])
 		assert.Equal(t, "tool_call", update["sessionUpdate"])
 		assert.Equal(t, "call-1", update["toolCallId"])
 		assert.Equal(t, "read_file", update["title"])
@@ -262,11 +267,22 @@ func TestSessionUpdateShapes(t *testing.T) {
 
 		got := decodeUpdate(t, acp.NewSessionNotification("sess-1",
 			acp.ToolCallUpdate("call-1", acp.ToolCallFailed)))
-		update := got["update"].(map[string]any)
+		update := requireObject(t, got["update"])
 		assert.Equal(t, "tool_call_update", update["sessionUpdate"])
 		assert.Equal(t, "call-1", update["toolCallId"])
 		assert.Equal(t, "failed", update["status"])
 	})
+}
+
+// requireObject asserts a field decoded to a JSON object before indexing it. A
+// bare type assertion panics on a shape change, and a panic takes down the test
+// binary's goroutine — so a wire-shape regression would report less than it
+// could, hiding the sibling subtests behind the first one to break.
+func requireObject(t *testing.T, v any) map[string]any {
+	t.Helper()
+	obj, ok := v.(map[string]any)
+	require.True(t, ok, "expected a JSON object, got %T", v)
+	return obj
 }
 
 func decodeUpdate(t *testing.T, n acp.SessionNotification) map[string]any {

--- a/internal/acp/session_test.go
+++ b/internal/acp/session_test.go
@@ -3,6 +3,7 @@ package acp_test
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"sync"
 	"testing"
 
@@ -471,4 +472,49 @@ func TestSessionPromptRefusesASecondConcurrentTurn(t *testing.T) {
 	// The guard must clear, or the session would be usable exactly once.
 	_, err = registry.Call("session/prompt", prompt)
 	assert.NoError(t, err, "a finished turn releases the session")
+}
+
+// TestSessionNewResolvesARelativeWorkingDir covers an agent constructed with a
+// relative working-directory override. WithWorkingDir stores the value as
+// given and New only fills it from os.Getwd when empty, so it can stay
+// relative — while ACP requires the client's cwd to be absolute.
+//
+// Comparing the two with Clean alone preserves that distinction and rejects
+// every valid request for the very directory the tools operate in.
+func TestSessionNewResolvesARelativeWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	cfg := sessionConfig(nil)
+	cfg.WorkingDir = "." // relative, names the process's own directory
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, cfg)
+
+	_, err = registry.Call("session/new", json.RawMessage(
+		`{"cwd":"`+wd+`","mcpServers":[]}`))
+	assert.NoError(t, err, "the absolute client cwd names the same directory as %q", cfg.WorkingDir)
+}
+
+// TestSessionNewRefusesWhenNoWorkingDirWasWired guards the empty case against
+// the absolute-path resolution added for relative overrides. filepath.Abs("")
+// returns the process's own directory, so resolving before checking would turn
+// "the caller never said which directory it serves" into "serve wherever this
+// process happens to be running".
+func TestSessionNewRefusesWhenNoWorkingDirWasWired(t *testing.T) {
+	t.Parallel()
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	cfg := sessionConfig(nil)
+	cfg.WorkingDir = ""
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterSession(registry, cfg)
+
+	_, err = registry.Call("session/new", json.RawMessage(
+		`{"cwd":"`+wd+`","mcpServers":[]}`))
+	require.Error(t, err, "an unwired agent must not silently serve the process directory")
+	assert.ErrorIs(t, err, acp.ErrInvalidParams)
 }

--- a/internal/acp/types.go
+++ b/internal/acp/types.go
@@ -99,6 +99,13 @@ const (
 	MethodInitialize = "initialize"
 	MethodShutdown   = "shutdown"
 
+	// Session methods
+	MethodSessionNew    = "session/new"
+	MethodSessionPrompt = "session/prompt"
+	// MethodSessionUpdate is a notification the agent sends, not a method it
+	// serves: it carries turn events back to the client during session/prompt.
+	MethodSessionUpdate = "session/update"
+
 	// Rubichan-specific extensions
 	MethodSkillInvoke     = "skill/invoke"
 	MethodSkillList       = "skill/list"

--- a/internal/acp/update.go
+++ b/internal/acp/update.go
@@ -1,0 +1,81 @@
+package acp
+
+// ToolCallStatus is the lifecycle of a tool call as reported to the client.
+type ToolCallStatus string
+
+const (
+	ToolCallPending    ToolCallStatus = "pending"
+	ToolCallInProgress ToolCallStatus = "in_progress"
+	ToolCallCompleted  ToolCallStatus = "completed"
+	ToolCallFailed     ToolCallStatus = "failed"
+)
+
+// SessionNotification is the params of a session/update notification.
+//
+// Update is the tagged union of turn events. The tag lives in a field named
+// sessionUpdate rather than in the JSON-RPC method, so every variant arrives
+// under the same method name and a client demultiplexes on the field. Getting
+// the tag wrong yields an update the client silently ignores rather than one it
+// rejects, which is why the variants are built here instead of at call sites.
+type SessionNotification struct {
+	SessionID string `json:"sessionId"`
+	Update    any    `json:"update"`
+}
+
+// NewSessionNotification addresses an update to a session.
+func NewSessionNotification(sessionID string, update any) SessionNotification {
+	return SessionNotification{SessionID: sessionID, Update: update}
+}
+
+// agentMessageChunk is one piece of the agent's reply.
+type agentMessageChunk struct {
+	SessionUpdate string       `json:"sessionUpdate"`
+	Content       ContentBlock `json:"content"`
+}
+
+// AgentMessageChunk carries a fragment of assistant text to the client. This is
+// how the reply itself reaches the far side: session/prompt's result carries
+// only a stop reason.
+func AgentMessageChunk(text string) any {
+	return agentMessageChunk{
+		SessionUpdate: "agent_message_chunk",
+		Content:       ContentBlock{Type: ContentText, Text: text},
+	}
+}
+
+// toolCall announces a tool the agent has begun.
+type toolCall struct {
+	SessionUpdate string         `json:"sessionUpdate"`
+	ToolCallID    string         `json:"toolCallId"`
+	Title         string         `json:"title"`
+	Status        ToolCallStatus `json:"status"`
+}
+
+// ToolCall announces a tool invocation as pending. The title is what a client
+// shows a user, so it is the tool's name rather than its id.
+func ToolCall(id, title string) any {
+	return toolCall{
+		SessionUpdate: "tool_call",
+		ToolCallID:    id,
+		Title:         title,
+		Status:        ToolCallPending,
+	}
+}
+
+// toolCallUpdate moves an announced tool call to a new status.
+type toolCallUpdate struct {
+	SessionUpdate string         `json:"sessionUpdate"`
+	ToolCallID    string         `json:"toolCallId"`
+	Status        ToolCallStatus `json:"status"`
+}
+
+// ToolCallUpdate reports a tool call's new status against the id ToolCall
+// announced. A client matches on that id, so an update carrying a different one
+// creates a second tool call in the UI rather than advancing the first.
+func ToolCallUpdate(id string, status ToolCallStatus) any {
+	return toolCallUpdate{
+		SessionUpdate: "tool_call_update",
+		ToolCallID:    id,
+		Status:        status,
+	}
+}

--- a/internal/agent/acp_handlers.go
+++ b/internal/agent/acp_handlers.go
@@ -11,6 +11,25 @@ import (
 // agentVersion is reported to peers in the initialize handshake.
 const agentVersion = "1.0.0"
 
+// acpAgentCapabilities is what this agent tells an ACP client it can do.
+//
+// It is a single function rather than a literal at each use because two places
+// now depend on it: the handshake publishes it, and session/prompt gates
+// incoming content on it. Restating it in both would let the agent advertise
+// one set and enforce another, which is the specific dishonesty the prompt
+// decoder exists to prevent.
+//
+// Every field is false, and stays false until the method behind it is
+// registered. embeddedContext means the agent accepts embedded
+// ContentBlock::Resource data in session/prompt; loadSession means it serves
+// session/load. Neither exists yet, and advertising a capability whose method
+// is unregistered tells a client it may send something that will fail — the
+// same defect as the deleted adapters, pointed the other way. These flip on in
+// the slice that registers the handler.
+func acpAgentCapabilities() acp.AgentCapabilities {
+	return acp.AgentCapabilities{}
+}
+
 // NewACPRegistry builds the capability registry an ACP peer is served from:
 // the agent's tools plus its method handlers. This is a composition-root
 // operation — the agent core holds no ACP state.
@@ -40,15 +59,8 @@ func (a *Agent) registerACPCapabilities(registry *acp.CapabilityRegistry) {
 	}
 
 	acp.RegisterInitialize(registry, acp.InitializeConfig{
-		AgentInfo: acp.AgentInfo{Name: "rubichan", Version: agentVersion},
-		// Every field here is false, and stays false until the method behind it
-		// is registered. embeddedContext means the agent accepts embedded
-		// ContentBlock::Resource data in session/prompt; loadSession means it
-		// serves session/load. Neither exists yet, and advertising a capability
-		// whose method is unregistered tells a client it may send something
-		// that will fail — the same defect as the deleted adapters, pointed the
-		// other way. These flip on in the slice that registers the handler.
-		Capabilities: acp.AgentCapabilities{},
+		AgentInfo:    acp.AgentInfo{Name: "rubichan", Version: agentVersion},
+		Capabilities: acpAgentCapabilities(),
 		OnInitialized: func(caps acp.ClientCapabilities, _ acp.AgentInfo) {
 			a.setClientCapabilities(caps)
 		},

--- a/internal/agent/acp_handlers.go
+++ b/internal/agent/acp_handlers.go
@@ -38,14 +38,24 @@ func acpAgentCapabilities() acp.AgentCapabilities {
 // acp.Conn, which takes a registry and owns the framing. Callers wrap it with
 // acp.NewConn(r, w, registry) where a mode actually serves ACP.
 func NewACPRegistry(a *Agent) *acp.CapabilityRegistry {
-	registry := acp.NewCapabilityRegistry()
-	a.registerACPCapabilities(registry)
+	registry, _ := newACPRegistry(a)
 	return registry
+}
+
+// newACPRegistry also returns the handshake the registry's initialize marks, so
+// a caller wiring session methods can gate them on it. Returning it rather than
+// reaching back into the registry keeps the ordering rule explicit at the
+// composition root instead of hidden inside the registry.
+func newACPRegistry(a *Agent) (*acp.CapabilityRegistry, *acp.Handshake) {
+	registry := acp.NewCapabilityRegistry()
+	handshake := acp.NewHandshake()
+	a.registerACPCapabilities(registry, handshake)
+	return registry, handshake
 }
 
 // registerACPCapabilities registers all ACP capabilities and method
 // handlers on the given registry.
-func (a *Agent) registerACPCapabilities(registry *acp.CapabilityRegistry) {
+func (a *Agent) registerACPCapabilities(registry *acp.CapabilityRegistry, handshake *acp.Handshake) {
 	for _, toolName := range a.tools.Names() {
 		tool, ok := a.tools.Get(toolName)
 		if !ok {
@@ -61,6 +71,7 @@ func (a *Agent) registerACPCapabilities(registry *acp.CapabilityRegistry) {
 	acp.RegisterInitialize(registry, acp.InitializeConfig{
 		AgentInfo:    acp.AgentInfo{Name: "rubichan", Version: agentVersion},
 		Capabilities: acpAgentCapabilities(),
+		Handshake:    handshake,
 		OnInitialized: func(caps acp.ClientCapabilities, _ acp.AgentInfo) {
 			a.setClientCapabilities(caps)
 		},

--- a/internal/agent/acp_serve_internal_test.go
+++ b/internal/agent/acp_serve_internal_test.go
@@ -9,6 +9,9 @@ import (
 	"time"
 
 	"github.com/julianshen/rubichan/internal/acp"
+	"github.com/julianshen/rubichan/internal/config"
+	"github.com/julianshen/rubichan/internal/provider"
+	"github.com/julianshen/rubichan/internal/tools"
 	"github.com/julianshen/rubichan/pkg/agentsdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -223,3 +226,64 @@ func (c *acpClient) result(t *testing.T, id int, v any) {
 }
 
 func (c *acpClient) close() { _ = c.w.Close() }
+
+// acpStubProvider is a provider that is never actually streamed from: the
+// ServeACP test only completes a handshake, which touches no provider.
+type acpStubProvider struct{}
+
+func (acpStubProvider) Stream(context.Context, provider.CompletionRequest) (<-chan provider.StreamEvent, error) {
+	ch := make(chan provider.StreamEvent)
+	close(ch)
+	return ch, nil
+}
+
+func (acpStubProvider) Name() string { return "acp-stub" }
+
+// TestServeACPWiresARealAgent covers the exported entry point rather than the
+// seam beneath it. It asserts only that a real Agent can be served and answer
+// its handshake — the turn behaviour is covered against an injected turn, which
+// does not need a live provider.
+func TestServeACPWiresARealAgent(t *testing.T) {
+	t.Parallel()
+
+	a := New(
+		acpStubProvider{},
+		tools.NewRegistry(),
+		func(context.Context, string, json.RawMessage) (bool, error) { return true, nil },
+		&config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+			Agent:    config.AgentConfig{MaxTurns: 1},
+		},
+	)
+
+	serverR, clientW := io.Pipe()
+	clientR, serverW := io.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = ServeACP(ctx, a, serverR, serverW)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		_ = clientW.Close()
+		_ = serverW.Close()
+	})
+
+	client := &acpClient{w: clientW, r: bufio.NewScanner(clientR), enc: json.NewEncoder(clientW)}
+	client.send(t, 1, "initialize", map[string]any{
+		"protocolVersion":    1,
+		"clientCapabilities": map[string]any{},
+	})
+
+	var got acp.InitializeResult
+	client.result(t, 1, &got)
+	assert.Equal(t, "rubichan", got.AgentInfo.Name)
+
+	client.close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ServeACP did not return after the client hung up")
+	}
+}

--- a/internal/agent/acp_serve_internal_test.go
+++ b/internal/agent/acp_serve_internal_test.go
@@ -105,7 +105,16 @@ func TestServeACPRefusesAPromptForAnUnopenedSession(t *testing.T) {
 
 	client, _ := startACP(t, nil)
 
-	client.send(t, 1, "session/prompt", map[string]any{
+	// The handshake first, or the refusal under test would be masked by the
+	// ordering check rather than the session lookup.
+	client.send(t, 1, "initialize", map[string]any{
+		"protocolVersion":    1,
+		"clientCapabilities": map[string]any{},
+	})
+	var initResult acp.InitializeResult
+	client.result(t, 1, &initResult)
+
+	client.send(t, 2, "session/prompt", map[string]any{
 		"sessionId": "never-minted",
 		"prompt":    []any{map[string]any{"type": "text", "text": "hello"}},
 	})
@@ -114,6 +123,27 @@ func TestServeACPRefusesAPromptForAnUnopenedSession(t *testing.T) {
 	require.NotNil(t, msg.Error)
 	assert.Equal(t, acp.ErrorCodeInvalidParams, msg.Error.Code,
 		"an unknown session is the client's mistake to fix")
+	assert.Contains(t, msg.Error.Message, "never-minted")
+}
+
+// TestServeACPRefusesASessionBeforeInitialize pins ACP's ordering rule over the
+// wire. A client that skips the handshake has agreed no protocol version and
+// declared no capabilities, so serving it a session would mean running turns
+// under a contract neither side stated.
+func TestServeACPRefusesASessionBeforeInitialize(t *testing.T) {
+	t.Parallel()
+
+	client, _ := startACP(t, nil)
+
+	client.send(t, 1, "session/new", map[string]any{
+		"cwd":        "/repo",
+		"mcpServers": []any{},
+	})
+
+	msg := client.read(t)
+	require.NotNil(t, msg.Error)
+	assert.Equal(t, acp.ErrorCodeInvalidParams, msg.Error.Code)
+	assert.Contains(t, msg.Error.Message, "initialize")
 }
 
 // acpClient is the far side of a served ACP connection.
@@ -133,9 +163,11 @@ func startACP(t *testing.T, turn turnFunc) (*acpClient, chan struct{}) {
 	// test is about the session wiring, and NewACPRegistry needs a live Agent
 	// to enumerate tools from.
 	registry := acp.NewCapabilityRegistry()
+	handshake := acp.NewHandshake()
 	acp.RegisterInitialize(registry, acp.InitializeConfig{
 		AgentInfo:    acp.AgentInfo{Name: "rubichan", Version: agentVersion},
 		Capabilities: acpAgentCapabilities(),
+		Handshake:    handshake,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -146,6 +178,7 @@ func startACP(t *testing.T, turn turnFunc) (*acpClient, chan struct{}) {
 			Registry:     registry,
 			Capabilities: acpAgentCapabilities(),
 			WorkingDir:   "/repo",
+			Handshake:    handshake,
 			Turn:         turn,
 		})
 	}()

--- a/internal/agent/acp_serve_internal_test.go
+++ b/internal/agent/acp_serve_internal_test.go
@@ -1,0 +1,225 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/julianshen/rubichan/internal/acp"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServeACPCarriesAWholeConversation is the end-to-end this slice exists to
+// make possible: a client opens a session and prompts it, the reply streams
+// back as session/update notifications, and the call closes with a stop reason.
+//
+// It is driven over a real pipe rather than by calling handlers directly,
+// because the defect this whole rebuild was started for was a set of methods
+// that each worked in isolation and could not complete one operation between
+// them.
+func TestServeACPCarriesAWholeConversation(t *testing.T) {
+	t.Parallel()
+
+	turn := func(_ context.Context, msg string) (<-chan agentsdk.TurnEvent, error) {
+		ch := make(chan agentsdk.TurnEvent, 4)
+		ch <- agentsdk.TurnEvent{Type: "text_delta", Text: "saw: " + msg}
+		ch <- agentsdk.TurnEvent{Type: "done", ExitReason: agentsdk.ExitCompleted}
+		close(ch)
+		return ch, nil
+	}
+
+	client, done := startACP(t, turn)
+
+	// initialize
+	client.send(t, 1, "initialize", map[string]any{
+		"protocolVersion":    1,
+		"clientCapabilities": map[string]any{},
+	})
+	var initResult acp.InitializeResult
+	client.result(t, 1, &initResult)
+	assert.Equal(t, acp.ProtocolVersion, initResult.ProtocolVersion)
+
+	// session/new
+	client.send(t, 2, "session/new", map[string]any{
+		"cwd":        "/repo",
+		"mcpServers": []any{},
+	})
+	var created acp.NewSessionResult
+	client.result(t, 2, &created)
+	require.NotEmpty(t, created.SessionID)
+
+	// session/prompt: updates arrive before the response to the same call.
+	client.send(t, 3, "session/prompt", map[string]any{
+		"sessionId": created.SessionID,
+		"prompt":    []any{map[string]any{"type": "text", "text": "hello"}},
+	})
+
+	var chunks []string
+	var stop acp.PromptResult
+	for {
+		msg := client.read(t)
+		if msg.Method == acp.MethodSessionUpdate {
+			var n struct {
+				SessionID string `json:"sessionId"`
+				Update    struct {
+					SessionUpdate string           `json:"sessionUpdate"`
+					Content       acp.ContentBlock `json:"content"`
+				} `json:"update"`
+			}
+			require.NoError(t, json.Unmarshal(msg.Params, &n))
+			assert.Equal(t, created.SessionID, n.SessionID)
+			assert.Equal(t, "agent_message_chunk", n.Update.SessionUpdate)
+			chunks = append(chunks, n.Update.Content.Text)
+			continue
+		}
+		require.Nil(t, msg.Error, "session/prompt failed: %v", msg.Error)
+		require.NotNil(t, msg.Result)
+		require.NoError(t, json.Unmarshal(*msg.Result, &stop))
+		break
+	}
+
+	assert.Equal(t, []string{"saw: hello"}, chunks,
+		"the reply reaches the client only through session/update")
+	assert.Equal(t, acp.StopEndTurn, stop.StopReason)
+
+	client.close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("serveACP did not return after the client hung up")
+	}
+}
+
+// TestServeACPRefusesAPromptForAnUnopenedSession pins that the session check is
+// live over the wire, not only in the handler's unit test.
+func TestServeACPRefusesAPromptForAnUnopenedSession(t *testing.T) {
+	t.Parallel()
+
+	client, _ := startACP(t, nil)
+
+	client.send(t, 1, "session/prompt", map[string]any{
+		"sessionId": "never-minted",
+		"prompt":    []any{map[string]any{"type": "text", "text": "hello"}},
+	})
+
+	msg := client.read(t)
+	require.NotNil(t, msg.Error)
+	assert.Equal(t, acp.ErrorCodeInvalidParams, msg.Error.Code,
+		"an unknown session is the client's mistake to fix")
+}
+
+// acpClient is the far side of a served ACP connection.
+type acpClient struct {
+	w   *io.PipeWriter
+	r   *bufio.Scanner
+	enc *json.Encoder
+}
+
+func startACP(t *testing.T, turn turnFunc) (*acpClient, chan struct{}) {
+	t.Helper()
+
+	serverR, clientW := io.Pipe()
+	clientR, serverW := io.Pipe()
+
+	// The registry carries the real handshake but no agent-backed tools: this
+	// test is about the session wiring, and NewACPRegistry needs a live Agent
+	// to enumerate tools from.
+	registry := acp.NewCapabilityRegistry()
+	acp.RegisterInitialize(registry, acp.InitializeConfig{
+		AgentInfo:    acp.AgentInfo{Name: "rubichan", Version: agentVersion},
+		Capabilities: acpAgentCapabilities(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = serveACP(ctx, serverR, serverW, registry, acpAgentCapabilities(), turn)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		_ = clientW.Close()
+		_ = serverW.Close()
+	})
+
+	return &acpClient{
+		w:   clientW,
+		r:   bufio.NewScanner(clientR),
+		enc: json.NewEncoder(clientW),
+	}, done
+}
+
+func (c *acpClient) send(t *testing.T, id int, method string, params any) {
+	t.Helper()
+	raw, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	sent := make(chan error, 1)
+	go func() {
+		sent <- c.enc.Encode(acp.Request{
+			JSONRPC: "2.0", ID: id, Method: method, Params: raw,
+		})
+	}()
+	select {
+	case err := <-sent:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("the served connection never read the request")
+	}
+}
+
+// inbound is either a response to one of our calls or a notification from the
+// agent; the two are told apart by whether a method is present.
+type inbound struct {
+	Method string           `json:"method"`
+	Params json.RawMessage  `json:"params"`
+	ID     any              `json:"id"`
+	Result *json.RawMessage `json:"result"`
+	Error  *acp.RPCError    `json:"error"`
+}
+
+func (c *acpClient) read(t *testing.T) inbound {
+	t.Helper()
+	type scanned struct {
+		line []byte
+		ok   bool
+	}
+	got := make(chan scanned, 1)
+	go func() {
+		ok := c.r.Scan()
+		got <- scanned{append([]byte(nil), c.r.Bytes()...), ok}
+	}()
+
+	select {
+	case s := <-got:
+		require.True(t, s.ok, "the connection closed before answering")
+		var msg inbound
+		require.NoError(t, json.Unmarshal(s.line, &msg))
+		return msg
+	case <-time.After(3 * time.Second):
+		t.Fatal("no message from the served connection within 3s")
+		return inbound{}
+	}
+}
+
+// result reads until the response to id arrives, ignoring notifications.
+func (c *acpClient) result(t *testing.T, id int, v any) {
+	t.Helper()
+	for {
+		msg := c.read(t)
+		if msg.Method != "" {
+			continue
+		}
+		require.Nil(t, msg.Error, "request %d failed: %v", id, msg.Error)
+		require.NotNil(t, msg.Result)
+		require.NoError(t, json.Unmarshal(*msg.Result, v))
+		return
+	}
+}
+
+func (c *acpClient) close() { _ = c.w.Close() }

--- a/internal/agent/acp_serve_internal_test.go
+++ b/internal/agent/acp_serve_internal_test.go
@@ -142,7 +142,7 @@ func startACP(t *testing.T, turn turnFunc) (*acpClient, chan struct{}) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_ = serveACP(ctx, serverR, serverW, registry, acpAgentCapabilities(), turn)
+		_ = serveACP(ctx, serverR, serverW, registry, acpAgentCapabilities(), "/repo", turn)
 	}()
 	t.Cleanup(func() {
 		cancel()

--- a/internal/agent/acp_serve_internal_test.go
+++ b/internal/agent/acp_serve_internal_test.go
@@ -332,18 +332,14 @@ func TestServeACPWiresARealAgent(t *testing.T) {
 // store it creates, and that store is per connection — so serving one Agent
 // twice produced two "sole" sessions sharing a single conversation, which is
 // the exact defect the guard was added to prevent, one level up.
+//
+// The claim is permanent. An earlier version released it on return, which left
+// the sequential case broken: a later connection would open a fresh session and
+// inherit the earlier one's history off the agent.
 func TestServeACPRefusesASecondConnectionToOneAgent(t *testing.T) {
 	t.Parallel()
 
-	a := New(
-		acpStubProvider{},
-		tools.NewRegistry(),
-		func(context.Context, string, json.RawMessage) (bool, error) { return true, nil },
-		&config.Config{
-			Provider: config.ProviderConfig{Model: "test-model"},
-			Agent:    config.AgentConfig{MaxTurns: 1},
-		},
-	)
+	a := newACPTestAgent(t)
 
 	firstR, firstW := io.Pipe()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -361,10 +357,11 @@ func TestServeACPRefusesASecondConnectionToOneAgent(t *testing.T) {
 
 	err := ServeACP(context.Background(), a, strings.NewReader(""), io.Discard)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already serving")
+	assert.Contains(t, err.Error(), "already served")
 
-	// Releasing the claim matters as much as taking it: an agent that could be
-	// served exactly once per process would be worse than one that refuses.
+	// End the first connection, then try again. This is the sequential case:
+	// the second client would get a new session id backed by the first
+	// client's conversation, so it must still be refused.
 	cancel()
 	_ = firstW.Close()
 	select {
@@ -372,5 +369,23 @@ func TestServeACPRefusesASecondConnectionToOneAgent(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("the first ServeACP did not return")
 	}
-	assert.False(t, a.acpServing.Load(), "the claim must be released when serving ends")
+
+	err = ServeACP(context.Background(), a, strings.NewReader(""), io.Discard)
+	require.Error(t, err,
+		"a finished connection must not free the agent: its conversation carries over")
+	assert.Contains(t, err.Error(), "already served")
+}
+
+// newACPTestAgent builds an agent that can be served but never streamed from.
+func newACPTestAgent(t *testing.T) *Agent {
+	t.Helper()
+	return New(
+		acpStubProvider{},
+		tools.NewRegistry(),
+		func(context.Context, string, json.RawMessage) (bool, error) { return true, nil },
+		&config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+			Agent:    config.AgentConfig{MaxTurns: 1},
+		},
+	)
 }

--- a/internal/agent/acp_serve_internal_test.go
+++ b/internal/agent/acp_serve_internal_test.go
@@ -142,7 +142,12 @@ func startACP(t *testing.T, turn turnFunc) (*acpClient, chan struct{}) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_ = serveACP(ctx, serverR, serverW, registry, acpAgentCapabilities(), "/repo", turn)
+		_ = serveACP(ctx, serverR, serverW, acpServeConfig{
+			Registry:     registry,
+			Capabilities: acpAgentCapabilities(),
+			WorkingDir:   "/repo",
+			Turn:         turn,
+		})
 	}()
 	t.Cleanup(func() {
 		cancel()

--- a/internal/agent/acp_serve_internal_test.go
+++ b/internal/agent/acp_serve_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -324,4 +325,52 @@ func TestServeACPWiresARealAgent(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("ServeACP did not return after the client hung up")
 	}
+}
+
+// TestServeACPRefusesASecondConnectionToOneAgent closes the session-isolation
+// hole at connection scope. RegisterSession's sole-session guard lives in the
+// store it creates, and that store is per connection — so serving one Agent
+// twice produced two "sole" sessions sharing a single conversation, which is
+// the exact defect the guard was added to prevent, one level up.
+func TestServeACPRefusesASecondConnectionToOneAgent(t *testing.T) {
+	t.Parallel()
+
+	a := New(
+		acpStubProvider{},
+		tools.NewRegistry(),
+		func(context.Context, string, json.RawMessage) (bool, error) { return true, nil },
+		&config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+			Agent:    config.AgentConfig{MaxTurns: 1},
+		},
+	)
+
+	firstR, firstW := io.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- ServeACP(ctx, a, firstR, io.Discard) }()
+	t.Cleanup(func() {
+		cancel()
+		_ = firstW.Close()
+	})
+
+	// Wait for the first connection to have claimed the agent, rather than
+	// racing it: the claim happens on the serving goroutine.
+	require.Eventually(t, a.acpServing.Load, 2*time.Second, 5*time.Millisecond,
+		"the first ServeACP never claimed the agent")
+
+	err := ServeACP(context.Background(), a, strings.NewReader(""), io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already serving")
+
+	// Releasing the claim matters as much as taking it: an agent that could be
+	// served exactly once per process would be worse than one that refuses.
+	cancel()
+	_ = firstW.Close()
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the first ServeACP did not return")
+	}
+	assert.False(t, a.acpServing.Load(), "the claim must be released when serving ends")
 }

--- a/internal/agent/acp_session.go
+++ b/internal/agent/acp_session.go
@@ -202,13 +202,22 @@ func acpPromptFunc(n Notifier, turn turnFunc) acp.PromptFunc {
 // connection would get its own session store, pass its own sole-session check,
 // and still append to the first connection's history.
 func ServeACP(ctx context.Context, a *Agent, r io.Reader, w io.Writer) error {
+	// The claim is permanent, not held for the duration of the connection.
+	//
+	// Releasing it on return was the obvious thing and it was wrong: the
+	// conversation lives on the agent and nothing resets it between
+	// connections, so a second client would open a fresh ACP session and
+	// inherit the first client's history. That is a cross-client leak, and it
+	// is worse than a one-shot API.
+	//
+	// Making reuse safe means resetting or replacing every piece of
+	// session-owned agent state — conversation, context manager, session
+	// memory, persistence — which is the per-session-state feature this slice
+	// deliberately does not attempt. Until that exists, an agent serves ACP
+	// once and a second connection needs a second agent.
 	if !a.acpServing.CompareAndSwap(false, true) {
-		return fmt.Errorf("acp: this agent is already serving a connection; construct a second agent to serve another")
+		return fmt.Errorf("acp: this agent has already served an ACP connection; construct a new agent to serve another, because its conversation would otherwise carry over")
 	}
-	// Released rather than latched, so an agent can serve again once the first
-	// connection ends. A one-shot claim would be a worse bug than the one it
-	// fixes.
-	defer a.acpServing.Store(false)
 
 	registry, handshake := newACPRegistry(a)
 	return serveACP(ctx, r, w, acpServeConfig{

--- a/internal/agent/acp_session.go
+++ b/internal/agent/acp_session.go
@@ -1,0 +1,169 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/julianshen/rubichan/internal/acp"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+)
+
+// Notifier is the half of an ACP connection a running turn needs: the ability
+// to push an update without waiting for an answer. Narrowed to one method so a
+// turn cannot originate requests, and so tests need not stand up a connection.
+type Notifier interface {
+	Notify(method string, params any) error
+}
+
+// turnFunc is the shape of Agent.Turn. Declared here rather than imported: the
+// identical type lives in internal/shell, and depending on a sibling mode
+// package for a function signature would couple the agent to one of its
+// callers.
+type turnFunc func(ctx context.Context, userMessage string) (<-chan agentsdk.TurnEvent, error)
+
+// allExitReasons is every TurnExitReason the agent can report. It exists so the
+// ACP mapping can be checked for completeness: adding a reason without deciding
+// how a client should be told about it fails a test rather than silently
+// acquiring whatever the default branch does.
+var allExitReasons = []agentsdk.TurnExitReason{
+	agentsdk.ExitUnknown,
+	agentsdk.ExitCompleted,
+	agentsdk.ExitMaxTurns,
+	agentsdk.ExitCancelled,
+	agentsdk.ExitProviderError,
+	agentsdk.ExitRateLimited,
+	agentsdk.ExitSkillActivationFailed,
+	agentsdk.ExitTaskComplete,
+	agentsdk.ExitNoProgress,
+	agentsdk.ExitEmptyResponse,
+	agentsdk.ExitCompactionFailed,
+	agentsdk.ExitContextOverflow,
+	agentsdk.ExitMaxOutputTokens,
+	agentsdk.ExitPanic,
+	agentsdk.ExitDiminishingReturns,
+	agentsdk.ExitStopHookPrevented,
+	agentsdk.ExitBudgetExceeded,
+}
+
+// stopReasonFor translates the agent's exit reason into the one ACP defines.
+//
+// The map is lossy — ACP has five stop reasons and the agent has seventeen exit
+// reasons — but it is lossy deliberately. Reasons that mean "the turn ended"
+// collapse onto end_turn; reasons that mean "the turn broke" become errors, so
+// a client is told the agent failed rather than that the model finished.
+func stopReasonFor(r agentsdk.TurnExitReason) (acp.StopReason, error) {
+	switch r {
+	case agentsdk.ExitCompleted,
+		agentsdk.ExitTaskComplete,
+		agentsdk.ExitStopHookPrevented,
+		agentsdk.ExitNoProgress,
+		agentsdk.ExitEmptyResponse,
+		agentsdk.ExitDiminishingReturns:
+		return acp.StopEndTurn, nil
+
+	case agentsdk.ExitMaxTurns:
+		return acp.StopMaxTurnRequests, nil
+
+	case agentsdk.ExitCancelled:
+		return acp.StopCancelled, nil
+
+	case agentsdk.ExitMaxOutputTokens, agentsdk.ExitBudgetExceeded:
+		return acp.StopMaxTokens, nil
+
+	// Everything below is a failed turn. ExitUnknown is included on purpose:
+	// it is documented as a bug, and answering it as a completed turn would
+	// hide the code path that forgot to set a reason.
+	case agentsdk.ExitUnknown,
+		agentsdk.ExitProviderError,
+		agentsdk.ExitRateLimited,
+		agentsdk.ExitSkillActivationFailed,
+		agentsdk.ExitCompactionFailed,
+		agentsdk.ExitContextOverflow,
+		agentsdk.ExitPanic:
+		return "", fmt.Errorf("turn failed: %s", r)
+
+	default:
+		// No default folding into end_turn: an unclassified reason is a gap in
+		// this mapping, and saying so beats guessing.
+		return "", fmt.Errorf("unclassified turn exit reason: %s", r)
+	}
+}
+
+// promptText flattens an ACP prompt into the single string Turn accepts.
+//
+// A resource_link is rendered rather than dropped. The client attached it
+// deliberately, and answering as though it were never sent produces a reply
+// about a file the user believes was in scope.
+func promptText(blocks []acp.ContentBlock) string {
+	var b strings.Builder
+	for _, block := range blocks {
+		switch block.Type {
+		case acp.ContentText:
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(block.Text)
+		case acp.ContentResourceLink:
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			fmt.Fprintf(&b, "[attached resource: %s (%s)]", block.Name, block.URI)
+		}
+	}
+	return b.String()
+}
+
+// acpPromptFunc adapts a turn to ACP's session/prompt.
+//
+// The turn's events are streamed as session/update notifications while it runs.
+// This is not decoration: session/prompt's result carries only a stop reason,
+// so without these the client would learn that a turn finished and never what
+// it said.
+func acpPromptFunc(n Notifier, turn turnFunc) acp.PromptFunc {
+	return func(ctx context.Context, req acp.PromptRequest) (acp.StopReason, error) {
+		events, err := turn(ctx, promptText(req.Prompt))
+		if err != nil {
+			return "", fmt.Errorf("start turn: %w", err)
+		}
+
+		notify := func(update any) {
+			// A failed notification is logged by the connection, not fatal here:
+			// abandoning a running turn because one update did not reach the
+			// client would lose the work as well as the message.
+			_ = n.Notify(acp.MethodSessionUpdate, acp.NewSessionNotification(req.SessionID, update))
+		}
+
+		var (
+			exit  agentsdk.TurnExitReason
+			ended bool
+		)
+		for ev := range events {
+			switch ev.Type {
+			case agentsdk.EventTextDelta:
+				notify(acp.AgentMessageChunk(ev.Text))
+			case "tool_call":
+				if ev.ToolCall != nil {
+					notify(acp.ToolCall(ev.ToolCall.ID, ev.ToolCall.Name))
+				}
+			case "tool_result":
+				if ev.ToolResult != nil {
+					status := acp.ToolCallCompleted
+					if ev.ToolResult.IsError {
+						status = acp.ToolCallFailed
+					}
+					notify(acp.ToolCallUpdate(ev.ToolResult.ID, status))
+				}
+			case "done":
+				exit, ended = ev.ExitReason, true
+			}
+		}
+
+		// A stream that closed without a done event leaves the turn's outcome
+		// genuinely unknown. Answering end_turn would invent one.
+		if !ended {
+			return "", fmt.Errorf("turn ended without a done event")
+		}
+		return stopReasonFor(exit)
+	}
+}

--- a/internal/agent/acp_session.go
+++ b/internal/agent/acp_session.go
@@ -198,31 +198,38 @@ func acpPromptFunc(n Notifier, turn turnFunc) acp.PromptFunc {
 // so the registry, the connection and the session wiring are assembled here and
 // nowhere else.
 func ServeACP(ctx context.Context, a *Agent, r io.Reader, w io.Writer) error {
-	return serveACP(ctx, r, w, NewACPRegistry(a), acpAgentCapabilities(), a.WorkingDir(), a.Turn)
+	return serveACP(ctx, r, w, acpServeConfig{
+		Registry:     NewACPRegistry(a),
+		Capabilities: acpAgentCapabilities(),
+		WorkingDir:   a.WorkingDir(),
+		Turn:         a.Turn,
+	})
+}
+
+// acpServeConfig is what serving ACP needs from its surroundings. Grouped into
+// a struct rather than passed positionally because the list had grown past the
+// point where a caller could tell two adjacent strings apart.
+type acpServeConfig struct {
+	Registry     *acp.CapabilityRegistry
+	Capabilities acp.AgentCapabilities
+	WorkingDir   string
+	Turn         turnFunc
 }
 
 // serveACP is ServeACP with its collaborators passed in, so the wiring can be
 // exercised against a turn that does not need a live provider.
-func serveACP(
-	ctx context.Context,
-	r io.Reader,
-	w io.Writer,
-	registry *acp.CapabilityRegistry,
-	caps acp.AgentCapabilities,
-	workingDir string,
-	turn turnFunc,
-) error {
-	conn := acp.NewConn(r, w, registry)
+func serveACP(ctx context.Context, r io.Reader, w io.Writer, cfg acpServeConfig) error {
+	conn := acp.NewConn(r, w, cfg.Registry)
 
 	// Session methods are registered after the connection exists because the
 	// prompt handler streams through it, and the connection is built from the
 	// registry. Ordering it this way is safe rather than merely convenient:
 	// RegisterMethod is mutex-guarded, and Serve has not started reading yet, so
 	// no request can arrive against a half-populated registry.
-	acp.RegisterSession(registry, acp.SessionConfig{
-		Capabilities: caps,
-		WorkingDir:   workingDir,
-		Prompt:       acpPromptFunc(conn, turn),
+	acp.RegisterSession(cfg.Registry, acp.SessionConfig{
+		Capabilities: cfg.Capabilities,
+		WorkingDir:   cfg.WorkingDir,
+		Prompt:       acpPromptFunc(conn, cfg.Turn),
 	})
 
 	return conn.Serve(ctx)

--- a/internal/agent/acp_session.go
+++ b/internal/agent/acp_session.go
@@ -58,8 +58,6 @@ func stopReasonFor(r agentsdk.TurnExitReason) (acp.StopReason, error) {
 	case agentsdk.ExitCompleted,
 		agentsdk.ExitTaskComplete,
 		agentsdk.ExitStopHookPrevented,
-		agentsdk.ExitNoProgress,
-		agentsdk.ExitEmptyResponse,
 		agentsdk.ExitDiminishingReturns:
 		return acp.StopEndTurn, nil
 
@@ -75,13 +73,21 @@ func stopReasonFor(r agentsdk.TurnExitReason) (acp.StopReason, error) {
 	// Everything below is a failed turn. ExitUnknown is included on purpose:
 	// it is documented as a bug, and answering it as a completed turn would
 	// hide the code path that forgot to set a reason.
+	// ExitNoProgress and ExitEmptyResponse are here because the agent emits an
+	// explicit error event immediately before each — tool_phase.go for the
+	// first, assemble_turn.go for the second. They are the agent declaring the
+	// turn failed, so end_turn would contradict it. The empty-response case is
+	// the worst of the two: the client would receive a clean stop reason and
+	// not one chunk of assistant text.
 	case agentsdk.ExitUnknown,
 		agentsdk.ExitProviderError,
 		agentsdk.ExitRateLimited,
 		agentsdk.ExitSkillActivationFailed,
 		agentsdk.ExitCompactionFailed,
 		agentsdk.ExitContextOverflow,
-		agentsdk.ExitPanic:
+		agentsdk.ExitPanic,
+		agentsdk.ExitNoProgress,
+		agentsdk.ExitEmptyResponse:
 		return "", fmt.Errorf("turn failed: %s", r)
 
 	default:
@@ -136,13 +142,24 @@ func acpPromptFunc(n Notifier, turn turnFunc) acp.PromptFunc {
 		}
 
 		var (
-			exit  agentsdk.TurnExitReason
-			ended bool
+			exit    agentsdk.TurnExitReason
+			ended   bool
+			lastErr error
 		)
 		for ev := range events {
 			switch ev.Type {
 			case agentsdk.EventTextDelta:
 				notify(acp.AgentMessageChunk(ev.Text))
+			case "error":
+				// Retained, not reported yet. The agent emits error events it
+				// then recovers from — a model fallback is one — so the done
+				// event decides the outcome. But when the turn does fail, this
+				// is the only text saying *why*: the exit reason is a category,
+				// not a diagnosis. Dropping it left the client with
+				// "turn failed: empty_response" and nothing else.
+				if ev.Error != nil {
+					lastErr = ev.Error
+				}
 			case "tool_call":
 				if ev.ToolCall != nil {
 					notify(acp.ToolCall(ev.ToolCall.ID, ev.ToolCall.Name))
@@ -165,7 +182,12 @@ func acpPromptFunc(n Notifier, turn turnFunc) acp.PromptFunc {
 		if !ended {
 			return "", fmt.Errorf("turn ended without a done event")
 		}
-		return stopReasonFor(exit)
+
+		stop, err := stopReasonFor(exit)
+		if err != nil && lastErr != nil {
+			return "", fmt.Errorf("%w: %v", err, lastErr)
+		}
+		return stop, err
 	}
 }
 

--- a/internal/agent/acp_session.go
+++ b/internal/agent/acp_session.go
@@ -197,7 +197,19 @@ func acpPromptFunc(n Notifier, turn turnFunc) acp.PromptFunc {
 // This is the composition root for ACP: the agent core holds no protocol state,
 // so the registry, the connection and the session wiring are assembled here and
 // nowhere else.
+// One agent serves one connection at a time. Every session opened on any
+// connection runs through this agent's single conversation, so a second
+// connection would get its own session store, pass its own sole-session check,
+// and still append to the first connection's history.
 func ServeACP(ctx context.Context, a *Agent, r io.Reader, w io.Writer) error {
+	if !a.acpServing.CompareAndSwap(false, true) {
+		return fmt.Errorf("acp: this agent is already serving a connection; construct a second agent to serve another")
+	}
+	// Released rather than latched, so an agent can serve again once the first
+	// connection ends. A one-shot claim would be a worse bug than the one it
+	// fixes.
+	defer a.acpServing.Store(false)
+
 	registry, handshake := newACPRegistry(a)
 	return serveACP(ctx, r, w, acpServeConfig{
 		Registry:     registry,

--- a/internal/agent/acp_session.go
+++ b/internal/agent/acp_session.go
@@ -198,10 +198,12 @@ func acpPromptFunc(n Notifier, turn turnFunc) acp.PromptFunc {
 // so the registry, the connection and the session wiring are assembled here and
 // nowhere else.
 func ServeACP(ctx context.Context, a *Agent, r io.Reader, w io.Writer) error {
+	registry, handshake := newACPRegistry(a)
 	return serveACP(ctx, r, w, acpServeConfig{
-		Registry:     NewACPRegistry(a),
+		Registry:     registry,
 		Capabilities: acpAgentCapabilities(),
 		WorkingDir:   a.WorkingDir(),
+		Handshake:    handshake,
 		Turn:         a.Turn,
 	})
 }
@@ -213,7 +215,10 @@ type acpServeConfig struct {
 	Registry     *acp.CapabilityRegistry
 	Capabilities acp.AgentCapabilities
 	WorkingDir   string
-	Turn         turnFunc
+	// Handshake gates the session methods on initialize. Nil disables the
+	// check, which is what a test serving no handshake wants.
+	Handshake *acp.Handshake
+	Turn      turnFunc
 }
 
 // serveACP is ServeACP with its collaborators passed in, so the wiring can be
@@ -229,6 +234,7 @@ func serveACP(ctx context.Context, r io.Reader, w io.Writer, cfg acpServeConfig)
 	acp.RegisterSession(cfg.Registry, acp.SessionConfig{
 		Capabilities: cfg.Capabilities,
 		WorkingDir:   cfg.WorkingDir,
+		Handshake:    cfg.Handshake,
 		Prompt:       acpPromptFunc(conn, cfg.Turn),
 	})
 

--- a/internal/agent/acp_session.go
+++ b/internal/agent/acp_session.go
@@ -198,7 +198,7 @@ func acpPromptFunc(n Notifier, turn turnFunc) acp.PromptFunc {
 // so the registry, the connection and the session wiring are assembled here and
 // nowhere else.
 func ServeACP(ctx context.Context, a *Agent, r io.Reader, w io.Writer) error {
-	return serveACP(ctx, r, w, NewACPRegistry(a), acpAgentCapabilities(), a.Turn)
+	return serveACP(ctx, r, w, NewACPRegistry(a), acpAgentCapabilities(), a.WorkingDir(), a.Turn)
 }
 
 // serveACP is ServeACP with its collaborators passed in, so the wiring can be
@@ -209,6 +209,7 @@ func serveACP(
 	w io.Writer,
 	registry *acp.CapabilityRegistry,
 	caps acp.AgentCapabilities,
+	workingDir string,
 	turn turnFunc,
 ) error {
 	conn := acp.NewConn(r, w, registry)
@@ -220,6 +221,7 @@ func serveACP(
 	// no request can arrive against a half-populated registry.
 	acp.RegisterSession(registry, acp.SessionConfig{
 		Capabilities: caps,
+		WorkingDir:   workingDir,
 		Prompt:       acpPromptFunc(conn, turn),
 	})
 

--- a/internal/agent/acp_session.go
+++ b/internal/agent/acp_session.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/julianshen/rubichan/internal/acp"
@@ -166,4 +167,39 @@ func acpPromptFunc(n Notifier, turn turnFunc) acp.PromptFunc {
 		}
 		return stopReasonFor(exit)
 	}
+}
+
+// ServeACP serves the Agent Client Protocol over r/w until the stream ends or
+// ctx is cancelled.
+//
+// This is the composition root for ACP: the agent core holds no protocol state,
+// so the registry, the connection and the session wiring are assembled here and
+// nowhere else.
+func ServeACP(ctx context.Context, a *Agent, r io.Reader, w io.Writer) error {
+	return serveACP(ctx, r, w, NewACPRegistry(a), acpAgentCapabilities(), a.Turn)
+}
+
+// serveACP is ServeACP with its collaborators passed in, so the wiring can be
+// exercised against a turn that does not need a live provider.
+func serveACP(
+	ctx context.Context,
+	r io.Reader,
+	w io.Writer,
+	registry *acp.CapabilityRegistry,
+	caps acp.AgentCapabilities,
+	turn turnFunc,
+) error {
+	conn := acp.NewConn(r, w, registry)
+
+	// Session methods are registered after the connection exists because the
+	// prompt handler streams through it, and the connection is built from the
+	// registry. Ordering it this way is safe rather than merely convenient:
+	// RegisterMethod is mutex-guarded, and Serve has not started reading yet, so
+	// no request can arrive against a half-populated registry.
+	acp.RegisterSession(registry, acp.SessionConfig{
+		Capabilities: caps,
+		Prompt:       acpPromptFunc(conn, turn),
+	})
+
+	return conn.Serve(ctx)
 }

--- a/internal/agent/acp_session_internal_test.go
+++ b/internal/agent/acp_session_internal_test.go
@@ -1,0 +1,179 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/julianshen/rubichan/internal/acp"
+	"github.com/julianshen/rubichan/pkg/agentsdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStopReasonForCoversEveryExitReason is the test that keeps this mapping
+// honest as the agent grows. ACP has five stop reasons and the agent has far
+// more exit reasons, so the map is lossy by necessity — but it must be lossy on
+// purpose. A default branch folding unknown reasons into end_turn would report
+// a clean finish for a turn that crashed, and would do so silently for every
+// exit reason added after this was written.
+func TestStopReasonForCoversEveryExitReason(t *testing.T) {
+	t.Parallel()
+
+	// Turns that ended. ACP has no vocabulary for "the model stopped making
+	// progress" or "a stop hook intervened", and end_turn is the honest
+	// approximation: the turn is over and nothing failed.
+	ended := map[agentsdk.TurnExitReason]acp.StopReason{
+		agentsdk.ExitCompleted:          acp.StopEndTurn,
+		agentsdk.ExitTaskComplete:       acp.StopEndTurn,
+		agentsdk.ExitStopHookPrevented:  acp.StopEndTurn,
+		agentsdk.ExitNoProgress:         acp.StopEndTurn,
+		agentsdk.ExitEmptyResponse:      acp.StopEndTurn,
+		agentsdk.ExitDiminishingReturns: acp.StopEndTurn,
+		agentsdk.ExitMaxTurns:           acp.StopMaxTurnRequests,
+		agentsdk.ExitCancelled:          acp.StopCancelled,
+		agentsdk.ExitMaxOutputTokens:    acp.StopMaxTokens,
+		agentsdk.ExitBudgetExceeded:     acp.StopMaxTokens,
+	}
+
+	// Turns that broke. These must surface as errors: reporting one as a stop
+	// reason tells the client the model finished when the agent fell over.
+	// ExitUnknown is documented as a bug, so it belongs here rather than being
+	// quietly answered as a completed turn.
+	failed := []agentsdk.TurnExitReason{
+		agentsdk.ExitUnknown,
+		agentsdk.ExitProviderError,
+		agentsdk.ExitRateLimited,
+		agentsdk.ExitSkillActivationFailed,
+		agentsdk.ExitCompactionFailed,
+		agentsdk.ExitContextOverflow,
+		agentsdk.ExitPanic,
+	}
+
+	for reason, want := range ended {
+		got, err := stopReasonFor(reason)
+		require.NoError(t, err, "exit reason %v", reason)
+		assert.Equal(t, want, got, "exit reason %v", reason)
+	}
+
+	for _, reason := range failed {
+		_, err := stopReasonFor(reason)
+		assert.Error(t, err, "exit reason %v must not be reported as a clean stop", reason)
+	}
+
+	// The guard: every reason the agent defines is classified above. A new one
+	// fails here rather than silently acquiring a default.
+	assert.Len(t, ended, len(allExitReasons)-len(failed),
+		"a TurnExitReason was added without deciding how ACP should report it")
+}
+
+// TestPromptTextRendersTheBlocksTheAgentAccepts covers the flattening of an ACP
+// prompt into the single string Turn takes. A resource_link must survive as
+// something the model can act on: dropping it would answer a question about a
+// file the user explicitly attached without ever mentioning it.
+func TestPromptTextRendersTheBlocksTheAgentAccepts(t *testing.T) {
+	t.Parallel()
+
+	got := promptText([]acp.ContentBlock{
+		{Type: acp.ContentText, Text: "explain this"},
+		{Type: acp.ContentResourceLink, URI: "file:///src/main.go", Name: "main.go"},
+		{Type: acp.ContentText, Text: "briefly"},
+	})
+
+	assert.Contains(t, got, "explain this")
+	assert.Contains(t, got, "briefly")
+	assert.Contains(t, got, "main.go")
+	assert.Contains(t, got, "file:///src/main.go")
+}
+
+// fakeNotifier records what a turn streamed instead of writing it to a stream.
+type fakeNotifier struct {
+	sent []acp.SessionNotification
+}
+
+func (f *fakeNotifier) Notify(method string, params any) error {
+	if n, ok := params.(acp.SessionNotification); ok {
+		f.sent = append(f.sent, n)
+	}
+	return nil
+}
+
+// TestACPPromptStreamsTheTurn is the whole point of the slice: assistant text
+// leaves the agent as session/update notifications while the turn runs, and the
+// call closes with a mapped stop reason. Without the streaming half, a client
+// would receive a stop reason and never the reply.
+func TestACPPromptStreamsTheTurn(t *testing.T) {
+	t.Parallel()
+
+	turn := func(_ context.Context, _ string) (<-chan agentsdk.TurnEvent, error) {
+		ch := make(chan agentsdk.TurnEvent, 8)
+		ch <- agentsdk.TurnEvent{Type: "text_delta", Text: "hel"}
+		ch <- agentsdk.TurnEvent{Type: "text_delta", Text: "lo"}
+		ch <- agentsdk.TurnEvent{
+			Type:     "tool_call",
+			ToolCall: &agentsdk.ToolCallEvent{ID: "c1", Name: "read_file"},
+		}
+		ch <- agentsdk.TurnEvent{
+			Type:       "tool_result",
+			ToolResult: &agentsdk.ToolResultEvent{ID: "c1", Name: "read_file"},
+		}
+		ch <- agentsdk.TurnEvent{Type: "done", ExitReason: agentsdk.ExitCompleted}
+		close(ch)
+		return ch, nil
+	}
+
+	notifier := &fakeNotifier{}
+	prompt := acpPromptFunc(notifier, turn)
+
+	stop, err := prompt(context.Background(), acp.PromptRequest{
+		SessionID: "sess-1",
+		Cwd:       "/repo",
+		Prompt:    []acp.ContentBlock{{Type: acp.ContentText, Text: "hi"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, acp.StopEndTurn, stop)
+
+	require.Len(t, notifier.sent, 4, "two text chunks, one tool call, one tool update")
+	for _, n := range notifier.sent {
+		assert.Equal(t, "sess-1", n.SessionID)
+	}
+}
+
+// TestACPPromptReportsATurnThatBroke keeps a failed turn from being answered as
+// a clean one. The done event carries the failure, so nothing else in the
+// stream would reveal it.
+func TestACPPromptReportsATurnThatBroke(t *testing.T) {
+	t.Parallel()
+
+	turn := func(_ context.Context, _ string) (<-chan agentsdk.TurnEvent, error) {
+		ch := make(chan agentsdk.TurnEvent, 1)
+		ch <- agentsdk.TurnEvent{Type: "done", ExitReason: agentsdk.ExitProviderError}
+		close(ch)
+		return ch, nil
+	}
+
+	_, err := acpPromptFunc(&fakeNotifier{}, turn)(context.Background(), acp.PromptRequest{
+		SessionID: "sess-1",
+		Prompt:    []acp.ContentBlock{{Type: acp.ContentText, Text: "hi"}},
+	})
+	assert.Error(t, err)
+}
+
+// TestACPPromptRejectsATurnThatNeverFinished covers a stream that closes with no
+// done event. There is no exit reason to map, and answering end_turn would
+// invent one — the turn's outcome is genuinely unknown.
+func TestACPPromptRejectsATurnThatNeverFinished(t *testing.T) {
+	t.Parallel()
+
+	turn := func(_ context.Context, _ string) (<-chan agentsdk.TurnEvent, error) {
+		ch := make(chan agentsdk.TurnEvent, 1)
+		ch <- agentsdk.TurnEvent{Type: "text_delta", Text: "partial"}
+		close(ch)
+		return ch, nil
+	}
+
+	_, err := acpPromptFunc(&fakeNotifier{}, turn)(context.Background(), acp.PromptRequest{
+		SessionID: "sess-1",
+		Prompt:    []acp.ContentBlock{{Type: acp.ContentText, Text: "hi"}},
+	})
+	assert.Error(t, err)
+}

--- a/internal/agent/acp_session_internal_test.go
+++ b/internal/agent/acp_session_internal_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/julianshen/rubichan/internal/acp"
@@ -26,8 +27,6 @@ func TestStopReasonForCoversEveryExitReason(t *testing.T) {
 		agentsdk.ExitCompleted:          acp.StopEndTurn,
 		agentsdk.ExitTaskComplete:       acp.StopEndTurn,
 		agentsdk.ExitStopHookPrevented:  acp.StopEndTurn,
-		agentsdk.ExitNoProgress:         acp.StopEndTurn,
-		agentsdk.ExitEmptyResponse:      acp.StopEndTurn,
 		agentsdk.ExitDiminishingReturns: acp.StopEndTurn,
 		agentsdk.ExitMaxTurns:           acp.StopMaxTurnRequests,
 		agentsdk.ExitCancelled:          acp.StopCancelled,
@@ -47,6 +46,12 @@ func TestStopReasonForCoversEveryExitReason(t *testing.T) {
 		agentsdk.ExitCompactionFailed,
 		agentsdk.ExitContextOverflow,
 		agentsdk.ExitPanic,
+		// The agent emits an explicit error event immediately before each of
+		// these two — tool_phase.go for no-progress, assemble_turn.go for an
+		// empty response. Reporting end_turn would tell the client the model
+		// finished cleanly on a turn the agent itself just declared failed.
+		agentsdk.ExitNoProgress,
+		agentsdk.ExitEmptyResponse,
 	}
 
 	for reason, want := range ended {
@@ -206,4 +211,55 @@ func TestACPPromptReportsATurnThatNeverStarted(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "start turn")
+}
+
+// TestACPPromptCarriesTheAgentsOwnErrorText covers the error events the adapter
+// used to drop on the floor. The agent emits one immediately before
+// ExitNoProgress and ExitEmptyResponse, and it is the only thing that says what
+// actually went wrong — the exit reason alone is a category, not a diagnosis.
+func TestACPPromptCarriesTheAgentsOwnErrorText(t *testing.T) {
+	t.Parallel()
+
+	turn := func(_ context.Context, _ string) (<-chan agentsdk.TurnEvent, error) {
+		ch := make(chan agentsdk.TurnEvent, 2)
+		ch <- agentsdk.TurnEvent{
+			Type:  "error",
+			Error: errors.New("detected no progress after 3 repeated tool-only rounds"),
+		}
+		ch <- agentsdk.TurnEvent{Type: "done", ExitReason: agentsdk.ExitNoProgress}
+		close(ch)
+		return ch, nil
+	}
+
+	_, err := acpPromptFunc(&fakeNotifier{}, turn)(context.Background(), acp.PromptRequest{
+		SessionID: "sess-1",
+		Prompt:    []acp.ContentBlock{{Type: acp.ContentText, Text: "hi"}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repeated tool-only rounds",
+		"the agent said why it failed; that must reach the client")
+}
+
+// TestACPPromptDoesNotFailATurnThatRecovered keeps the error capture from
+// turning a survivable hiccup into a failed turn. The agent emits error events
+// it then recovers from — a model fallback, for instance — and the done event
+// is what decides the outcome.
+func TestACPPromptDoesNotFailATurnThatRecovered(t *testing.T) {
+	t.Parallel()
+
+	turn := func(_ context.Context, _ string) (<-chan agentsdk.TurnEvent, error) {
+		ch := make(chan agentsdk.TurnEvent, 3)
+		ch <- agentsdk.TurnEvent{Type: "error", Error: errors.New("transient provider hiccup")}
+		ch <- agentsdk.TurnEvent{Type: "text_delta", Text: "recovered"}
+		ch <- agentsdk.TurnEvent{Type: "done", ExitReason: agentsdk.ExitCompleted}
+		close(ch)
+		return ch, nil
+	}
+
+	stop, err := acpPromptFunc(&fakeNotifier{}, turn)(context.Background(), acp.PromptRequest{
+		SessionID: "sess-1",
+		Prompt:    []acp.ContentBlock{{Type: acp.ContentText, Text: "hi"}},
+	})
+	require.NoError(t, err, "the done event decides the outcome, not a recovered error")
+	assert.Equal(t, acp.StopEndTurn, stop)
 }

--- a/internal/agent/acp_session_internal_test.go
+++ b/internal/agent/acp_session_internal_test.go
@@ -177,3 +177,33 @@ func TestACPPromptRejectsATurnThatNeverFinished(t *testing.T) {
 	})
 	assert.Error(t, err)
 }
+
+// TestStopReasonForRejectsAReasonItDoesNotKnow exercises the guard branch. It
+// is unreachable through the agent's own constants, which is the point: if one
+// is ever added without being classified, this is the behaviour it gets —
+// a refusal naming the gap, not a silent end_turn.
+func TestStopReasonForRejectsAReasonItDoesNotKnow(t *testing.T) {
+	t.Parallel()
+
+	_, err := stopReasonFor(agentsdk.TurnExitReason(9999))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unclassified")
+}
+
+// TestACPPromptReportsATurnThatNeverStarted covers the failure before any event
+// exists. There is nothing to stream and no exit reason to map, so the error
+// has to carry the outcome by itself.
+func TestACPPromptReportsATurnThatNeverStarted(t *testing.T) {
+	t.Parallel()
+
+	turn := func(context.Context, string) (<-chan agentsdk.TurnEvent, error) {
+		return nil, assert.AnError
+	}
+
+	_, err := acpPromptFunc(&fakeNotifier{}, turn)(context.Background(), acp.PromptRequest{
+		SessionID: "sess-1",
+		Prompt:    []acp.ContentBlock{{Type: acp.ContentText, Text: "hi"}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "start turn")
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -470,6 +470,14 @@ type Agent struct {
 	acpClientCaps   acp.ClientCapabilities
 	acpClientCapsMu sync.RWMutex
 
+	// acpServing marks this agent as bound to one ACP connection.
+	//
+	// The sole-session guard lives in the session store, which ServeACP creates
+	// per connection — so without a claim at this scope, serving one agent
+	// twice yields two "sole" sessions sharing this agent's single
+	// conversation, which is the very thing that guard exists to prevent.
+	acpServing atomic.Bool
+
 	provider            provider.LLMProvider
 	tools               *tools.Registry
 	conversation        *Conversation


### PR DESCRIPTION
Slice 3 of the ACP rebuild. After this, a client can complete a real conversation: `initialize` → `session/new` → `session/prompt`, with the reply streaming back as `session/update` and the call closing on a `stopReason`.

| | |
|---|---|
| `f42712a` `[BEHAVIORAL]` | Decode `session/prompt` content against the declared capabilities |
| `4f52275` `[BEHAVIORAL]` | Give `Conn` the notification direction it was missing |
| `1550c3a` `[BEHAVIORAL]` | Serve `session/new` and `session/prompt` |
| `2f44e94` `[BEHAVIORAL]` | Add the `session/update` variants a turn streams |
| `803b46c` `[BEHAVIORAL]` | Adapt a turn to `session/prompt`, streaming as it runs |
| `dd4d59d` `[STRUCTURAL]` | Extract Method: `acpAgentCapabilities` |
| `d415eba` `[BEHAVIORAL]` | Add `ServeACP`, the first entry point that completes an operation |
| `162a493` `[STRUCTURAL]` | Doc: correct the ACP claims this slice falsified |
| `e6eb0a1` `5263981` `[BEHAVIORAL]` | Cover the paths that were documented but untested |

## `Conn.Notify` is not scope creep — without it the method is fiction

`session/prompt` answers with `{stopReason}` and nothing else. In ACP the reply itself travels as `session/update` notifications *during* the call. `Conn` could originate a request and await an answer, but had no way to send a message expecting none — so a `session/prompt` registered without it would complete every turn and never deliver a word of it.

That is the exact defect #339 deleted the mode adapters for: methods that each work alone and cannot complete an operation between them. Registering the method without the notification direction would have recreated it.

## The capability gate runs in both directions

The handshake declares `promptCapabilities` all false. Three of ACP's five `ContentBlock` variants — `image`, `audio`, `resource` — are gated on those flags. So they are **refused**, not decoded and ignored.

The gate reads the same `AgentCapabilities` value the handshake publishes, which is why `dd4d59d` extracts `acpAgentCapabilities()`: with the literal restated in two places, turning `promptCapabilities.image` on would have advertised a capability the decoder still rejected.

Refusing is the point. Silently skipping an inadmissible block leaves the client believing an attachment was read when it was dropped — the same dishonesty as advertising a capability no method backs, pointed the other way.

**Two more of the same class turned up while writing the handler.** `session/new` takes `mcpServers` and `additionalDirectories`, and my first version accepted both and did nothing with them. A client would then prompt believing its MCP tools were connected and its extra directories in scope. Both are now refused with a message saying why. An empty list is not a request, so `"mcpServers":[]` still opens a session.

## The exit-reason map is where this could quietly lie

ACP defines five stop reasons. The agent defines seventeen exit reasons. Collapsing them is unavoidable; doing it silently is not.

- Reasons meaning *the turn ended* → `end_turn`, `max_turn_requests`, `cancelled`, `max_tokens`.
- Reasons meaning *the turn broke* — `ExitProviderError`, `ExitPanic`, `ExitContextOverflow` and kin — become **errors**. Reporting one as a stop reason tells the client the model finished when the agent fell over.
- `ExitUnknown` is in the failure group deliberately. It is documented as a bug; answering it cleanly would hide the path that forgot to set a reason.
- **There is no `default` folding the rest into `end_turn`.** An unclassified reason is a gap, and a test asserts every reason the agent defines has been classified — so adding one fails the build instead of silently acquiring a default.

A stream that closes with no `done` event is also an error: the outcome is genuinely unknown, and `end_turn` would be invented.

## The test that matters is the pipe test

`TestServeACPCarriesAWholeConversation` drives a real `io.Pipe` through the full sequence and asserts the reply arrives **only** via `session/update`. Calling the handlers directly would have passed against the broken design this rebuild exists to replace, so it deliberately does not.

## Known limitations, recorded rather than left to be discovered

- **A turn cannot be cancelled.** `Handler` takes only `params`, so there is no request context and `session/cancel` is unimplementable until a context is threaded through every handler in the package. Noted at the call site that uses `context.Background()`.
- **No mid-turn `session/request_permission`.** `Conn.Request` can express it; nothing calls it.
- **Nothing calls `ServeACP`.** There is still no `--acp` flag, so ACP remains unreached from `main` — now one call away rather than an unspecified amount of wiring away. CLAUDE.md says so explicitly, and the grep it cites still returns only the definition.

## Verification

- `internal/acp` and `internal/agent` **race-clean**; `go build ./...`, `go vet ./...`, `gofmt` clean.
- New code coverage: `stopReasonFor` 100%, `promptText` 100%, `serveACP` 100%, `ServeACP` 100%, `acpPromptFunc` 95.2%, `DecodePromptContent` 100%, `checkAdmissible` 100%, `RegisterSession` 97.1%, all four `session/update` constructors 100%.

**A correction to the baseline I have been reporting on previous PRs.** I have been describing full-suite failures as "the same 10 environmental tests". That was incomplete. `internal/tools` carries a **pre-existing flake** that adds a varying 11th failure — I saw `TestShellToolExecuteStreamEmitsEvents`, then `TestShellToolDescriptionField`, and on **unmodified `main`** a third, `TestProcessToolExec`, with a clean run in between. It is unrelated to this branch, which touches neither package, but "identical to the 10-test baseline" was the wrong claim and I would rather correct it than keep repeating it. Worth its own issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqv8RZoJcM9HPRt1fw86LK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ACP session support for creating sessions and submitting prompts.
  - Added end-to-end conversation streaming, including agent messages and tool-call updates.
  - Added support for text, images, audio, resources, and resource links when permitted.
  - Added one-way notifications for real-time session updates.
  - Added the `ServeACP` entry point for hosting ACP conversations.

- **Bug Fixes**
  - Added validation for invalid sessions, parameters, working directories, unsupported content, and incomplete turns.

- **Documentation**
  - Updated ACP documentation to describe session-based operation, streaming, capabilities, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->